### PR TITLE
fix(api): stabilize trace/span behavior in local dev

### DIFF
--- a/apps/api/dev.sh
+++ b/apps/api/dev.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+parent_pid="$PPID"
+
+node_args=(--watch --import tsx dist/index.js)
+
+if [[ -n "${DD_ENV:-}" ]]; then
+  node_args=(--watch --import dd-trace/initialize.mjs --import tsx dist/index.js)
+fi
+
+pnpm exec tsc -p tsconfig.build.json -w &
+tsc_pid=$!
+
+DD_TRACE_PRELOADED="${DD_TRACE_PRELOADED:-false}"
+if [[ -n "${DD_ENV:-}" ]]; then
+  DD_TRACE_PRELOADED="true"
+fi
+
+NODE_OPTIONS=--conditions=development DD_TRACE_PRELOADED="$DD_TRACE_PRELOADED" node "${node_args[@]}" &
+node_pid=$!
+
+cleanup() {
+  kill "$node_pid" 2>/dev/null || true
+  kill "$tsc_pid" 2>/dev/null || true
+}
+
+trap cleanup EXIT INT TERM
+
+(
+  while kill -0 "$parent_pid" 2>/dev/null && kill -0 "$node_pid" 2>/dev/null; do
+    sleep 1
+  done
+
+  kill "$node_pid" 2>/dev/null || true
+  kill "$tsc_pid" 2>/dev/null || true
+) &
+watchdog_pid=$!
+
+wait "$node_pid"
+kill "$watchdog_pid" 2>/dev/null || true

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "NODE_OPTIONS=--conditions=development tsx watch src/index.ts",
+    "dev": "bash ./dev.sh",
     "build": "tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,5 +1,7 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
+import type { Context } from "hono";
 import { cors } from "hono/cors";
