### PR TITLE
chore(ci): align deploy EKS workflow terminology

### DIFF
--- a/.github/workflows/deploy-eks.yml
+++ b/.github/workflows/deploy-eks.yml
@@ -23,6 +23,10 @@ permissions:
 env:
   AWS_REGION: us-east-1
 
+concurrency:
+  group: deploy-eks
+  cancel-in-progress: true
+
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -149,7 +153,7 @@ jobs:
             '{
               repository: "refly-ai/nexu-apps",
               environment: "prod",
-              syncMode: "createPR",
+              syncMode: "directCommit",
               changes: [
                 {
                   application: "nexu",


### PR DESCRIPTION
## Summary
- rename the workflow display name to `Deploy EKS` so it reflects the EKS deployment pipeline context
- update push path trigger to watch `.github/workflows/deploy-eks.yml` instead of the old workflow filename
- clarify the sync job name to `Sync App Values to GitOps Repo` for more accurate GitOps wording

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed and clarified deployment workflow naming and job labels.
  * Updated deployment sync mode to use direct commits instead of PRs.
  * Added concurrency controls to prevent overlapping deployment runs.

---

Note: These are infrastructure changes with no visible impact on end-user functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->