### PR TITLE
fix: use flyctl instead of fly in deploy-preview workflow

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -80,15 +80,15 @@ jobs:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: |
           APP="${{ steps.slug.outputs.app_name }}"
-          fly apps create "$APP" --org personal 2>/dev/null || true
-          fly secrets set \
+          flyctl apps create "$APP" --org personal 2>/dev/null || true
+          flyctl secrets set \
             DATABASE_URL="${{ secrets.DATABASE_URL }}" \
             BETTER_AUTH_SECRET="${{ secrets.BETTER_AUTH_SECRET }}" \
             BETTER_AUTH_URL="https://${APP}.fly.dev" \
             WEB_URL="https://${{ steps.slug.outputs.app_name }}.preview.nexu.io" \
             RESEND_API_KEY="${{ secrets.RESEND_API_KEY }}" \
             --app "$APP"
-          fly deploy --app "$APP" --config apps/api/fly.toml --wait-timeout 120
+          flyctl deploy --app "$APP" --config apps/api/fly.toml --wait-timeout 120
           echo "url=https://${APP}.fly.dev" >> "$GITHUB_OUTPUT"
 
   deploy-preview:


### PR DESCRIPTION
## Summary
- The `superfly/flyctl-actions/setup-flyctl` action installs the binary as `flyctl`, not `fly`
- This caused `deploy-api-preview` job to fail with `fly: command not found` (exit code 127)
- Changed 3 occurrences of `fly` → `flyctl` in the Deploy API to Fly.io step

## Test plan
- [ ] Trigger `/preview` on any open PR and verify `deploy-api-preview` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment infrastructure tooling to enhance CI/CD pipeline reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->