### PR TITLE
feat: expose commit hash metadata in health and web

### DIFF
--- a/.github/workflows/build-and-push-images.yml
+++ b/.github/workflows/build-and-push-images.yml
@@ -77,6 +77,9 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           push: true
+          build-args: |
+            COMMIT_HASH=${{ github.sha }}
+            VITE_COMMIT_HASH=${{ github.sha }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.app }}

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -35,6 +35,8 @@ jobs:
 
   deploy-app:
     runs-on: ubuntu-latest
+    env:
+      VITE_COMMIT_HASH: ${{ github.sha }}
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -24,6 +24,8 @@ FROM node:22-slim
 
 RUN corepack enable && corepack prepare pnpm@10.26.0 --activate
 
+ARG COMMIT_HASH
+
 WORKDIR /app
 
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
@@ -38,6 +40,7 @@ COPY --from=builder /app/apps/api/dist/ apps/api/dist/
 
 ENV NODE_ENV=production
 ENV PORT=3000
+ENV COMMIT_HASH=${COMMIT_HASH}
 
 EXPOSE 3000
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -26,6 +26,7 @@ import type { AppBindings } from "./types.js";
 
 export function createApp() {
   const app = new OpenAPIHono<AppBindings>();
+  const commitHash = process.env.COMMIT_HASH;
 
   app.use("*", logger());
   app.use(
@@ -58,7 +59,14 @@ export function createApp() {
     info: { title: "Nexu API", version: "1.0.0" },
   });
 
-  app.get("/health", (c) => c.json({ status: "ok" }));
+  app.get("/health", (c) =>
+    c.json({
+      status: "ok",
+      metadata: {
+        commitHash: commitHash ?? null,
+      },
+    }),
+  );
 
   return app;
 }

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -17,7 +17,9 @@ COPY packages/shared/ packages/shared/
 COPY apps/web/ apps/web/
 
 ARG VITE_API_URL=""
+ARG VITE_COMMIT_HASH=""
 ENV VITE_API_URL=${VITE_API_URL}
+ENV VITE_COMMIT_HASH=${VITE_COMMIT_HASH}
 
 RUN pnpm --filter @nexu/web build
 

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="x-commit-hash" content="%VITE_COMMIT_HASH%" />
     <title>Nexu - OpenClaw Dashboard</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- add API `/health` metadata with `commitHash` sourced from `COMMIT_HASH`
- expose frontend commit hash via `<meta name=\"x-commit-hash\">` using `VITE_COMMIT_HASH`
- wire CI/CD build env propagation so both API and web receive `${{ github.sha }}` during builds/deploy

## Validation
- `fnm exec --using=24 pnpm --filter @nexu/api typecheck`
- `fnm exec --using=24 pnpm --filter @nexu/web typecheck`
- `fnm exec --using=24 pnpm check:esm-imports`
- `fnm exec --using=24 env VITE_COMMIT_HASH=smoke-build-hash pnpm --filter @nexu/web build`
- full `pnpm lint` currently fails on pre-existing issues unrelated to this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * API health endpoint now includes commit hash metadata
  * Web application embeds commit hash in HTML metadata

* **Chores**
  * Enhanced build workflows to inject commit hashes during container image builds
  * Updated container configurations to propagate commit hash information across services

<!-- end of auto-generated comment: release notes by coderabbit.ai -->