### PR TITLE
fix(gateway): quiet openclaw probe output for JSON parsing

### DIFF
--- a/apps/gateway/src/gateway-health.ts
+++ b/apps/gateway/src/gateway-health.ts
@@ -91,6 +91,10 @@ async function runCliProbe(
       {
         timeout: env.RUNTIME_GATEWAY_CLI_TIMEOUT_MS,
         windowsHide: true,
+        env: {
+          ...process.env,
+          OPENCLAW_LOG_LEVEL: "error",
+        },
       },
       (error, stdout) => {
         if (error) {


### PR DESCRIPTION
## Summary
- force `OPENCLAW_LOG_LEVEL=error` for gateway probe subprocesses so `openclaw health/status --json` emits clean JSON on stdout.
- prevent plugin registration noise from polluting probe output and causing `parse_error` in gateway readiness checks.

## Validation
- pnpm --filter @nexu/gateway typecheck
- pnpm exec biome check apps/gateway/src/gateway-health.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated health probe execution configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->