### PR TITLE
fix: normalize fly.toml dockerfile path before deploy

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -88,6 +88,8 @@ jobs:
             WEB_URL="https://${{ steps.slug.outputs.app_name }}.preview.nexu.io" \
             RESEND_API_KEY="${{ secrets.RESEND_API_KEY }}" \
             --app "$APP"
+          # flyctl resolves dockerfile relative to fly.toml dir; normalize for old branches
+          sed -i 's|dockerfile = "apps/api/Dockerfile.fly"|dockerfile = "Dockerfile.fly"|' apps/api/fly.toml
           flyctl deploy --app "$APP" --config apps/api/fly.toml --wait-timeout 120
           echo "url=https://${APP}.fly.dev" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Problem
Workflow YAML runs from main, but `apps/api/fly.toml` is checked out from the PR branch. Old PR branches still have `dockerfile = "apps/api/Dockerfile.fly"`, which flyctl resolves as `apps/api/` + `apps/api/Dockerfile.fly` = doubled path.

Previous fixes (PRs #91-#94) fixed fly.toml on main, but that doesn't help old PR branches since the checkout uses the PR's head SHA.

## Fix
`sed -i` the fly.toml at deploy time to normalize the path, before flyctl reads it. Works for both old branches (has wrong path → sed fixes it) and new branches (already correct → sed is a no-op).

## Test plan
- [ ] Merge → `/preview` on PR #90 (old branch) → `deploy-api-preview` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deployment configuration path resolution to improve compatibility with legacy branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->