### PR TITLE
fix(web): configure Better Auth base URL via env

### DIFF
--- a/.github/workflows/deploy-eks.yml
+++ b/.github/workflows/deploy-eks.yml
@@ -85,6 +85,7 @@ jobs:
             COMMIT_HASH=${{ github.sha }}
             VITE_COMMIT_HASH=${{ github.sha }}
             VITE_AMPLITUDE_API_KEY=${{ secrets.VITE_AMPLITUDE_API_KEY }}
+            VITE_AUTH_BASE_URL=${{ vars.VITE_AUTH_BASE_URL }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.app }}

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -37,6 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VITE_COMMIT_HASH: ${{ github.sha }}
+      VITE_AUTH_BASE_URL: ${{ vars.VITE_AUTH_BASE_URL }}
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -1,6 +1,9 @@
 import { emailOTPClient } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
 
+const authBaseUrl = import.meta.env.VITE_AUTH_BASE_URL;
+
 export const authClient = createAuthClient({
+  baseURL: authBaseUrl || undefined,
   plugins: [emailOTPClient()],
 });


### PR DESCRIPTION
## Summary
- make web `authClient` accept `VITE_AUTH_BASE_URL` and keep existing same-origin behavior when unset
- pass `VITE_AUTH_BASE_URL` into both web deployment workflows so built assets can target the intended auth origin
- this allows production to pin auth flows to `api.nexu.io` when needed, avoiding OAuth state mismatches from mixed origins

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Authentication service base URL can now be configured through environment variables, enabling deployments to use different authentication endpoints across environments.

* **Chores**
  * Deployment workflows updated to support configurable authentication service settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->