### PR TITLE
fix: support Slack apps installed across multiple workspaces

### DIFF
--- a/apps/api/src/lib/config-generator.ts
+++ b/apps/api/src/lib/config-generator.ts
@@ -169,6 +169,13 @@ export async function generatePoolConfig(
         // Provide a placeholder so the account passes the configured check.
         appToken: "xapp-placeholder-not-used-in-http-mode",
         streaming: "partial",
+        // Explicit per-account policies so `openclaw doctor --fix` cannot
+        // break routing by moving top-level defaults into accounts.default.
+        groupPolicy: "open",
+        dmPolicy: "open",
+        allowFrom: ["*"],
+        requireMention: true,
+        ackReaction: "eyes",
       };
 
       bindingsList.push({

--- a/apps/api/src/routes/channel-routes.ts
+++ b/apps/api/src/routes/channel-routes.ts
@@ -437,7 +437,8 @@ export function registerChannelRoutes(app: OpenAPIHono<AppBindings>) {
     const bot = await channelSpanHandler.resolveDefaultBot(userId);
     const botId = bot.id;
 
-    const accountId = `slack-${appId}`;
+    const accountId = `slack-${appId}-${teamId}`;
+    const oldAccountId = `slack-${appId}`;
     const slackExternalId = `${teamId}:${appId}`;
 
     // Check if this Slack app is already connected (by externalId)
@@ -470,7 +471,7 @@ export function registerChannelRoutes(app: OpenAPIHono<AppBindings>) {
       );
 
     const existingChannel = existingChannels.find(
-      (ch) => ch.accountId === accountId,
+      (ch) => ch.accountId === accountId || ch.accountId === oldAccountId,
     );
 
     if (existingChannel || globalExisting) {
@@ -544,19 +545,6 @@ export function registerChannelRoutes(app: OpenAPIHono<AppBindings>) {
           updatedAt: now,
           createdAt: now,
         });
-      }
-
-      // Clean up other stale Slack channels for the same bot (wrong accountId from bot_id era)
-      for (const stale of existingChannels) {
-        if (stale.id !== channelId) {
-          await db
-            .delete(webhookRoutes)
-            .where(eq(webhookRoutes.botChannelId, stale.id));
-          await db
-            .delete(channelCredentials)
-            .where(eq(channelCredentials.botChannelId, stale.id));
-          await db.delete(botChannels).where(eq(botChannels.id, stale.id));
-        }
       }
     } else {
       // New connection
@@ -952,7 +940,8 @@ export function registerSlackOAuthCallback(app: OpenAPIHono<AppBindings>) {
     }
 
     const appId = tokenResponse.app_id;
-    const accountId = `slack-${appId}`;
+    const accountId = `slack-${appId}-${teamId}`;
+    const oldAccountId = `slack-${appId}`;
     const slackExternalId = `${teamId}:${appId}`;
 
     // --- 5. Find or create the user's default bot ---
@@ -960,16 +949,15 @@ export function registerSlackOAuthCallback(app: OpenAPIHono<AppBindings>) {
     const botId = bot.id;
 
     // --- 6. Create or update the channel connection ---
-    const [existing] = await db
+    const existingSlackChannels = await db
       .select()
       .from(botChannels)
       .where(
-        and(
-          eq(botChannels.botId, botId),
-          eq(botChannels.channelType, "slack"),
-          eq(botChannels.accountId, accountId),
-        ),
+        and(eq(botChannels.botId, botId), eq(botChannels.channelType, "slack")),
       );
+    const existing = existingSlackChannels.find(
+      (ch) => ch.accountId === accountId || ch.accountId === oldAccountId,
+    );
 
     const now = new Date().toISOString();
     let channelId: string;
@@ -982,6 +970,7 @@ export function registerSlackOAuthCallback(app: OpenAPIHono<AppBindings>) {
         .update(botChannels)
         .set({
           status: "connected",
+          accountId,
           channelConfig: JSON.stringify({ teamId, teamName, appId }),
           updatedAt: now,
         })
@@ -1018,7 +1007,12 @@ export function registerSlackOAuthCallback(app: OpenAPIHono<AppBindings>) {
             botId,
             updatedAt: now,
           })
-          .where(eq(webhookRoutes.botChannelId, channelId));
+          .where(
+            and(
+              eq(webhookRoutes.channelType, "slack"),
+              eq(webhookRoutes.externalId, slackExternalId),
+            ),
+          );
       }
     } else {
       // New connection — check global uniqueness first

--- a/apps/api/src/routes/slack-events.ts
+++ b/apps/api/src/routes/slack-events.ts
@@ -224,7 +224,9 @@ class SlackEventsTraceHandler {
         .from(botChannels)
         .where(eq(botChannels.id, route.botChannelId));
 
-      const accountId = channel?.accountId ?? `slack-${teamId}`;
+      const accountId = channel?.accountId ?? `slack-${apiAppId}-${teamId}`;
+
+      // Upsert session for message events (fire-and-forget)
       const event = payload.event as Record<string, unknown> | undefined;
       const isMessageEvent =
         event?.type === "message" || event?.type === "app_mention";


### PR DESCRIPTION
## Summary
  - Make Slack `accountId` team-scoped (`slack-{appId}-{teamId}`) instead of app-scoped (`slack-{appId}`), so each workspace gets its own
   bot_channels entry, credentials, and OpenClaw account
  - Add per-account Slack policies (groupPolicy, dmPolicy) in config generator to prevent `openclaw doctor --fix` from breaking routing
  - Remove stale channel cleanup that assumed one Slack connection per bot

  ## Problem
  When a Slack app is installed in multiple workspaces, all workspaces shared a single `bot_channels` entry. OpenClaw's
  `shouldDropMismatchedSlackEvent` compares incoming `team_id` against `auth.test()` result, silently dropping events from non-primary
  workspaces.

  ## Migration
  Existing connections continue to work. On reconnect (OAuth or manual), old-format `accountId` entries are automatically migrated to the
   new team-scoped format. Each workspace needs to be re-authorized once to obtain its own bot token.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Slack account policies for group messaging, direct messaging, sender restrictions, mention requirements, and acknowledgment reactions.

* **Improvements**
  * Enhanced multi-team Slack workspace support with improved account identification and routing.
  * Improved webhook routing and channel reconnection handling with backward compatibility maintained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->