### PR TITLE
Unify agent workspace path with OpenClaw agents directory

### DIFF
--- a/apps/api/src/lib/config-generator.ts
+++ b/apps/api/src/lib/config-generator.ts
@@ -126,7 +126,7 @@ export async function generatePoolConfig(
     const agent: AgentConfig = {
       id: bot.id,
       name: bot.name,
-      workspace: `${stateDir}/workspaces/${bot.id}`,
+      workspace: `${stateDir}/agents/${bot.id}`,
     };
 
     if (index === 0) {


### PR DESCRIPTION
## Summary                                                                                                                    
  - Change agent workspace path from `{stateDir}/workspaces/{botId}` to `{stateDir}/agents/{botId}`                             
  - Aligns workspace files (SOUL.md, memory/, etc.) with OpenClaw's internal agent data (sessions/, agent/)                     
  - Previously workspace files and session data were split across two directories, causing memory indexer to miss session files 

  ## Changes
  - `apps/api/src/lib/config-generator.ts` — update workspace path from `workspaces/` to `agents/`