### PR TITLE
fix(gateway): separate openclaw log source metadata

### DIFF
--- a/apps/gateway/src/log.ts
+++ b/apps/gateway/src/log.ts
@@ -1,14 +1,20 @@
 import pino from "pino";
 
 const env = process.env.DD_ENV ?? process.env.NODE_ENV ?? "development";
-const version = process.env.DD_VERSION ?? process.env.COMMIT_HASH ?? "unknown";
+const version =
+  process.env.DD_VERSION ??
+  process.env.COMMIT_HASH ??
+  process.env.GIT_COMMIT_SHA ??
+  process.env.IMAGE_TAG ??
+  process.env.npm_package_version;
 
 export const logger = pino({
   level: process.env.LOG_LEVEL ?? (env === "production" ? "info" : "debug"),
   base: {
     service: "nexu-gateway",
     env,
-    version,
+    log_source: "gateway",
+    ...(version ? { version } : {}),
   },
   timestamp: pino.stdTimeFunctions.isoTime,
 });

--- a/apps/gateway/src/openclaw-process.ts
+++ b/apps/gateway/src/openclaw-process.ts
@@ -1,6 +1,8 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { env } from "./env.js";
-import { BaseError, GatewayError, logger } from "./log.js";
+import { BaseError, GatewayError, logger as gatewayLogger } from "./log.js";
+
+const logger = gatewayLogger.child({ log_source: "openclaw" });
 
 let openclawGatewayProcess: ChildProcess | null = null;
 
@@ -22,7 +24,10 @@ export function startManagedOpenclawGateway(): void {
   const args = buildOpenclawGatewayArgs();
   const child = spawn(env.OPENCLAW_BIN, args, {
     stdio: "inherit",
-    env: process.env,
+    env: {
+      ...process.env,
+      OPENCLAW_LOG_LEVEL: "error",
+    },
   });
 
   openclawGatewayProcess = child;


### PR DESCRIPTION
## Summary
- add explicit gateway logger base metadata with `log_source: gateway` and a resilient version fallback chain to avoid missing version tags.
- initialize an openclaw-scoped child logger inside `openclaw-process.ts` and use it for process lifecycle/error logs.
- force `OPENCLAW_LOG_LEVEL=error` when spawning the managed openclaw process to reduce noisy stdout logs mixed into gateway streams.

## Validation
- pnpm --filter @nexu/gateway typecheck
- pnpm exec biome check apps/gateway/src/openclaw-process.ts apps/gateway/src/log.ts