### PR TITLE
fix(web): redirect Google OAuth callback to workspace

### DIFF
--- a/apps/web/src/pages/auth.tsx
+++ b/apps/web/src/pages/auth.tsx
@@ -173,7 +173,7 @@ export function AuthPage() {
     try {
       await authClient.signIn.social({
         provider,
-        callbackURL: window.location.origin,
+        callbackURL: `${window.location.origin}/workspace`,
       });
     } catch {
       setLoading(null);


### PR DESCRIPTION
## Summary
- Redirect Google OAuth completion back to `/workspace` instead of the site root.
- Update social sign-in callback URL in auth page to improve post-login landing flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Google sign-in flow to correctly redirect users to the workspace page after successful authentication, improving the sign-in experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->