### PR TITLE
fix(gateway): pipe openclaw output through structured logger

### DIFF
--- a/apps/gateway/src/openclaw-process.ts
+++ b/apps/gateway/src/openclaw-process.ts
@@ -1,4 +1,5 @@
 import { type ChildProcess, spawn } from "node:child_process";
+import { createInterface } from "node:readline";
 import { env } from "./env.js";
 import { BaseError, GatewayError, logger as gatewayLogger } from "./log.js";
 
@@ -16,6 +17,34 @@ function buildOpenclawGatewayArgs(): string[] {
   return args;
 }
 
+function pipeChildStream(
+  stream: NodeJS.ReadableStream | null,
+  streamName: "stdout" | "stderr",
+): void {
+  if (!stream) {
+    return;
+  }
+
+  const reader = createInterface({
+    input: stream,
+    crlfDelay: Number.POSITIVE_INFINITY,
+  });
+
+  reader.on("line", (line) => {
+    if (line.length === 0) {
+      return;
+    }
+
+    logger.info(
+      {
+        stream: streamName,
+        raw_line: line,
+      },
+      "openclaw output",
+    );
+  });
+}
+
 export function startManagedOpenclawGateway(): void {
   if (openclawGatewayProcess !== null) {
     return;
@@ -23,12 +52,15 @@ export function startManagedOpenclawGateway(): void {
 
   const args = buildOpenclawGatewayArgs();
   const child = spawn(env.OPENCLAW_BIN, args, {
-    stdio: "inherit",
+    stdio: ["ignore", "pipe", "pipe"],
     env: {
       ...process.env,
       OPENCLAW_LOG_LEVEL: "error",
     },
   });
+
+  pipeChildStream(child.stdout, "stdout");
+  pipeChildStream(child.stderr, "stderr");
 
   openclawGatewayProcess = child;
 


### PR DESCRIPTION
## Summary
- switch managed openclaw process from inherited stdio to piped streams so child output no longer directly pollutes container logs.
- bridge openclaw stdout/stderr line-by-line into gateway logger with structured fields (`log_source=openclaw`, `stream`, `raw_line`).
- keep `OPENCLAW_LOG_LEVEL=error` for child process startup while preserving observability through structured relay logs.

## Validation
- pnpm --filter @nexu/gateway typecheck
- pnpm exec biome check apps/gateway/src/openclaw-process.ts
- pnpm typecheck
- pnpm lint