### PR TITLE
fix: set BETTER_AUTH_URL to frontend preview domain

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,1 +1,323 @@
+name: Deploy Preview
 
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [closed]
+
+concurrency:
+  group: preview-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  NODE_VERSION: "22"
+  PNPM_VERSION: "10.26.0"
+  PREVIEW_DOMAIN_SUFFIX: "preview.nexu.io"
+
+jobs:
+  resolve-pr:
+    if: >-
+      github.event_name == 'issue_comment'
+      && github.event.issue.pull_request
+      && contains(github.event.comment.body, '/preview')
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.pr.outputs.pr_number }}
+      head_ref: ${{ steps.pr.outputs.head_ref }}
+      head_sha: ${{ steps.pr.outputs.head_sha }}
+    steps:
+      - name: Add rocket reaction
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket',
+            });
+
+      - name: Resolve PR details
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_JSON=$(gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json headRefName,headRefOid)
+          HEAD_REF=$(echo "$PR_JSON" | jq -r '.headRefName')
+          HEAD_SHA=$(echo "$PR_JSON" | jq -r '.headRefOid')
+          echo "pr_number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+          echo "head_ref=$HEAD_REF" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+
+  deploy-api-preview:
+    needs: [resolve-pr]
+    runs-on: ubuntu-latest
+    outputs:
+      api_url: ${{ steps.deploy.outputs.url }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-pr.outputs.head_sha }}
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Generate app name
+        id: slug
+        run: |
+          BRANCH="${{ needs.resolve-pr.outputs.head_ref }}"
+          SLUG=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]' | sed 's/[\/\_]/-/g' | sed 's/[^a-z0-9-]//g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
+          SLUG="${SLUG:0:36}"
+          echo "app_name=nexu-api-preview-${SLUG}" >> "$GITHUB_OUTPUT"
+          echo "branch_slug=${SLUG}" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy API to Fly.io
+        id: deploy
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          APP="${{ steps.slug.outputs.app_name }}"
+          flyctl apps create "$APP" --org personal 2>/dev/null || true
+          flyctl secrets set \
+            DATABASE_URL="${{ secrets.DATABASE_URL }}" \
+            BETTER_AUTH_SECRET="${{ secrets.BETTER_AUTH_SECRET }}" \
+            BETTER_AUTH_URL="https://${{ steps.slug.outputs.branch_slug }}.${{ env.PREVIEW_DOMAIN_SUFFIX }}" \
+            WEB_URL="https://${{ steps.slug.outputs.app_name }}.preview.nexu.io" \
+            RESEND_API_KEY="${{ secrets.RESEND_API_KEY }}" \
+            --app "$APP"
+          # flyctl resolves dockerfile relative to fly.toml dir; normalize for old branches
+          sed -i 's|dockerfile = "apps/api/Dockerfile.fly"|dockerfile = "Dockerfile.fly"|' apps/api/fly.toml
+          flyctl deploy --app "$APP" --config apps/api/fly.toml --wait-timeout 120
+          echo "url=https://${APP}.fly.dev" >> "$GITHUB_OUTPUT"
+
+  deploy-preview:
+    needs: [resolve-pr, deploy-api-preview]
+    if: always() && needs.resolve-pr.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-pr.outputs.head_sha }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate branch slug
+        id: slug
+        run: |
+          BRANCH="${{ needs.resolve-pr.outputs.head_ref }}"
+          # Slugify: lowercase, replace / and _ with -, remove non-alphanumeric except -, trim dashes
+          SLUG=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]' | sed 's/[\/\_]/-/g' | sed 's/[^a-z0-9-]//g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
+          # Worker name = "nexu-app-preview-" (18 chars) + SLUG; CF limits previews to 54 chars total
+          SLUG="${SLUG:0:36}"
+          echo "branch_slug=$SLUG" >> "$GITHUB_OUTPUT"
+          echo "worker_name=nexu-app-preview-${SLUG}" >> "$GITHUB_OUTPUT"
+          echo "preview_hostname=${SLUG}.${{ env.PREVIEW_DOMAIN_SUFFIX }}" >> "$GITHUB_OUTPUT"
+
+      - name: Build web app
+        run: pnpm --filter @nexu/web build
+        env:
+          VITE_PREVIEW: "true"
+          VITE_COMMIT_HASH: ${{ needs.resolve-pr.outputs.head_sha }}
+          VITE_AUTH_BASE_URL: ""
+          VITE_WHATSAPP_WA_ME_URL: ${{ vars.VITE_WHATSAPP_WA_ME_URL }}
+          VITE_AMPLITUDE_API_KEY: ${{ secrets.AMPLITUDE_API_KEY }}
+
+      - name: Inject API proxy worker
+        env:
+          API_ORIGIN: ${{ needs.deploy-api-preview.outputs.api_url || 'https://api.nexu.io' }}
+        run: |
+          cat > apps/web/src/_worker.ts << 'EOF'
+          interface Env { ASSETS: Fetcher; API_ORIGIN: string; }
+          export default {
+            async fetch(request: Request, env: Env): Promise<Response> {
+              const url = new URL(request.url);
+              if (url.pathname.startsWith("/api/")) {
+                const origin = new URL(env.API_ORIGIN);
+                const target = new URL(url.pathname + url.search, origin);
+                const headers = new Headers(request.headers);
+                headers.set("Host", origin.host);
+                headers.set("Origin", origin.origin);
+                headers.set("Referer", origin.origin + "/");
+                return fetch(target, { method: request.method, headers, body: request.body });
+              }
+              return env.ASSETS.fetch(request);
+            },
+          } satisfies ExportedHandler<Env>;
+          EOF
+
+          cat > apps/web/wrangler.preview.jsonc << EOF
+          {
+            "name": "nexu-app-preview",
+            "compatibility_date": "2025-01-01",
+            "main": "src/_worker.ts",
+            "assets": {
+              "directory": "./dist",
+              "not_found_handling": "single-page-application",
+              "binding": "ASSETS"
+            },
+            "vars": { "API_ORIGIN": "${API_ORIGIN}" }
+          }
+          EOF
+
+      - name: Deploy preview worker
+        uses: cloudflare/wrangler-action@v3
+        id: deploy
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: "4"
+          command: deploy --config wrangler.preview.jsonc --name ${{ steps.slug.outputs.worker_name }}
+          workingDirectory: apps/web
+
+      - name: Attach custom domain
+        env:
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          # Get zone ID for nexu.io
+          ZONE_ID=$(curl -sf -H "Authorization: Bearer $CF_API_TOKEN" \
+            "https://api.cloudflare.com/client/v4/zones?name=nexu.io" \
+            | jq -r '.result[0].id')
+          echo "Zone ID: $ZONE_ID"
+
+          # Ensure wildcard DNS record *.preview.nexu.io exists (required for Workers Custom Domains)
+          WILDCARD_EXISTS=$(curl -sf -H "Authorization: Bearer $CF_API_TOKEN" \
+            "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/dns_records?name=*.preview.nexu.io&type=AAAA" \
+            | jq -r '.result | length')
+          if [ "$WILDCARD_EXISTS" = "0" ]; then
+            echo "Creating wildcard DNS record *.preview.nexu.io"
+            curl -sf -X POST \
+              -H "Authorization: Bearer $CF_API_TOKEN" \
+              -H "Content-Type: application/json" \
+              "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/dns_records" \
+              -d '{"type":"AAAA","name":"*.preview","content":"100::","proxied":true}' | jq .
+          else
+            echo "Wildcard DNS record *.preview.nexu.io already exists"
+          fi
+
+          # Attach custom domain to the worker
+          curl -sf -X PUT \
+            -H "Authorization: Bearer $CF_API_TOKEN" \
+            -H "Content-Type: application/json" \
+            "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/workers/domains" \
+            -d "{
+              \"hostname\": \"${{ steps.slug.outputs.preview_hostname }}\",
+              \"service\": \"${{ steps.slug.outputs.worker_name }}\",
+              \"zone_id\": \"$ZONE_ID\",
+              \"environment\": \"production\"
+            }" | jq .
+        continue-on-error: true
+
+      - name: Comment preview URL on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const hostname = '${{ steps.slug.outputs.preview_hostname }}';
+            const previewUrl = `https://${hostname}`;
+            const apiUrl = '${{ needs.deploy-api-preview.outputs.api_url }}' || 'https://api.nexu.io';
+            const body = `## Preview Deployment
+
+            | App | URL |
+            |-----|-----|
+            | Web | [${previewUrl}](${previewUrl}) |
+            | API | [${apiUrl}](${apiUrl}) |
+
+            Deployed from commit: \`${{ needs.resolve-pr.outputs.head_sha }}\``;
+
+            const prNumber = ${{ needs.resolve-pr.outputs.pr_number }};
+
+            // Find existing comment
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const botComment = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('## Preview Deployment')
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }
+
+  cleanup-preview:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate branch slug
+        id: slug
+        run: |
+          BRANCH="${{ github.head_ref }}"
+          SLUG=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]' | sed 's/[\/\_]/-/g' | sed 's/[^a-z0-9-]//g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
+          SLUG="${SLUG:0:36}"
+          echo "branch_slug=$SLUG" >> "$GITHUB_OUTPUT"
+          echo "worker_name=nexu-app-preview-${SLUG}" >> "$GITHUB_OUTPUT"
+          echo "preview_hostname=${SLUG}.${{ env.PREVIEW_DOMAIN_SUFFIX }}" >> "$GITHUB_OUTPUT"
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+        continue-on-error: true
+
+      - name: Delete API preview
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          APP="nexu-api-preview-${{ steps.slug.outputs.branch_slug }}"
+          flyctl apps destroy "$APP" --yes 2>/dev/null || true
+        continue-on-error: true
+
+      - name: Remove custom domain
+        env:
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          # Find and delete the custom domain
+          DOMAIN_ID=$(curl -sf -H "Authorization: Bearer $CF_API_TOKEN" \
+            "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/workers/domains?hostname=${{ steps.slug.outputs.preview_hostname }}" \
+            | jq -r '.result[0].id // empty')
+          if [ -n "$DOMAIN_ID" ]; then
+            curl -sf -X DELETE \
+              -H "Authorization: Bearer $CF_API_TOKEN" \
+              "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/workers/domains/$DOMAIN_ID"
+            echo "Removed custom domain: ${{ steps.slug.outputs.preview_hostname }}"
+          else
+            echo "No custom domain found to remove"
+          fi
+        continue-on-error: true
+
+      - name: Delete preview worker
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: "4"
+          command: delete --name ${{ steps.slug.outputs.worker_name }} --force
+        continue-on-error: true


### PR DESCRIPTION
## Summary
- `BETTER_AUTH_URL` was set to the Fly.io API URL (`nexu-api-preview-xxx.fly.dev`), but auth requests come from the frontend domain (`xxx.preview.nexu.io`)
- This caused Better Auth to issue cookies for the wrong origin, breaking login/session in preview deployments
- Fix: set `BETTER_AUTH_URL` to `https://{slug}.preview.nexu.io` (the frontend domain)
- Also adds `branch_slug` output to the deploy-api-preview job for reuse

## Test plan
- [ ] Merge and trigger `/preview` on PR #90
- [ ] Verify login works at `https://cursor-bc-9923e051-2584-48b5-96eb-7a.preview.nexu.io/auth?mode=login`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the preview deployment workflow to expose a branch identifier for previews.
  * Adjusted the preview deployment to derive the auth URL from that branch identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->