### PR TITLE
fix: stabilize deploy pipeline and runtime ESM packaging

### DIFF
--- a/apps/gateway/Dockerfile
+++ b/apps/gateway/Dockerfile
@@ -42,6 +42,7 @@ ENV NODE_ENV=production
 
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/apps/gateway/node_modules ./apps/gateway/node_modules
+COPY --from=build /app/packages/shared/node_modules ./packages/shared/node_modules
 COPY --from=build /app/apps/gateway/dist ./apps/gateway/dist
 COPY --from=build /app/apps/gateway/package.json ./apps/gateway/package.json
 COPY --from=build /app/packages/shared/dist ./packages/shared/dist


### PR DESCRIPTION
## Summary
- align API/Gateway TypeScript to NodeNext and enforce explicit `.js` relative imports to prevent runtime `ERR_MODULE_NOT_FOUND`
- harden CI/CD by adding a repo CI workflow and enabling Buildx GHA cache in image builds
- fix gateway runtime packaging by including workspace `node_modules` needed at runtime, and add ESM import-specifier verification script
- update Helm chart to support existing external Secret references when `secret.create=false`

## Validation
- CI workflow now runs `pnpm typecheck`, `pnpm lint`, `pnpm build`, and `pnpm check:esm-imports`