### PR TITLE
fix: only trigger deploy preview for cursor agent PRs

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   deploy-api-preview:
-    if: github.event.action != 'closed'
+    if: github.event.action != 'closed' && startsWith(github.head_ref, 'cursor/')
     runs-on: ubuntu-latest
     outputs:
       api_url: ${{ steps.deploy.outputs.url }}
@@ -59,7 +59,7 @@ jobs:
           echo "url=https://${APP}.fly.dev" >> "$GITHUB_OUTPUT"
 
   deploy-preview:
-    if: always() && github.event.action != 'closed'
+    if: always() && github.event.action != 'closed' && startsWith(github.head_ref, 'cursor/')
     needs: [deploy-api-preview]
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Filter `deploy-api-preview` and `deploy-preview` jobs to only run when PR branch starts with `cursor/`
- Human-created PRs (e.g. `db-dev-pr`) will skip preview deployment, saving CI resources
- Cleanup job remains unchanged — still runs for all closed PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)