+import { Span, Trace } from "./lib/trace-decorator.js";
 import { authMiddleware } from "./middleware/auth.js";
 import {
   errorMiddleware,
@@ -33,9 +35,33 @@ import { registerUserRoutes } from "./routes/user-routes.js";
 
 import type { AppBindings } from "./types.js";
 
+class HealthHandler {
+  constructor(private readonly commitHash?: string) {}
+
+  @Trace("api.health")
+  async handle(c: Context<AppBindings>): Promise<Response> {
+    const payload = await this.buildPayload();
+    return c.json(payload);
+  }
+
+  @Span("api.health.payload")
+  async buildPayload(): Promise<{
+    status: "ok";
+    metadata: { commitHash: string | null };
+  }> {
+    return {
+      status: "ok",
+      metadata: {
+        commitHash: this.commitHash ?? null,
+      },
+    };
+  }
+}
+
 export function createApp() {
   const app = new OpenAPIHono<AppBindings>();
   const commitHash = process.env.COMMIT_HASH;
+  const healthHandler = new HealthHandler(commitHash);
 
   app.use("*", requestLoggerMiddleware);
   app.use("*", errorMiddleware);
@@ -73,14 +99,7 @@ export function createApp() {
     info: { title: "Nexu API", version: "1.0.0" },
   });
 
-  app.get("/health", (c) =>
-    c.json({
-      status: "ok",
-      metadata: {
-        commitHash: commitHash ?? null,
-      },
-    }),
-  );
+  app.get("/health", (c) => healthHandler.handle(c));
 
   app.onError((error, c) => {
     const handled = resolveErrorHandling(c, error);

--- a/apps/api/src/datadog.ts
+++ b/apps/api/src/datadog.ts
@@ -1,21 +1,42 @@
 import "dotenv/config";
-import { BaseError } from "./lib/error.js";
-import { logger } from "./lib/logger.js";
+
+function toErrorInfo(err: unknown): {
+  error_type: string;
+  error_message: string;
+} {
+  if (err instanceof Error) {
+    return {
+      error_type: err.name,
+      error_message: err.message,
+    };
+  }
+
+  return {
+    error_type: typeof err,
+    error_message: String(err),
+  };
+}
+
+function logInitFail(err: unknown): void {
+  const errorInfo = toErrorInfo(err);
+  console.warn(
+    JSON.stringify({
+      message: "datadog_init_failed",
+      scope: "datadog_init",
+      ...errorInfo,
+    }),
+  );
+}
 
 if (!process.env.DD_VERSION && process.env.COMMIT_HASH) {
   process.env.DD_VERSION = process.env.COMMIT_HASH;
 }
 
-if (process.env.DD_ENV) {
+if (process.env.DD_ENV && process.env.DD_TRACE_PRELOADED !== "true") {
   try {
     // @ts-expect-error dd-trace lacks ESM exports map
     await import("dd-trace/initialize.mjs");
   } catch (err) {
-    const unknownError = BaseError.from(err);
-    logger.warn({
-      message: "datadog_init_failed",
-      scope: "datadog_init",
-      ...unknownError.toJSON(),
-    });
+    logInitFail(err);
   }
 }

--- a/apps/api/src/lib/trace-decorator.ts
+++ b/apps/api/src/lib/trace-decorator.ts
@@ -1,0 +1,102 @@
+import { logger } from "./logger.js";
+
+type DatadogSpan = {
+  setTag: (key: string, value: unknown) => void;
+};
+
+type DatadogTracer = {
+  trace: <T>(
+    spanName: string,
+    options: Record<string, unknown>,
+    callback: (span: DatadogSpan) => T,
+  ) => T;
+};
+
+let tracerPromise: Promise<DatadogTracer | null> | null = null;
+
+async function getTracer(): Promise<DatadogTracer | null> {
+  if (!process.env.DD_ENV) {
+    return null;
+  }
+
+  if (tracerPromise) {
+    return tracerPromise;
+  }
+
+  tracerPromise = import("dd-trace")
+    .then((module) => {
+      const candidate = (module.default?.tracer ?? module.default) as {
+        trace?: DatadogTracer["trace"];
+      };
+
+      if (typeof candidate.trace !== "function") {
+        return null;
+      }
+
+      return {
+        trace: candidate.trace.bind(candidate),
+      };
+    })
+    .catch(() => null);
+
+  return tracerPromise;
+}
+
+type AsyncMethod = (...args: unknown[]) => Promise<unknown>;
+
+function decorateWithSpan(spanName: string, spanType: "trace" | "span") {
+  return (
+    _target: object,
+    _propertyKey: string,
+    descriptor: PropertyDescriptor,
+  ): void => {
+    const original = descriptor.value;
+
+    if (typeof original !== "function") {
+      return;
+    }
+
+    descriptor.value = async function (...args: unknown[]) {
+      const tracer = await getTracer();
+
+      if (!tracer) {
+        logger.info({
+          message: "trace_local_event",
+          span_name: spanName,
+          span_type: spanType,
+        });
+        return (original as AsyncMethod).apply(this, args);
+      }
+
+      return tracer.trace(
+        spanName,
+        {
+          resource: spanName,
+          tags: {
+            span_type: spanType,
+          },
+        },
+        async (span) => {
+          try {
+            return await (original as AsyncMethod).apply(this, args);
+          } catch (error) {
+            span.setTag("error", true);
+            if (error instanceof Error) {
+              span.setTag("error.type", error.name || "Error");
+              span.setTag("error.msg", error.message || "unknown_error");
+            }
+            throw error;
+          }
+        },
+      );
+    };
+  };
+}
+
+export function Trace(spanName: string) {
+  return decorateWithSpan(spanName, "trace");
+}
+
+export function Span(spanName: string) {
+  return decorateWithSpan(spanName, "span");
+}

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -5,7 +5,8 @@
     "moduleResolution": "NodeNext",
     "outDir": "./dist",
     "rootDir": ".",
-    "types": ["node"]
+    "types": ["node"],
+    "experimentalDecorators": true
   },
   "include": ["src", "scripts"],
   "exclude": ["node_modules", "dist", "src/**/__tests__"]


### PR DESCRIPTION
## Summary
- switch API dev runtime to `tsc -w` + `node --watch` via `apps/api/dev.sh`, with safe child-process cleanup and optional Datadog preload
- add lightweight `@Trace`/`@Span` decorators for API handlers and apply them to `/health` to validate trace/span layering
- guard Datadog initialization to avoid double init when preloaded and keep init-failure logging concise

## Validation
- `pnpm --filter @nexu/api typecheck`
- local smoke: `/health` returns 200 with `DD_ENV=` and `DD_ENV=local`
- confirmed no dd-trace load-order warning in `DD_ENV=local` dev mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced health endpoint with application metadata
  * Improved development server orchestration with better process management

* **Improvements**
  * Better error reporting and logging for monitoring systems
  * Added distributed tracing support for improved observability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->