### PR TITLE
fix(api): fallback DD_VERSION to COMMIT_HASH

### DIFF
--- a/apps/api/src/datadog.ts
+++ b/apps/api/src/datadog.ts
@@ -1,5 +1,9 @@
 import "dotenv/config";
 
+if (!process.env.DD_VERSION && process.env.COMMIT_HASH) {
+  process.env.DD_VERSION = process.env.COMMIT_HASH;
+}
+
 if (process.env.DD_ENV) {
   try {
     // @ts-expect-error dd-trace lacks ESM exports map


### PR DESCRIPTION
## Summary
- set `DD_VERSION` from `COMMIT_HASH` when `DD_VERSION` is not provided
- keep existing Datadog initialization flow unchanged (`DD_ENV` still gates tracer init)
- remove the need to manually keep `DD_VERSION` in sync with image tags for standard deploys

## Verification
- `pnpm --filter @nexu/api typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved application version configuration to ensure consistent version information is available during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->