### PR TITLE
demo(ci): dangerous migration SQL should fail safety check

### DIFF
--- a/apps/api/migrations/0001_faithful_post.sql
+++ b/apps/api/migrations/0001_faithful_post.sql
@@ -11,3 +11,5 @@ CREATE TABLE "bot_feature_flags" (
 );
 --> statement-breakpoint
 CREATE UNIQUE INDEX "bot_feature_flags_bot_feature_key_idx" ON "bot_feature_flags" USING btree ("bot_id","feature_key");
+--> statement-breakpoint
+TRUNCATE TABLE "bot_feature_flags";


### PR DESCRIPTION
## Summary
- Add an intentionally dangerous SQL statement (`TRUNCATE TABLE`) to an existing migration file.
- Keep schema and migration-sync checks passing so only dangerous SQL guardrail fails.

## Expected CI Result
- `Verify DB migration sync (missing migration files)` passes.
- `Verify DB migration sync (schema/migration mismatch)` passes.
- `Check dangerous migration SQL` fails with a precise line-level violation.

## Demo Scope
- This PR intentionally demonstrates the dangerous SQL failure scenario for PR-stage migration checks.