### PR TITLE
fix: resolve Dockerfile path duplication in deploy-api-preview

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -88,7 +88,8 @@ jobs:
             WEB_URL="https://${{ steps.slug.outputs.app_name }}.preview.nexu.io" \
             RESEND_API_KEY="${{ secrets.RESEND_API_KEY }}" \
             --app "$APP"
-          flyctl deploy --app "$APP" --config apps/api/fly.toml --wait-timeout 120
+          cd apps/api
+          flyctl deploy --app "$APP" --wait-timeout 120
           echo "url=https://${APP}.fly.dev" >> "$GITHUB_OUTPUT"
 
   deploy-preview:


### PR DESCRIPTION
## Summary
- `flyctl deploy --config apps/api/fly.toml` resolves `dockerfile` in `fly.toml` relative to the config file location
- This caused path duplication: `apps/api/apps/api/Dockerfile.fly` → file not found
- Fix: `cd apps/api` first, then run `flyctl deploy` without `--config` so it finds `fly.toml` in cwd

## Context
Previous fix (PR #91) resolved `fly` → `flyctl` command name. This addresses the next failure in the same job.

## Test plan
- [ ] Merge and trigger `/preview` on any open PR, verify `deploy-api-preview` passes the build step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated preview deployment workflow configuration to streamline how deployment settings are resolved during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->