### PR TITLE
feat: enforce DB migration checks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   checks:
@@ -16,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -30,6 +33,135 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Verify DB migration sync (missing migration files)
+        id: migration-sync-missing
+        continue-on-error: true
+        env:
+          DB_MIGRATION_EVENT_NAME: ${{ github.event_name }}
+          DB_MIGRATION_BASE_REF: ${{ github.base_ref }}
+          DB_MIGRATION_SYNC_MODE: missing
+          DB_MIGRATION_SYNC_REPORT_PATH: ${{ runner.temp }}/db-migration-sync-missing-report.md
+        run: pnpm --filter @nexu/api db:check-sync:missing
+
+      - name: Verify DB migration sync (schema/migration mismatch)
+        id: migration-sync-mismatch
+        if: steps.migration-sync-missing.outcome == 'success'
+        continue-on-error: true
+        env:
+          DB_MIGRATION_EVENT_NAME: ${{ github.event_name }}
+          DB_MIGRATION_BASE_REF: ${{ github.base_ref }}
+          DB_MIGRATION_SYNC_MODE: mismatch
+          DB_MIGRATION_SYNC_REPORT_PATH: ${{ runner.temp }}/db-migration-sync-mismatch-report.md
+        run: pnpm --filter @nexu/api db:check-sync:mismatch
+
+      - name: Check dangerous migration SQL
+        id: migration-dangerous
+        continue-on-error: true
+        env:
+          DB_MIGRATION_DANGEROUS_REPORT_PATH: ${{ runner.temp }}/db-migration-dangerous-report.md
+        run: pnpm --filter @nexu/api db:check-dangerous
+
+      - name: Comment migration check failures on PR
+        if: github.event_name == 'pull_request' && (steps.migration-sync-missing.outcome == 'failure' || steps.migration-sync-mismatch.outcome == 'failure' || steps.migration-dangerous.outcome == 'failure')
+        uses: actions/github-script@v7
+        env:
+          SYNC_MISSING_REPORT_PATH: ${{ runner.temp }}/db-migration-sync-missing-report.md
+          SYNC_MISMATCH_REPORT_PATH: ${{ runner.temp }}/db-migration-sync-mismatch-report.md
+          DANGEROUS_REPORT_PATH: ${{ runner.temp }}/db-migration-dangerous-report.md
+        with:
+          script: |
+            const fs = require("node:fs");
+            const marker = "<!-- db-migration-ci-report -->";
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const toStatus = (outcome) => {
+              if (outcome === "failure") return "❌ Failed";
+              if (outcome === "success") return "✅ Passed";
+              if (outcome === "skipped") return "⏭️ Skipped";
+              return "⌛ Pending";
+            };
+
+            const sections = [];
+            const missingSyncOutcome = "${{ steps.migration-sync-missing.outcome }}";
+            const mismatchSyncOutcome = "${{ steps.migration-sync-mismatch.outcome }}";
+            const dangerousOutcome = "${{ steps.migration-dangerous.outcome }}";
+
+            const missingSyncFailed = missingSyncOutcome === "failure";
+            const mismatchSyncFailed = mismatchSyncOutcome === "failure";
+            const dangerousFailed = dangerousOutcome === "failure";
+
+            if (missingSyncFailed) {
+              if (fs.existsSync(process.env.SYNC_MISSING_REPORT_PATH)) {
+                sections.push(fs.readFileSync(process.env.SYNC_MISSING_REPORT_PATH, "utf8").trim());
+              } else {
+                sections.push("### ❌ Verify DB migration sync (missing migration files)\n\nSee workflow logs for details.");
+              }
+            }
+
+            if (mismatchSyncFailed) {
+              if (fs.existsSync(process.env.SYNC_MISMATCH_REPORT_PATH)) {
+                sections.push(fs.readFileSync(process.env.SYNC_MISMATCH_REPORT_PATH, "utf8").trim());
+              } else {
+                sections.push("### ❌ Verify DB migration sync (schema/migration mismatch)\n\nSee workflow logs for details.");
+              }
+            }
+
+            if (dangerousFailed) {
+              if (fs.existsSync(process.env.DANGEROUS_REPORT_PATH)) {
+                sections.push(fs.readFileSync(process.env.DANGEROUS_REPORT_PATH, "utf8").trim());
+              } else {
+                sections.push("### Dangerous SQL Check Failed\n\nSee workflow logs for details.");
+              }
+            }
+
+            const body = `${marker}
+            ## 🚨 DB Migration Checks Failed
+
+            > [!CAUTION]
+            > One or more required DB migration checks failed. This PR is blocked until all required DB migration checks pass.
+
+            | Check | Result |
+            | --- | --- |
+            | Verify DB migration sync (missing migration files) | ${toStatus(missingSyncOutcome)} |
+            | Verify DB migration sync (schema/migration mismatch) | ${toStatus(mismatchSyncOutcome)} |
+            | Check dangerous migration SQL | ${toStatus(dangerousOutcome)} |
+
+            ${sections.join("\n\n---\n\n")}
+
+            **Pass Gate**: all required checks in the table above must be ✅ Passed.
+
+            Workflow run: ${runUrl}`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find((comment) =>
+              comment.user.type === "Bot" && comment.body.includes(marker),
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Fail on migration check errors
+        if: steps.migration-sync-missing.outcome == 'failure' || steps.migration-sync-mismatch.outcome == 'failure' || steps.migration-dangerous.outcome == 'failure'
+        run: exit 1
 
       - name: Typecheck
         run: pnpm typecheck

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,9 +26,23 @@ pnpm lint                             # Biome lint
 pnpm format                           # Biome format
 pnpm test                             # Vitest
 pnpm --filter @nexu/api test          # API tests only
+pnpm db:generate                      # Generate Drizzle migration files (recommended)
 pnpm --filter @nexu/api db:push       # Drizzle schema push
 pnpm generate-types                   # OpenAPI spec → frontend SDK
 ```
+
+## DB schema change workflow
+
+When changing DB structure, follow this workflow.
+
+### Development stage
+
+1. Use TS schema (`apps/api/src/db/schema/index.ts`) as the SSoT for target DB structure.
+2. Generate migration SQL with Drizzle (`pnpm db:generate`) and commit files under `apps/api/migrations/`.
+
+### PR stage
+
+- CI automatically checks migration SQL; failures block the PR.
 
 ## Hard rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,11 +21,25 @@ pnpm lint                             # Biome lint (run after any code changes)
 pnpm format                           # Biome auto-fix + format
 pnpm test                             # Run all tests (Vitest)
 pnpm --filter @nexu/api test          # API tests only
+pnpm db:generate                      # Generate Drizzle migration files (recommended)
 pnpm --filter @nexu/api db:push       # Push Drizzle schema to database
 pnpm generate-types                   # Export OpenAPI spec → regenerate frontend SDK
 ```
 
 After API route/schema changes: `pnpm generate-types` then `pnpm typecheck`.
+
+## DB Schema Change Workflow
+
+When changing DB structure, follow this workflow.
+
+### Development stage
+
+1. Use TS schema (`apps/api/src/db/schema/index.ts`) as the SSoT for target DB structure.
+2. Generate migration SQL with Drizzle (`pnpm db:generate`) and commit files under `apps/api/migrations/`.
+
+### PR stage
+
+- CI automatically checks migration SQL; failures block the PR.
 
 ## Architecture
 

--- a/apps/api/drizzle.config.ts
+++ b/apps/api/drizzle.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "drizzle-kit";
 
 export default defineConfig({
   schema: "./src/db/schema/index.ts",
-  out: "./drizzle",
+  out: "./migrations",
   dialect: "postgresql",
   dbCredentials: {
     url:

--- a/apps/api/migrations/0000_unique_thunderbolt.sql
+++ b/apps/api/migrations/0000_unique_thunderbolt.sql
@@ -1,0 +1,241 @@
+CREATE TABLE "artifacts" (
+	"pk" serial PRIMARY KEY NOT NULL,
+	"id" text NOT NULL,
+	"bot_id" text NOT NULL,
+	"session_key" text,
+	"channel_type" text,
+	"channel_id" text,
+	"title" text NOT NULL,
+	"artifact_type" text,
+	"source" text,
+	"content_type" text,
+	"status" text DEFAULT 'building',
+	"preview_url" text,
+	"deploy_target" text,
+	"lines_of_code" integer,
+	"file_count" integer,
+	"duration_ms" integer,
+	"metadata" text,
+	"created_at" text NOT NULL,
+	"updated_at" text NOT NULL,
+	CONSTRAINT "artifacts_id_unique" UNIQUE("id")
+);
+--> statement-breakpoint
+CREATE TABLE "bot_channels" (
+	"pk" serial PRIMARY KEY NOT NULL,
+	"id" text NOT NULL,
+	"bot_id" text NOT NULL,
+	"channel_type" text NOT NULL,
+	"account_id" text NOT NULL,
+	"status" text DEFAULT 'pending',
+	"channel_config" text DEFAULT '{}',
+	"created_at" text NOT NULL,
+	"updated_at" text NOT NULL,
+	CONSTRAINT "bot_channels_id_unique" UNIQUE("id")
+);
+--> statement-breakpoint
+CREATE TABLE "bots" (
+	"pk" serial PRIMARY KEY NOT NULL,
+	"id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"name" text NOT NULL,
+	"slug" text NOT NULL,
+	"system_prompt" text,
+	"model_id" text DEFAULT 'anthropic/claude-sonnet-4',
+	"agent_config" text DEFAULT '{}',
+	"tools_config" text DEFAULT '{}',
+	"status" text DEFAULT 'active',
+	"pool_id" text,
+	"created_at" text NOT NULL,
+	"updated_at" text NOT NULL,
+	CONSTRAINT "bots_id_unique" UNIQUE("id")
+);
+--> statement-breakpoint
+CREATE TABLE "channel_credentials" (
+	"pk" serial PRIMARY KEY NOT NULL,
+	"id" text NOT NULL,
+	"bot_channel_id" text NOT NULL,
+	"credential_type" text NOT NULL,
+	"encrypted_value" text NOT NULL,
+	"created_at" text NOT NULL,
+	CONSTRAINT "channel_credentials_id_unique" UNIQUE("id")
+);
+--> statement-breakpoint
+CREATE TABLE "gateway_assignments" (
+	"pk" serial PRIMARY KEY NOT NULL,
+	"id" text NOT NULL,
+	"bot_id" text NOT NULL,
+	"pool_id" text NOT NULL,
+	"assigned_at" text NOT NULL,
+	CONSTRAINT "gateway_assignments_id_unique" UNIQUE("id"),
+	CONSTRAINT "gateway_assignments_bot_id_unique" UNIQUE("bot_id")
+);
+--> statement-breakpoint
+CREATE TABLE "gateway_pools" (
+	"pk" serial PRIMARY KEY NOT NULL,
+	"id" text NOT NULL,
+	"pool_name" text NOT NULL,
+	"pool_type" text DEFAULT 'shared',
+	"max_bots" integer DEFAULT 50,
+	"current_bots" integer DEFAULT 0,
+	"status" text DEFAULT 'pending',
+	"config_version" integer DEFAULT 0,
+	"pod_ip" text,
+	"last_heartbeat" text,
+	"last_seen_version" integer DEFAULT 0,
+	"created_at" text NOT NULL,
+	CONSTRAINT "gateway_pools_id_unique" UNIQUE("id"),
+	CONSTRAINT "gateway_pools_pool_name_unique" UNIQUE("pool_name")
+);
+--> statement-breakpoint
+CREATE TABLE "invite_codes" (
+	"pk" serial PRIMARY KEY NOT NULL,
+	"id" text NOT NULL,
+	"code" text NOT NULL,
+	"max_uses" integer DEFAULT 100,
+	"used_count" integer DEFAULT 0,
+	"created_by" text,
+	"expires_at" text,
+	"created_at" text NOT NULL,
+	CONSTRAINT "invite_codes_id_unique" UNIQUE("id"),
+	CONSTRAINT "invite_codes_code_unique" UNIQUE("code")
+);
+--> statement-breakpoint
+CREATE TABLE "oauth_states" (
+	"pk" serial PRIMARY KEY NOT NULL,
+	"id" text NOT NULL,
+	"state" text NOT NULL,
+	"bot_id" text,
+	"user_id" text NOT NULL,
+	"expires_at" text NOT NULL,
+	"used_at" text,
+	"return_to" text,
+	"created_at" text NOT NULL,
+	CONSTRAINT "oauth_states_id_unique" UNIQUE("id"),
+	CONSTRAINT "oauth_states_state_unique" UNIQUE("state")
+);
+--> statement-breakpoint
+CREATE TABLE "pool_config_snapshots" (
+	"pk" serial PRIMARY KEY NOT NULL,
+	"id" text NOT NULL,
+	"pool_id" text NOT NULL,
+	"version" integer NOT NULL,
+	"config_hash" text NOT NULL,
+	"config_json" text NOT NULL,
+	"created_at" text NOT NULL,
+	CONSTRAINT "pool_config_snapshots_id_unique" UNIQUE("id")
+);
+--> statement-breakpoint
+CREATE TABLE "pool_secrets" (
+	"pk" serial PRIMARY KEY NOT NULL,
+	"id" text NOT NULL,
+	"pool_id" text NOT NULL,
+	"secret_name" text NOT NULL,
+	"encrypted_value" text NOT NULL,
+	"scope" text DEFAULT 'pool' NOT NULL,
+	"created_at" text NOT NULL,
+	"updated_at" text NOT NULL,
+	CONSTRAINT "pool_secrets_id_unique" UNIQUE("id")
+);
+--> statement-breakpoint
+CREATE TABLE "sessions" (
+	"pk" serial PRIMARY KEY NOT NULL,
+	"id" text NOT NULL,
+	"bot_id" text NOT NULL,
+	"session_key" text NOT NULL,
+	"channel_type" text,
+	"channel_id" text,
+	"title" text NOT NULL,
+	"status" text DEFAULT 'active',
+	"message_count" integer DEFAULT 0,
+	"last_message_at" text,
+	"metadata" text,
+	"created_at" text NOT NULL,
+	"updated_at" text NOT NULL,
+	CONSTRAINT "sessions_id_unique" UNIQUE("id"),
+	CONSTRAINT "sessions_session_key_unique" UNIQUE("session_key")
+);
+--> statement-breakpoint
+CREATE TABLE "skills" (
+	"pk" serial PRIMARY KEY NOT NULL,
+	"id" text NOT NULL,
+	"name" text NOT NULL,
+	"content" text NOT NULL,
+	"files" text DEFAULT '{}' NOT NULL,
+	"status" text DEFAULT 'active',
+	"created_at" text NOT NULL,
+	"updated_at" text NOT NULL,
+	CONSTRAINT "skills_id_unique" UNIQUE("id"),
+	CONSTRAINT "skills_name_unique" UNIQUE("name")
+);
+--> statement-breakpoint
+CREATE TABLE "skills_snapshots" (
+	"pk" serial PRIMARY KEY NOT NULL,
+	"id" text NOT NULL,
+	"version" integer NOT NULL,
+	"skills_hash" text NOT NULL,
+	"skills_json" text NOT NULL,
+	"created_at" text NOT NULL,
+	CONSTRAINT "skills_snapshots_id_unique" UNIQUE("id"),
+	CONSTRAINT "skills_snapshots_version_unique" UNIQUE("version")
+);
+--> statement-breakpoint
+CREATE TABLE "usage_metrics" (
+	"pk" serial PRIMARY KEY NOT NULL,
+	"id" text NOT NULL,
+	"bot_id" text NOT NULL,
+	"period_start" text NOT NULL,
+	"period_end" text NOT NULL,
+	"message_count" integer DEFAULT 0,
+	"token_count" integer DEFAULT 0,
+	"created_at" text NOT NULL,
+	CONSTRAINT "usage_metrics_id_unique" UNIQUE("id")
+);
+--> statement-breakpoint
+CREATE TABLE "users" (
+	"pk" serial PRIMARY KEY NOT NULL,
+	"id" text NOT NULL,
+	"auth_user_id" text NOT NULL,
+	"plan" text DEFAULT 'free',
+	"invite_accepted_at" text,
+	"onboarding_role" text,
+	"onboarding_company" text,
+	"onboarding_use_cases" text,
+	"onboarding_referral_source" text,
+	"onboarding_referral_detail" text,
+	"onboarding_channel_votes" text,
+	"onboarding_avatar" text,
+	"onboarding_avatar_votes" text,
+	"onboarding_completed_at" text,
+	"created_at" text NOT NULL,
+	"updated_at" text NOT NULL,
+	CONSTRAINT "users_id_unique" UNIQUE("id"),
+	CONSTRAINT "users_auth_user_id_unique" UNIQUE("auth_user_id")
+);
+--> statement-breakpoint
+CREATE TABLE "webhook_routes" (
+	"pk" serial PRIMARY KEY NOT NULL,
+	"id" text NOT NULL,
+	"channel_type" text NOT NULL,
+	"external_id" text NOT NULL,
+	"pool_id" text NOT NULL,
+	"bot_channel_id" text NOT NULL,
+	"bot_id" text,
+	"account_id" text,
+	"runtime_url" text,
+	"updated_at" text NOT NULL,
+	"created_at" text NOT NULL,
+	CONSTRAINT "webhook_routes_id_unique" UNIQUE("id")
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "bot_channels_uniq_idx" ON "bot_channels" USING btree ("bot_id","channel_type","account_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "bots_user_slug_idx" ON "bots" USING btree ("user_id","slug");--> statement-breakpoint
+CREATE UNIQUE INDEX "cred_uniq_idx" ON "channel_credentials" USING btree ("bot_channel_id","credential_type");--> statement-breakpoint
+CREATE UNIQUE INDEX "pool_config_snapshots_pool_version_idx" ON "pool_config_snapshots" USING btree ("pool_id","version");--> statement-breakpoint
+CREATE INDEX "pool_config_snapshots_pool_hash_idx" ON "pool_config_snapshots" USING btree ("pool_id","config_hash");--> statement-breakpoint
+CREATE UNIQUE INDEX "pool_secrets_uniq_idx" ON "pool_secrets" USING btree ("pool_id","secret_name");--> statement-breakpoint
+CREATE INDEX "sessions_bot_id_idx" ON "sessions" USING btree ("bot_id");--> statement-breakpoint
+CREATE INDEX "sessions_status_idx" ON "sessions" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "sessions_created_at_idx" ON "sessions" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "sessions_channel_type_idx" ON "sessions" USING btree ("channel_type");--> statement-breakpoint
+CREATE UNIQUE INDEX "webhook_routes_uniq_idx" ON "webhook_routes" USING btree ("channel_type","external_id");

--- a/apps/api/migrations/meta/0000_snapshot.json
+++ b/apps/api/migrations/meta/0000_snapshot.json
@@ -1,0 +1,1554 @@
+{
+  "id": "bfe0d71f-ee9e-4281-a506-cb6551893cbb",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.artifacts": {
+      "name": "artifacts",
+      "schema": "",
+      "columns": {
+        "pk": {
+          "name": "pk",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_id": {
+          "name": "bot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_type": {
+          "name": "channel_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_type": {
+          "name": "artifact_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'building'"
+        },
+        "preview_url": {
+          "name": "preview_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deploy_target": {
+          "name": "deploy_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lines_of_code": {
+          "name": "lines_of_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "artifacts_id_unique": {
+          "name": "artifacts_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bot_channels": {
+      "name": "bot_channels",
+      "schema": "",
+      "columns": {
+        "pk": {
+          "name": "pk",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_id": {
+          "name": "bot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_type": {
+          "name": "channel_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "channel_config": {
+          "name": "channel_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bot_channels_uniq_idx": {
+          "name": "bot_channels_uniq_idx",
+          "columns": [
+            {
+              "expression": "bot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bot_channels_id_unique": {
+          "name": "bot_channels_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bots": {
+      "name": "bots",
+      "schema": "",
+      "columns": {
+        "pk": {
+          "name": "pk",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'anthropic/claude-sonnet-4'"
+        },
+        "agent_config": {
+          "name": "agent_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "tools_config": {
+          "name": "tools_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "pool_id": {
+          "name": "pool_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bots_user_slug_idx": {
+          "name": "bots_user_slug_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bots_id_unique": {
+          "name": "bots_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_credentials": {
+      "name": "channel_credentials",
+      "schema": "",
+      "columns": {
+        "pk": {
+          "name": "pk",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_channel_id": {
+          "name": "bot_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_type": {
+          "name": "credential_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "cred_uniq_idx": {
+          "name": "cred_uniq_idx",
+          "columns": [
+            {
+              "expression": "bot_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "credential_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "channel_credentials_id_unique": {
+          "name": "channel_credentials_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gateway_assignments": {
+      "name": "gateway_assignments",
+      "schema": "",
+      "columns": {
+        "pk": {
+          "name": "pk",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_id": {
+          "name": "bot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pool_id": {
+          "name": "pool_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gateway_assignments_id_unique": {
+          "name": "gateway_assignments_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id"]
+        },
+        "gateway_assignments_bot_id_unique": {
+          "name": "gateway_assignments_bot_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["bot_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gateway_pools": {
+      "name": "gateway_pools",
+      "schema": "",
+      "columns": {
+        "pk": {
+          "name": "pk",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pool_name": {
+          "name": "pool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pool_type": {
+          "name": "pool_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'shared'"
+        },
+        "max_bots": {
+          "name": "max_bots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 50
+        },
+        "current_bots": {
+          "name": "current_bots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "config_version": {
+          "name": "config_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "pod_ip": {
+          "name": "pod_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat": {
+          "name": "last_heartbeat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_version": {
+          "name": "last_seen_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gateway_pools_id_unique": {
+          "name": "gateway_pools_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id"]
+        },
+        "gateway_pools_pool_name_unique": {
+          "name": "gateway_pools_pool_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["pool_name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_codes": {
+      "name": "invite_codes",
+      "schema": "",
+      "columns": {
+        "pk": {
+          "name": "pk",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 100
+        },
+        "used_count": {
+          "name": "used_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_codes_id_unique": {
+          "name": "invite_codes_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id"]
+        },
+        "invite_codes_code_unique": {
+          "name": "invite_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["code"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_states": {
+      "name": "oauth_states",
+      "schema": "",
+      "columns": {
+        "pk": {
+          "name": "pk",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_id": {
+          "name": "bot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "return_to": {
+          "name": "return_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_states_id_unique": {
+          "name": "oauth_states_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id"]
+        },
+        "oauth_states_state_unique": {
+          "name": "oauth_states_state_unique",
+          "nullsNotDistinct": false,
+          "columns": ["state"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pool_config_snapshots": {
+      "name": "pool_config_snapshots",
+      "schema": "",
+      "columns": {
+        "pk": {
+          "name": "pk",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pool_id": {
+          "name": "pool_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_hash": {
+          "name": "config_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_json": {
+          "name": "config_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pool_config_snapshots_pool_version_idx": {
+          "name": "pool_config_snapshots_pool_version_idx",
+          "columns": [
+            {
+              "expression": "pool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pool_config_snapshots_pool_hash_idx": {
+          "name": "pool_config_snapshots_pool_hash_idx",
+          "columns": [
+            {
+              "expression": "pool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "config_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pool_config_snapshots_id_unique": {
+          "name": "pool_config_snapshots_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pool_secrets": {
+      "name": "pool_secrets",
+      "schema": "",
+      "columns": {
+        "pk": {
+          "name": "pk",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pool_id": {
+          "name": "pool_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_name": {
+          "name": "secret_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pool'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pool_secrets_uniq_idx": {
+          "name": "pool_secrets_uniq_idx",
+          "columns": [
+            {
+              "expression": "pool_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "secret_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pool_secrets_id_unique": {
+          "name": "pool_secrets_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "pk": {
+          "name": "pk",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_id": {
+          "name": "bot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_type": {
+          "name": "channel_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_bot_id_idx": {
+          "name": "sessions_bot_id_idx",
+          "columns": [
+            {
+              "expression": "bot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_status_idx": {
+          "name": "sessions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_created_at_idx": {
+          "name": "sessions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_channel_type_idx": {
+          "name": "sessions_channel_type_idx",
+          "columns": [
+            {
+              "expression": "channel_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_id_unique": {
+          "name": "sessions_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id"]
+        },
+        "sessions_session_key_unique": {
+          "name": "sessions_session_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["session_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skills": {
+      "name": "skills",
+      "schema": "",
+      "columns": {
+        "pk": {
+          "name": "pk",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "files": {
+          "name": "files",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "skills_id_unique": {
+          "name": "skills_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id"]
+        },
+        "skills_name_unique": {
+          "name": "skills_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skills_snapshots": {
+      "name": "skills_snapshots",
+      "schema": "",
+      "columns": {
+        "pk": {
+          "name": "pk",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skills_hash": {
+          "name": "skills_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skills_json": {
+          "name": "skills_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "skills_snapshots_id_unique": {
+          "name": "skills_snapshots_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id"]
+        },
+        "skills_snapshots_version_unique": {
+          "name": "skills_snapshots_version_unique",
+          "nullsNotDistinct": false,
+          "columns": ["version"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_metrics": {
+      "name": "usage_metrics",
+      "schema": "",
+      "columns": {
+        "pk": {
+          "name": "pk",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_id": {
+          "name": "bot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "usage_metrics_id_unique": {
+          "name": "usage_metrics_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "pk": {
+          "name": "pk",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'free'"
+        },
+        "invite_accepted_at": {
+          "name": "invite_accepted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_role": {
+          "name": "onboarding_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_company": {
+          "name": "onboarding_company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_use_cases": {
+          "name": "onboarding_use_cases",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_referral_source": {
+          "name": "onboarding_referral_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_referral_detail": {
+          "name": "onboarding_referral_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_channel_votes": {
+          "name": "onboarding_channel_votes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_avatar": {
+          "name": "onboarding_avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_avatar_votes": {
+          "name": "onboarding_avatar_votes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_id_unique": {
+          "name": "users_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id"]
+        },
+        "users_auth_user_id_unique": {
+          "name": "users_auth_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["auth_user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_routes": {
+      "name": "webhook_routes",
+      "schema": "",
+      "columns": {
+        "pk": {
+          "name": "pk",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_type": {
+          "name": "channel_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pool_id": {
+          "name": "pool_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_channel_id": {
+          "name": "bot_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_id": {
+          "name": "bot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_url": {
+          "name": "runtime_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "webhook_routes_uniq_idx": {
+          "name": "webhook_routes_uniq_idx",
+          "columns": [
+            {
+              "expression": "channel_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_routes_id_unique": {
+          "name": "webhook_routes_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/migrations/meta/_journal.json
+++ b/apps/api/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1772621591056,
+      "tag": "0000_unique_thunderbolt",
+      "breakpoints": true
+    }
+  ]
+}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,6 +10,13 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "generate-openapi": "tsx scripts/generate-openapi.ts",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate",
+    "db:check-sync": "tsx scripts/check-migration-sync.ts",
+    "db:check-sync:missing": "DB_MIGRATION_SYNC_MODE=missing tsx scripts/check-migration-sync.ts",
+    "db:check-sync:mismatch": "DB_MIGRATION_SYNC_MODE=mismatch tsx scripts/check-migration-sync.ts",
+    "db:check-dangerous": "tsx scripts/check-migration-dangerous.ts",
+    "db:check-dangerous-sql": "pnpm db:check-dangerous",
     "db:push": "drizzle-kit push",
     "db:seed": "tsx src/db/seed-dev.ts"
   },

--- a/apps/api/scripts/check-migration-dangerous.ts
+++ b/apps/api/scripts/check-migration-dangerous.ts
@@ -1,0 +1,212 @@
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { dirname, extname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+type Violation = {
+  filePath: string;
+  line: number;
+  message: string;
+  snippet: string;
+};
+
+type RegexRule = {
+  message: string;
+  regex: RegExp;
+};
+
+const regexRules: RegexRule[] = [
+  {
+    message: "DROP TABLE is not allowed in PR-stage migrations",
+    regex: /\bdrop\s+table\b/gi,
+  },
+  {
+    message:
+      "ALTER TABLE ... DROP COLUMN is not allowed in PR-stage migrations",
+    regex: /\balter\s+table\b[\s\S]*?\bdrop\s+column\b/gi,
+  },
+  {
+    message: "TRUNCATE TABLE is not allowed in PR-stage migrations",
+    regex: /\btruncate\s+table\b/gi,
+  },
+];
+
+const migrationsDirPath = fileURLToPath(
+  new URL("../migrations", import.meta.url),
+);
+const cwd = process.cwd();
+const reportPath = process.env.DB_MIGRATION_DANGEROUS_REPORT_PATH;
+
+async function writeReport(content: string) {
+  if (!reportPath) {
+    return;
+  }
+
+  await mkdir(dirname(reportPath), { recursive: true });
+  await writeFile(reportPath, content, "utf8");
+}
+
+async function collectSqlFiles(dirPath: string): Promise<string[]> {
+  const entries = await readdir(dirPath, { withFileTypes: true });
+  const sqlFiles: string[] = [];
+
+  for (const entry of entries) {
+    const fullPath = join(dirPath, entry.name);
+
+    if (entry.isDirectory()) {
+      const nestedFiles = await collectSqlFiles(fullPath);
+      sqlFiles.push(...nestedFiles);
+      continue;
+    }
+
+    if (entry.isFile() && extname(entry.name) === ".sql") {
+      sqlFiles.push(fullPath);
+    }
+  }
+
+  return sqlFiles;
+}
+
+function getLineNumber(source: string, index: number): number {
+  const before = source.slice(0, index);
+  return before.split("\n").length;
+}
+
+function getSnippet(source: string, index: number): string {
+  const line = source.slice(0, index).split("\n").length;
+  const target = source.split("\n")[line - 1] ?? "";
+  return target.trim();
+}
+
+function collectRegexViolations(filePath: string, source: string): Violation[] {
+  const violations: Violation[] = [];
+
+  for (const rule of regexRules) {
+    for (const match of source.matchAll(rule.regex)) {
+      const matchIndex = match.index ?? 0;
+      violations.push({
+        filePath,
+        line: getLineNumber(source, matchIndex),
+        message: rule.message,
+        snippet: getSnippet(source, matchIndex),
+      });
+    }
+  }
+
+  return violations;
+}
+
+function collectDeleteWithoutWhere(
+  filePath: string,
+  source: string,
+): Violation[] {
+  const violations: Violation[] = [];
+  const statements = source.matchAll(/\bdelete\s+from\b[\s\S]*?;/gi);
+
+  for (const statement of statements) {
+    const sql = statement[0];
+    if (/\bwhere\b/i.test(sql)) {
+      continue;
+    }
+
+    const matchIndex = statement.index ?? 0;
+    violations.push({
+      filePath,
+      line: getLineNumber(source, matchIndex),
+      message: "DELETE without WHERE is not allowed in PR-stage migrations",
+      snippet: getSnippet(source, matchIndex),
+    });
+  }
+
+  return violations;
+}
+
+function collectUpdateWithoutWhere(
+  filePath: string,
+  source: string,
+): Violation[] {
+  const violations: Violation[] = [];
+  const statements = source.matchAll(/\bupdate\b[\s\S]*?;/gi);
+
+  for (const statement of statements) {
+    const sql = statement[0];
+    if (/\bwhere\b/i.test(sql)) {
+      continue;
+    }
+
+    const matchIndex = statement.index ?? 0;
+    violations.push({
+      filePath,
+      line: getLineNumber(source, matchIndex),
+      message: "UPDATE without WHERE is not allowed in PR-stage migrations",
+      snippet: getSnippet(source, matchIndex),
+    });
+  }
+
+  return violations;
+}
+
+async function main() {
+  const sqlFiles = await collectSqlFiles(migrationsDirPath);
+
+  if (sqlFiles.length === 0) {
+    await writeReport(
+      "### ✅ Check dangerous migration SQL\n\nNo migration SQL files found.",
+    );
+    console.log("No migration SQL files found.");
+    return;
+  }
+
+  const violations: Violation[] = [];
+
+  for (const filePath of sqlFiles) {
+    const source = await readFile(filePath, "utf8");
+    violations.push(...collectRegexViolations(filePath, source));
+    violations.push(...collectDeleteWithoutWhere(filePath, source));
+    violations.push(...collectUpdateWithoutWhere(filePath, source));
+  }
+
+  if (violations.length === 0) {
+    await writeReport(
+      "### ✅ Check dangerous migration SQL\n\nNo dangerous SQL statements were detected.",
+    );
+    console.log("Migration dangerous-operation check passed.");
+    return;
+  }
+
+  const reportLines: string[] = [
+    "### ❌ Check dangerous migration SQL",
+    "",
+    "> [!CAUTION]",
+    "> Required check failed. CI detected blocked SQL patterns in migration files.",
+    "",
+    "**Pass Criteria**",
+    "- Migration SQL contains no blocked DDL (`DROP TABLE`, `TRUNCATE TABLE`, `ALTER TABLE ... DROP COLUMN`).",
+    "- `UPDATE`/`DELETE` statements in migrations are bounded with `WHERE`.",
+    "",
+    "**Blocked Statements**",
+    "```text",
+    "",
+  ];
+
+  console.error("Dangerous migration statements detected:");
+  for (const violation of violations) {
+    const relativePath = relative(cwd, violation.filePath);
+    reportLines.push(
+      `${relativePath}:${violation.line} ${violation.message} -> ${violation.snippet}`,
+    );
+    console.error(
+      `- ${relativePath}:${violation.line} ${violation.message} -> ${violation.snippet}`,
+    );
+  }
+
+  reportLines.push(
+    "```",
+    "",
+    "Review and adjust the listed SQL lines before re-running CI.",
+  );
+  await writeReport(reportLines.join("\n"));
+
+  process.exitCode = 1;
+}
+
+await main();

--- a/apps/api/scripts/check-migration-sync.ts
+++ b/apps/api/scripts/check-migration-sync.ts
@@ -1,0 +1,447 @@
+import { spawnSync } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+type StatusEntry = {
+  code: string;
+  filePath: string;
+  raw: string;
+};
+
+type FailureReason =
+  | "missing_migration"
+  | "schema_migration_mismatch"
+  | "migration_drift"
+  | "generation_failed"
+  | "status_failed";
+
+type SyncMode = "all" | "missing" | "mismatch";
+
+const reportPath = process.env.DB_MIGRATION_SYNC_REPORT_PATH;
+const baseRef = process.env.DB_MIGRATION_BASE_REF;
+const eventName = process.env.DB_MIGRATION_EVENT_NAME;
+const maxDiffLines = 220;
+const maxDiffChars = 16000;
+
+function parseSyncMode(raw: string | undefined): SyncMode {
+  if (raw === "missing" || raw === "mismatch") {
+    return raw;
+  }
+
+  return "all";
+}
+
+const syncMode = parseSyncMode(process.env.DB_MIGRATION_SYNC_MODE);
+
+function getCheckDisplayName(mode: SyncMode): string {
+  if (mode === "missing") {
+    return "Verify DB migration sync (missing migration files)";
+  }
+
+  if (mode === "mismatch") {
+    return "Verify DB migration sync (schema/migration mismatch)";
+  }
+
+  return "Verify DB migration sync";
+}
+
+function classifyFailureReason(
+  entries: StatusEntry[],
+  pullRequestChangedMigrations: string[],
+): FailureReason | null {
+  if (entries.length === 0) {
+    return null;
+  }
+
+  const hasUntracked = entries.some((entry) => entry.code === "??");
+  const hasMigrationChangesInPr = pullRequestChangedMigrations.length > 0;
+
+  if (hasUntracked && !hasMigrationChangesInPr) {
+    return "missing_migration";
+  }
+
+  if (hasUntracked && hasMigrationChangesInPr) {
+    return "schema_migration_mismatch";
+  }
+
+  return "migration_drift";
+}
+
+function shouldFailInMode(
+  mode: SyncMode,
+  reason: FailureReason | null,
+): boolean {
+  if (!reason) {
+    return false;
+  }
+
+  if (mode === "all") {
+    return true;
+  }
+
+  if (mode === "missing") {
+    return reason === "missing_migration";
+  }
+
+  return reason !== "missing_migration";
+}
+
+async function writeReport(content: string) {
+  if (!reportPath) {
+    return;
+  }
+
+  await mkdir(dirname(reportPath), { recursive: true });
+  await writeFile(reportPath, content, "utf8");
+}
+
+function runCommand(command: string, args: string[]) {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    stdio: "pipe",
+  });
+
+  return {
+    status: result.status ?? 1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+function parseStatusLine(line: string): StatusEntry | null {
+  if (line.length < 4) {
+    return null;
+  }
+
+  const code = line.slice(0, 2);
+  const filePath = line.slice(3).trim();
+
+  if (!filePath) {
+    return null;
+  }
+
+  return {
+    code,
+    filePath,
+    raw: line,
+  };
+}
+
+function getPullRequestChangedFiles(pathSpec: string): string[] {
+  if (eventName !== "pull_request" || !baseRef) {
+    return [];
+  }
+
+  const diffResult = runCommand("git", [
+    "diff",
+    "--name-only",
+    `origin/${baseRef}...HEAD`,
+    "--",
+    pathSpec,
+  ]);
+
+  if (diffResult.status !== 0) {
+    return [];
+  }
+
+  return diffResult.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+function truncateForCodeBlock(content: string): {
+  text: string;
+  truncated: boolean;
+} {
+  const rawLines = content.split("\n");
+  const byLine = rawLines.slice(0, maxDiffLines).join("\n");
+  const byChar = byLine.slice(0, maxDiffChars);
+  const truncated =
+    byLine.length < content.length || byChar.length < byLine.length;
+
+  return {
+    text: byChar,
+    truncated,
+  };
+}
+
+function getTrackedMigrationDiff(): string {
+  const diffResult = runCommand("git", [
+    "--no-pager",
+    "diff",
+    "--",
+    "migrations",
+  ]);
+  return diffResult.stdout.trim();
+}
+
+function getUntrackedMigrationDiff(filePath: string): string {
+  const diffResult = runCommand("git", [
+    "--no-pager",
+    "diff",
+    "--no-index",
+    "--",
+    "/dev/null",
+    filePath,
+  ]);
+
+  return diffResult.stdout.trim();
+}
+
+function getDiffPreview(entries: StatusEntry[]): {
+  text: string;
+  truncated: boolean;
+} {
+  const chunks: string[] = [];
+
+  const trackedDiff = getTrackedMigrationDiff();
+  if (trackedDiff.length > 0) {
+    chunks.push(trackedDiff);
+  }
+
+  const untrackedEntries = entries.filter((entry) => entry.code === "??");
+  for (const entry of untrackedEntries) {
+    const diff = getUntrackedMigrationDiff(entry.filePath);
+    if (diff.length > 0) {
+      chunks.push(diff);
+    }
+  }
+
+  if (chunks.length === 0) {
+    return {
+      text: "",
+      truncated: false,
+    };
+  }
+
+  return truncateForCodeBlock(chunks.join("\n\n"));
+}
+
+function formatFailureReport(
+  entries: StatusEntry[],
+  pullRequestChangedMigrations: string[],
+  pullRequestChangedSchemas: string[],
+  reason: FailureReason,
+  mode: SyncMode,
+): string {
+  const diffPreview = getDiffPreview(entries);
+  const checkDisplayName = getCheckDisplayName(mode);
+  const hasMigrationChangesInPr = pullRequestChangedMigrations.length > 0;
+  const generatedUntrackedMigrations = entries
+    .filter((entry) => entry.code === "??")
+    .map((entry) => entry.filePath);
+
+  const lines: string[] = [
+    `### ❌ ${checkDisplayName}`,
+    "",
+    "> [!CAUTION]",
+    "> Required check failed. `drizzle-kit generate` produced migration drift not reflected in this PR.",
+    "",
+    "**Failure Classification**",
+  ];
+
+  if (reason === "missing_migration") {
+    lines.push(
+      "- Missing migration files in PR: schema changed but generated migration artifacts were not committed.",
+    );
+  }
+
+  if (reason === "schema_migration_mismatch") {
+    lines.push(
+      "- Migration/schema mismatch: this PR edits migration files, but regeneration still produces additional files.",
+    );
+  }
+
+  if (reason === "migration_drift") {
+    lines.push(
+      "- Migration drift: generated migration output differs from committed migration files.",
+    );
+  }
+
+  if (reason === "generation_failed") {
+    lines.push("- Migration generation failed before drift inspection.");
+  }
+
+  if (reason === "status_failed") {
+    lines.push("- CI could not inspect migration status after generation.");
+  }
+
+  lines.push(
+    "",
+    "**Pass Criteria**",
+    "- Re-running `drizzle-kit generate` introduces zero changes under `apps/api/migrations`.",
+    "- All migration SQL and snapshot/journal artifacts needed by current schema are included in the PR.",
+  );
+
+  if (reason === "missing_migration") {
+    lines.push("", "**Schemas Missing Corresponding Migration Files**");
+
+    if (pullRequestChangedSchemas.length > 0) {
+      for (const filePath of pullRequestChangedSchemas) {
+        lines.push(`- ${filePath}`);
+      }
+    } else {
+      lines.push("- Unable to infer schema files from PR diff.");
+    }
+
+    if (generatedUntrackedMigrations.length > 0) {
+      lines.push("", "**Generated Migration Artifacts Not Included In PR**");
+      for (const filePath of generatedUntrackedMigrations) {
+        lines.push(`- ${filePath}`);
+      }
+    }
+  }
+
+  if (hasMigrationChangesInPr) {
+    lines.push("", "**Migration Files Changed In This PR**");
+    for (const filePath of pullRequestChangedMigrations) {
+      lines.push(`- ${filePath}`);
+    }
+  }
+
+  if (reason !== "missing_migration" && pullRequestChangedSchemas.length > 0) {
+    lines.push("", "**Schema Files Changed In This PR**");
+    for (const filePath of pullRequestChangedSchemas) {
+      lines.push(`- ${filePath}`);
+    }
+  }
+
+  lines.push(
+    "",
+    "**Detected Drift (git status --porcelain -- migrations)**",
+    "```text",
+  );
+
+  for (const entry of entries) {
+    lines.push(entry.raw);
+  }
+
+  lines.push("```");
+
+  if (reason !== "missing_migration" && diffPreview.text.length > 0) {
+    lines.push(
+      "",
+      "**Generated Diff Preview**",
+      "```diff",
+      diffPreview.text,
+      "```",
+    );
+    if (diffPreview.truncated) {
+      lines.push(
+        "_Diff truncated for readability. See workflow logs for the full generated diff._",
+      );
+    }
+  }
+
+  return lines.join("\n");
+}
+
+async function main() {
+  const generateResult = runCommand("pnpm", ["db:generate"]);
+  const checkDisplayName = getCheckDisplayName(syncMode);
+
+  if (generateResult.stdout) {
+    process.stdout.write(generateResult.stdout);
+  }
+
+  if (generateResult.status !== 0) {
+    if (generateResult.stderr) {
+      process.stderr.write(generateResult.stderr);
+    }
+
+    const message = [
+      `### ❌ ${checkDisplayName}`,
+      "",
+      "> [!CAUTION]",
+      "> Required check failed before sync validation could run.",
+      "",
+      "**Pass Criteria**",
+      "- `pnpm --filter @nexu/api db:generate` exits successfully.",
+      "- Re-running generation introduces zero changes under `apps/api/migrations`.",
+      "",
+      "```text",
+      generateResult.stderr.trim() || "Unknown drizzle generation error",
+      "```",
+    ].join("\n");
+
+    await writeReport(message);
+    process.exitCode = shouldFailInMode(syncMode, "generation_failed") ? 1 : 0;
+    return;
+  }
+
+  const statusResult = runCommand("git", [
+    "status",
+    "--porcelain",
+    "--",
+    "migrations",
+  ]);
+
+  if (statusResult.status !== 0) {
+    if (statusResult.stderr) {
+      process.stderr.write(statusResult.stderr);
+    }
+
+    const message = [
+      `### ❌ ${checkDisplayName}`,
+      "",
+      "> [!CAUTION]",
+      "> Required check failed because CI could not inspect migration file status.",
+      "",
+      "```text",
+      statusResult.stderr.trim() || "Unknown git status error",
+      "```",
+    ].join("\n");
+
+    await writeReport(message);
+    process.exitCode = shouldFailInMode(syncMode, "status_failed") ? 1 : 0;
+    return;
+  }
+
+  const entries = statusResult.stdout
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter((line) => line.length > 0)
+    .map(parseStatusLine)
+    .filter((entry): entry is StatusEntry => entry !== null);
+
+  const pullRequestChangedMigrations = getPullRequestChangedFiles("migrations");
+  const pullRequestChangedSchemas = getPullRequestChangedFiles("src/db/schema");
+
+  const reason = classifyFailureReason(entries, pullRequestChangedMigrations);
+
+  if (!reason) {
+    const success = `### ✅ ${checkDisplayName}\n\nSchema and migration files are in sync.`;
+    await writeReport(success);
+    console.log("Migration sync check passed.");
+    return;
+  }
+
+  const shouldFail = shouldFailInMode(syncMode, reason);
+
+  if (!shouldFail) {
+    const skipped = [
+      `### ✅ ${checkDisplayName}`,
+      "",
+      "No failure for this check category.",
+      "",
+      "Current migration drift is classified under another check.",
+    ].join("\n");
+    await writeReport(skipped);
+    console.log("Migration drift exists, but not in this check category.");
+    return;
+  }
+
+  const report = formatFailureReport(
+    entries,
+    pullRequestChangedMigrations,
+    pullRequestChangedSchemas,
+    reason,
+    syncMode,
+  );
+  await writeReport(report);
+  console.error(report);
+  process.exitCode = 1;
+}
+
+await main();

--- a/docs/agent-native/db-migration.md
+++ b/docs/agent-native/db-migration.md
@@ -1,0 +1,102 @@
+# DB Migration 方案
+
+## 现状
+
+- 基于 db/schema/index.ts 维护数据表定义
+- 同步方式：维护 migrate.ts（AI or 手动更新），服务启动时自动运行 migrate 逻辑
+- 存在的问题：migrate.ts 可能 out of sync，可能导致启动服务自动执行后出现数据丢失或不同步
+
+## 目标
+
+- DDL 更新全部自动化，测试环境可自动更新，生产环境需要人工审批变更，其余环节自动更新
+- DML 更新支持方便的触发入口，比如产运同学需要刷数据或者做一些临时操作，可以让 Agent 生成 DML，审批通过后即可变更
+
+## 设计原则
+
+### 原则
+
+- SSoT：只在一个地方定义 DB 的「期望状态」，保证系统状态与真理一致。DDL 期望状态即 Drizzle 的 schema TS 文件
+- DB 变更代码化 (IaC)，DDL/DML 变更都使用代码维护，提交到仓库
+- DB 变更使用 Git 进行版本控制，可追溯、可恢复、可审批
+
+### 约束
+
+- 团队使用 GitHub Free，私有仓库
+
+### 推导
+
+- migration sql 放在 PR，是最好的执行记录与审批载体
+- DDL migration sql 默认工具自动生成，特殊情况（复杂的表结构迁移）可以人工进行调整
+- DML sql 可以人工 + AI 辅助编写
+- 生产环境的 DDL/DML 变更使用单独的「变更执行 PR」进行人工审批，记录审批过程，审批通过（PR 合并）绑定运行变更动作
+- 应用运行时不执行 DDL/DML（否则其实是将变更与审批解耦，且难以追溯变更历史）
+
+## 整体流程（阶段一：Drizzle 方案）
+
+### 本地开发阶段
+
+1. 使用 TS schema (apps/api/src/db/schema/index.ts) 定义目标结构，作为 SSoT
+2. 使用 drizzle-kit generate 生成 migration sql，放在 apps/api/migrations/ 目录下
+3. （可选）对于复杂场景，编辑 migration sql 文件，添加自定义数据迁移逻辑
+4. （可选）本地测试 migration sql
+
+### PR 阶段
+
+1. CI 检查 TS schema 和 migration sql 是否一致
+  - 运行 `drizzle-kit generate`，然后看 git 状态
+2. CI 检查 migration sql 中的危险操作（启发式脚本）
+3. Code Review: 有 DB 变更（修改了 apps/api/migrations/ 目录）的 PR，需要 infra 对应的 owner 审批通过。
+
+### 测试环境 DB 变更
+
+1. PR 合并后，CI 自动执行 migration sql，更新测试环境数据库。
+
+### 生产环境 DB 变更
+
+1. 发版时拉出 release 分支
+2. 生成一个 release 分支的 PR，用于审批此次发版的 DB 变更
+3. 在发版 CI 中，添加 DB 变更步骤，执行 DB 变更
+
+### 其他说明
+
+- 禁止 push：停止用 drizzle-kit push（本地开发环境除外）
+- 禁止启动时迁移：从 apps/api/src/index.ts 移除 await migrate()，迁移改成独立 CI 步骤（测试环境、生产环境）
+
+## 整体流程（阶段二：Atlas 方案）
+
+### 本地开发阶段
+
+1. 使用 TS schema (apps/api/src/db/schema/index.ts) 定义目标结构，作为 SSoT
+2. 使用 `atlas migrate diff` 生成 migration sql，放在 apps/api/migrations/ 目录下
+3. （可选）对于复杂场景，编辑 migration sql 文件，添加自定义数据迁移逻辑
+4. （可选）本地测试 migration sql
+
+### PR 阶段
+
+1. CI 检查 TS schema 和 migration sql 是否一致
+  - 运行 `atlas migrate diff --check`
+2. CI 检查 migration sql 中的问题
+  - 运行 `atlas migrate lint`，检查：锁表风险、命名规范、数据一致性
+3. Code Review: 有 DB 变更（修改了 apps/api/migrations/ 目录）的 PR，需要 infra 对应的 owner 审批通过。
+
+### 测试环境 DB 变更
+
+1. PR 合并后，CI 自动执行 migration sql，更新测试环境数据库
+  - 运行 `atlas migrate apply`
+
+### 生产环境 DB 变更
+
+1. 发版时拉出 release 分支
+2. 生成一个 release 分支的 PR，用于审批此次发版的 DB 变更
+3. 在发版 CI 中，添加 DB 变更步骤，执行 DB 变更
+  - 运行 `atlas migrate apply`
+
+### 日常巡检
+
+1. 定期巡检线上库与分支的差异，发现问题发送告警
+
+## Notes
+
+- 建议补充 DML 变更流程：使用独立的「DML 变更执行 PR」模板，至少包含影响范围、执行 SQL、预期结果、回滚/补偿方案、审批人。
+- 建议明确生产变更执行策略：谁可触发、在哪个 GitHub Environment 执行、需要几级审批、失败后是否自动中止后续发布步骤。
+- 建议明确回滚策略：约定是 forward-only（追加修复 migration）还是必须提供 down SQL，并给出对应的适用场景与操作规范。

--- a/docs/references/api-patterns.md
+++ b/docs/references/api-patterns.md
@@ -293,7 +293,7 @@ export const usageMetrics = pgTable("usage_metrics", {
 - `pk` (bigint, auto-increment) 为内部主键，`id` (cuid2 text) 为公开 ID
 - 列名: `snake_case`，Drizzle 字段: `camelCase`
 - Schema 集中在 `db/schema/index.ts`
-- 用 `drizzle-kit push` 推 schema，不用手写 migration
+- 用 `drizzle-kit generate` 生成 migration SQL 并提交 `apps/api/migrations/`（复杂场景可在生成后受控编辑）
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,13 @@
     "test": "pnpm -r test",
     "generate-types": "pnpm --filter @nexu/api generate-openapi && pnpm --filter @nexu/web generate-sdk",
     "seed": "pnpm --filter @nexu/api db:seed",
+    "db:generate": "pnpm --filter @nexu/api db:generate",
+    "db:migrate": "pnpm --filter @nexu/api db:migrate",
+    "db:check-sync": "pnpm --filter @nexu/api db:check-sync",
+    "db:check-sync:missing": "pnpm --filter @nexu/api db:check-sync:missing",
+    "db:check-sync:mismatch": "pnpm --filter @nexu/api db:check-sync:mismatch",
+    "db:check-dangerous": "pnpm --filter @nexu/api db:check-dangerous",
+    "db:check-dangerous-sql": "pnpm --filter @nexu/api db:check-dangerous-sql",
     "db:push": "pnpm --filter @nexu/api db:push"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

This PR adds migration safety gates to CI so schema and migration artifacts stay in sync and unsafe SQL is blocked before merge.

## Changes

- Added CI steps to run migration sync checks (missing/mismatch modes) and dangerous SQL checks.
- Added automated PR comment reporting with clear pass/fail status and actionable details when migration checks fail.
- Added `check-migration-sync.ts` and `check-migration-dangerous.ts` scripts plus workspace/API package scripts to run them.
- Updated Drizzle config to output into `apps/api/migrations` and committed generated migration SQL and metadata snapshot files.
- Updated contributor docs with the DB schema change workflow and related migration commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added database migration commands for generation, migration, and safety checks.
  * CI now runs automated migration verification and posts results to PRs; failing checks block merges.
  * Introduced the initial production-ready database schema and indexes.

* **Documentation**
  * Added comprehensive DB schema change workflow and migration guidelines.
  * Updated API patterns guidance to recommend generated migration workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->