### PR TITLE
fix(helm): stop configuring runtime pool id in chart values

### DIFF
--- a/deploy/helm/nexu/README.md
+++ b/deploy/helm/nexu/README.md
@@ -45,6 +45,12 @@ helm upgrade --install nexu ./deploy/k8s/helm/nexu \
 
 Do not keep production secrets in `values.yaml`. Pass secrets with CI/CD or use `ExternalSecrets`.
 
+## Gateway Pool ID
+
+Do not set `RUNTIME_POOL_ID` in Helm values.
+
+The chart runs Gateway as a StatefulSet and generates `RUNTIME_POOL_ID` automatically from the pod index (`apps.kubernetes.io/pod-index`), so each pod gets a stable unique pool ID.
+
 ## External Secrets
 
 This chart can either create a Secret from values or reference an existing Secret.

--- a/deploy/helm/nexu/templates/configmap.yaml
+++ b/deploy/helm/nexu/templates/configmap.yaml
@@ -10,6 +10,5 @@ data:
   NODE_ENV: {{ .Values.config.NODE_ENV | quote }}
   WEB_URL: {{ .Values.config.WEB_URL | quote }}
   BETTER_AUTH_URL: {{ .Values.config.BETTER_AUTH_URL | quote }}
-  RUNTIME_POOL_ID: {{ .Values.config.RUNTIME_POOL_ID | quote }}
   RUNTIME_MANAGE_OPENCLAW_PROCESS: {{ .Values.config.RUNTIME_MANAGE_OPENCLAW_PROCESS | quote }}
   NEXU_API_URL: {{ printf "http://%s:%v" (include "nexu.api.fullname" .) .Values.api.service.port | quote }}

--- a/deploy/helm/nexu/values.yaml
+++ b/deploy/helm/nexu/values.yaml
@@ -13,7 +13,6 @@ config:
   NODE_ENV: "production"
   WEB_URL: "https://nexu.example.com"
   BETTER_AUTH_URL: "https://api.nexu.example.com"
-  RUNTIME_POOL_ID: "pool_local_01"
   RUNTIME_MANAGE_OPENCLAW_PROCESS: "true"
 
 secret:

--- a/docs/guides/docker-deployment.md
+++ b/docs/guides/docker-deployment.md
@@ -77,6 +77,7 @@ docker build -f Dockerfile.gateway -t nexu-gateway .
 - Gateway runtime service (`apps/gateway/src/index.ts`) fetches config with retry, waits for gateway readiness, registers pool, and keeps heartbeat/config-sync loops running
 - Optional process management switch: `RUNTIME_MANAGE_OPENCLAW_PROCESS=true` lets the runtime spawn `openclaw gateway` via `child_process`
 - Key env vars: `RUNTIME_API_BASE_URL`, `INTERNAL_API_TOKEN`, `RUNTIME_POOL_ID`, `RUNTIME_POD_IP`, `OPENCLAW_CONFIG_PATH`
+- In Docker Compose, `RUNTIME_POOL_ID` can be set manually for local runtime identity
 
 ### PostgreSQL
 - `postgres:16-alpine`, credentials `nexu:nexu`, database `nexu_dev`
@@ -90,3 +91,4 @@ See `deploy/k8s/README.md`. Key differences from Compose:
 - Config sync sidecar for live config updates
 - Secrets via K8s Secrets
 - Ingress handles TLS termination
+- For Helm StatefulSet deployments, do not set `RUNTIME_POOL_ID` in chart values; it is auto-generated from pod index (`apps.kubernetes.io/pod-index`)


### PR DESCRIPTION
## Summary
- remove `RUNTIME_POOL_ID` from Helm chart values and ConfigMap so it is no longer user-configurable
- document that Gateway StatefulSet auto-generates `RUNTIME_POOL_ID` from pod index for stable per-pod identity
- clarify in deployment docs that manual `RUNTIME_POOL_ID` is for Docker Compose local usage, not Helm StatefulSet deployments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced deployment guides clarifying pool ID handling for Docker and Kubernetes environments
  * Added guidance that Kubernetes Helm deployments automatically generate stable pool IDs

* **Configuration**
  * Simplified Helm configuration by removing manual pool ID setting requirement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->