### PR TITLE
fix: correct Dockerfile path in fly.toml to be relative to config dir

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -88,7 +88,7 @@ jobs:
             WEB_URL="https://${{ steps.slug.outputs.app_name }}.preview.nexu.io" \
             RESEND_API_KEY="${{ secrets.RESEND_API_KEY }}" \
             --app "$APP"
-          flyctl deploy --app "$APP" --dockerfile apps/api/Dockerfile.fly --config apps/api/fly.toml --wait-timeout 120
+          flyctl deploy --app "$APP" --config apps/api/fly.toml --wait-timeout 120
           echo "url=https://${APP}.fly.dev" >> "$GITHUB_OUTPUT"
 
   deploy-preview:

--- a/apps/api/fly.toml
+++ b/apps/api/fly.toml
@@ -2,7 +2,7 @@ app = "nexu-api"
 primary_region = "sin"
 
 [build]
-  dockerfile = "apps/api/Dockerfile.fly"
+  dockerfile = "Dockerfile.fly"
   [build.args]
     COMMIT_HASH = ""
 


### PR DESCRIPTION
## Root Cause

flyctl **always** resolves `dockerfile` in fly.toml relative to the **config file's directory**, not the working directory. Previous attempts (`--dockerfile`, `cd apps/api`) failed because:

- `--dockerfile` does not override fly.toml's `[build].dockerfile`
- `cd apps/api` changes cwd but fly.toml still has `apps/api/Dockerfile.fly`, resolved as `apps/api/` + `apps/api/Dockerfile.fly`

## Fix

| File | Before | After |
|------|--------|-------|
| `apps/api/fly.toml` | `dockerfile = "apps/api/Dockerfile.fly"` | `dockerfile = "Dockerfile.fly"` |
| `deploy-preview.yml` | `--dockerfile apps/api/Dockerfile.fly --config apps/api/fly.toml` | `--config apps/api/fly.toml` |

Resolution: `{fly.toml dir}/` + `Dockerfile.fly` = `apps/api/Dockerfile.fly` ✅

## Test plan
- [ ] Merge → `/preview` on PR #90 → `deploy-api-preview` passes build step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal deployment configuration for improved build process efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->