### PR TITLE
fix: improve deploy pipeline and Helm secret configuration

### DIFF
--- a/deploy/helm/nexu/README.md
+++ b/deploy/helm/nexu/README.md
@@ -44,3 +44,19 @@ helm upgrade --install nexu ./deploy/k8s/helm/nexu \
 ## Sensitive Values
 
 Do not keep production secrets in `values.yaml`. Pass secrets with CI/CD or use `ExternalSecrets`.
+
+## External Secrets
+
+This chart can either create a Secret from values or reference an existing Secret.
+
+- Default behavior (create Secret): `secret.create=true`
+- Use external Secret: set `secret.create=false` and `secret.existingSecretName=<your-secret-name>`
+
+Example:
+
+```bash
+helm upgrade --install nexu ./deploy/k8s/helm/nexu \
+  --namespace nexu \
+  --set secret.create=false \
+  --set secret.existingSecretName=nexu-app-secrets
+```

--- a/deploy/helm/nexu/templates/_helpers.tpl
+++ b/deploy/helm/nexu/templates/_helpers.tpl
@@ -57,5 +57,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "nexu.secretName" -}}
+{{- if .Values.secret.existingSecretName -}}
+{{- .Values.secret.existingSecretName | trunc 63 | trimSuffix "-" -}}
+{{- else if .Values.secret.create -}}
 {{- printf "%s-secrets" (include "nexu.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- fail "secret.existingSecretName is required when secret.create=false" -}}
+{{- end -}}
 {{- end -}}

--- a/deploy/helm/nexu/templates/secret.yaml
+++ b/deploy/helm/nexu/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.secret.create }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -16,3 +17,4 @@ stringData:
   SLACK_SIGNING_SECRET: {{ .Values.secret.SLACK_SIGNING_SECRET | quote }}
   LITELLM_BASE_URL: {{ .Values.secret.LITELLM_BASE_URL | quote }}
   LITELLM_API_KEY: {{ .Values.secret.LITELLM_API_KEY | quote }}
+{{- end }}

--- a/deploy/helm/nexu/values.yaml
+++ b/deploy/helm/nexu/values.yaml
@@ -16,6 +16,8 @@ config:
   POOL_ID: "pool_local_01"
 
 secret:
+  create: true
+  existingSecretName: ""
   DATABASE_URL: "postgresql://nexu:CHANGEME@postgres:5432/nexu"
   BETTER_AUTH_SECRET: "CHANGEME-random-secret"
   ENCRYPTION_KEY: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"


### PR DESCRIPTION
## Summary
- update CI image build workflow to use the correct AWS role reference and run `pnpm` in CI mode for the gateway Docker build
- add Helm chart support for external/existing Kubernetes Secrets via `secret.create` and `secret.existingSecretName`
- document external Secret usage in the Helm chart README with an install example

## Testing
- pnpm lint
- helm template nexu ./deploy/helm/nexu
- helm template nexu ./deploy/helm/nexu --set secret.create=false --set secret.existingSecretName=ext-secret