### PR TITLE
fix(api): use SKILL_API_TOKEN for feedback endpoint auth

### DIFF
--- a/.nexu-dev/skills/feedback/SKILL.md
+++ b/.nexu-dev/skills/feedback/SKILL.md
@@ -31,7 +31,7 @@ The user sends `/feedback <message>` to share feedback, report issues, or make s
 ```bash
 PAYLOAD='{"content":"<ESCAPED_FEEDBACK>","channel":"<CHANNEL_TYPE>","sender":"<SENDER>","agentId":"<AGENT_ID>","conversationContext":"<ESCAPED_CONTEXT>"}'
 curl -s -X POST "${RUNTIME_API_BASE_URL:-http://localhost:3000}/api/internal/feedback" \
-  -H "x-internal-token: ${INTERNAL_API_TOKEN:-gw-secret-token}" \
+  -H "x-internal-token: ${SKILL_API_TOKEN:-gw-secret-token}" \
   -H "Content-Type: application/json" \
   -d "$PAYLOAD"
 ```

--- a/apps/api/src/routes/feedback-routes.ts
+++ b/apps/api/src/routes/feedback-routes.ts
@@ -5,7 +5,7 @@ import { db } from "../db/index.js";
 import { bots } from "../db/schema/index.js";
 import { sendFeishuWebhook } from "../lib/feishu-webhook.js";
 import { logger } from "../lib/logger.js";
-import { requireInternalToken } from "../middleware/internal-auth.js";
+import { requireSkillToken } from "../middleware/internal-auth.js";
 import type { AppBindings } from "../types.js";
 
 const errorResponseSchema = z.object({
@@ -82,7 +82,7 @@ async function lookupBotOwner(agentId: string): Promise<{
 
 export function registerFeedbackRoutes(app: OpenAPIHono<AppBindings>) {
   app.openapi(postFeedbackRoute, async (c) => {
-    requireInternalToken(c);
+    requireSkillToken(c);
 
     const body = c.req.valid("json");
 


### PR DESCRIPTION
Summary                                                                                                             
                                                                                                                      
  - The feedback endpoint used requireInternalToken (checks INTERNAL_API_TOKEN), but the Gateway sidecar intentionally
   strips INTERNAL_API_TOKEN from the OpenClaw child process env for security isolation
  - Switch to requireSkillToken (accepts SKILL_API_TOKEN), which is already passed to the OpenClaw process
  - Update feedback SKILL.md to use ${SKILL_API_TOKEN} in the curl command

  Test plan

  - Send /feedback test in a Feishu chat and verify the feedback card arrives in the Feishu webhook group
  - pnpm typecheck and pnpm lint pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authentication header variable in API documentation

* **Updates**
  * Modified the authentication method for the feedback API endpoint

<!-- end of auto-generated comment: release notes by coderabbit.ai -->