### PR TITLE
fix(gateway): fetch initial config before readiness probe

### DIFF
--- a/apps/gateway/src/bootstrap.ts
+++ b/apps/gateway/src/bootstrap.ts
@@ -77,13 +77,14 @@ export async function bootstrapGateway(): Promise<void> {
     configPath: env.OPENCLAW_CONFIG_PATH,
     manageOpenclawProcess: env.RUNTIME_MANAGE_OPENCLAW_PROCESS,
   });
+  await registerPoolWithRetry();
+  log("pool registered", { poolId: env.RUNTIME_POOL_ID });
+
+  await fetchInitialConfigWithRetry();
+
   if (env.RUNTIME_MANAGE_OPENCLAW_PROCESS) {
     startManagedOpenclawGateway();
   }
 
   await waitGatewayReady();
-  await registerPoolWithRetry();
-  log("pool registered", { poolId: env.RUNTIME_POOL_ID });
-
-  await fetchInitialConfigWithRetry();
 }


### PR DESCRIPTION
## Summary
- Fix gateway startup ordering to register the pool and sync initial config before launching and probing the managed OpenClaw process.
- Prevent startup deadlock when `/etc/openclaw` is an emptyDir and no config file exists at container start.
- Keep runtime behavior unchanged after readiness succeeds; this only changes bootstrap sequencing.

## Validation
- pnpm typecheck
- pnpm lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chore**
  * Optimized the gateway startup sequence by reordering initialization operations to occur earlier in the bootstrap process and removing redundant invocations. Enhanced logging visibility during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->