### PR TITLE
test(db-migration-ci): fail case schema/migration mismatch

### DIFF
--- a/apps/api/migrations/0001_manual_mismatch_demo.sql
+++ b/apps/api/migrations/0001_manual_mismatch_demo.sql
@@ -1,0 +1,3 @@
+-- Intentional mismatch demo for CI testing.
+-- This file does not match the actual schema change in src/db/schema/index.ts.
+ALTER TABLE "users" ADD COLUMN "mismatch_demo" text;

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -303,6 +303,7 @@ export const sessions = pgTable(
     messageCount: integer("message_count").default(0),
     lastMessageAt: text("last_message_at"),
     metadata: text("metadata"),
+    debugTag: text("debug_tag"),
     createdAt: text("created_at")
       .notNull()
       .$defaultFn(() => new Date().toISOString()),


### PR DESCRIPTION
## Summary
- Change schema (`sessions.debug_tag`) and add a hand-written migration that does not match generated output.
- This PR is the **schema/migration mismatch** failure case.

## Expected CI result
- Verify DB migration sync (missing migration files): ✅ Pass
- Verify DB migration sync (schema/migration mismatch): ❌ Fail
- Check dangerous migration SQL: ✅ Pass