### PR TITLE
fix: use explicit --dockerfile to resolve Dockerfile path duplication

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -88,8 +88,7 @@ jobs:
             WEB_URL="https://${{ steps.slug.outputs.app_name }}.preview.nexu.io" \
             RESEND_API_KEY="${{ secrets.RESEND_API_KEY }}" \
             --app "$APP"
-          cd apps/api
-          flyctl deploy --app "$APP" --wait-timeout 120
+          flyctl deploy --app "$APP" --dockerfile apps/api/Dockerfile.fly --config apps/api/fly.toml --wait-timeout 120
           echo "url=https://${APP}.fly.dev" >> "$GITHUB_OUTPUT"
 
   deploy-preview:


### PR DESCRIPTION
## Summary
- flyctl resolves `dockerfile` in fly.toml **relative to the config file directory**, not the working directory
- Previous fix (#92) used `cd apps/api` which still caused `apps/api/apps/api/Dockerfile.fly`
- This fix uses `--dockerfile apps/api/Dockerfile.fly` explicitly from repo root, overriding the fly.toml setting
- Build context stays at repo root, which is required by the Dockerfile's COPY paths (`COPY apps/api/ ...`)

## Changes
```diff
- cd apps/api
- flyctl deploy --app "$APP" --wait-timeout 120
+ flyctl deploy --app "$APP" --dockerfile apps/api/Dockerfile.fly --config apps/api/fly.toml --wait-timeout 120
```

## Test plan
- [ ] Merge and trigger `/preview` on PR #90, verify `deploy-api-preview` builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized deployment configuration for improved reliability and consistency in the preview environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->