### PR TITLE
fix(gateway): emit correct log levels for Datadog severity mapping

### DIFF
--- a/apps/gateway/src/log.ts
+++ b/apps/gateway/src/log.ts
@@ -10,6 +10,9 @@ const version =
 
 export const logger = pino({
   level: process.env.LOG_LEVEL ?? (env === "production" ? "info" : "debug"),
+  formatters: {
+    level: (label) => ({ level: label }),
+  },
   base: {
     service: "nexu-gateway",
     env,

--- a/apps/gateway/src/metrics.ts
+++ b/apps/gateway/src/metrics.ts
@@ -24,17 +24,20 @@ async function getClient(): Promise<DogStatsDClient | null> {
   }
 }
 
+type LogLevel = "info" | "warn" | "error";
+
 function emitMetric(
   name: string,
   tags: string[],
   logPayload: Record<string, unknown>,
+  level: LogLevel = "info",
 ): void {
   void getClient().then((c) => {
     if (c) {
       c.increment(name, 1, tags);
     }
   });
-  logger.info(logPayload, name);
+  logger[level](logPayload, name);
 }
 
 export function reportOpenclawCrash(context: {
@@ -52,6 +55,7 @@ export function reportOpenclawCrash(context: {
       exitCode: context.exitCode,
       signal: context.signal,
     },
+    "error",
   );
 }
 
@@ -67,6 +71,7 @@ export function reportOpenclawRestart(context: {
       attempt: context.attempt,
       success: context.success,
     },
+    "warn",
   );
 }
 
@@ -78,13 +83,19 @@ export function reportOpenclawRestartLimitExceeded(attempts: number): void {
       event: "openclaw_restart_limit_exceeded",
       attempts,
     },
+    "error",
   );
 }
 
 export function reportOpenclawKillForRestart(): void {
-  emitMetric("gateway.openclaw.kill_for_restart", [], {
-    event: "openclaw_kill_for_restart",
-  });
+  emitMetric(
+    "gateway.openclaw.kill_for_restart",
+    [],
+    {
+      event: "openclaw_kill_for_restart",
+    },
+    "warn",
+  );
 }
 
 export function reportProbeFailure(context: {
@@ -103,6 +114,7 @@ export function reportProbeFailure(context: {
       latencyMs: context.latencyMs,
       exitCode: context.exitCode,
     },
+    "warn",
   );
 }
 
@@ -137,8 +149,13 @@ export function reportStateTransition(context: {
 export function reportHeartbeatFailure(context: {
   errorCode: string;
 }): void {
-  emitMetric("gateway.heartbeat.failure", [`error_code:${context.errorCode}`], {
-    event: "gateway_heartbeat_failure",
-    errorCode: context.errorCode,
-  });
+  emitMetric(
+    "gateway.heartbeat.failure",
+    [`error_code:${context.errorCode}`],
+    {
+      event: "gateway_heartbeat_failure",
+      errorCode: context.errorCode,
+    },
+    "warn",
+  );
 }


### PR DESCRIPTION
## Summary                                                                                                                    
                                                                                                                                
  - Add Pino `formatters.level` so JSON output uses `"level": "warn"` instead of `"level": 40`, which Datadog was               
  misinterpreting as info
  - Add severity parameter to `emitMetric` — crash and restart-limit-exceeded emit at `error`, probe/heartbeat failures and
  restarts emit at `warn`, success/transition metrics stay at `info`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced log level formatting in the gateway logger configuration.
  * Improved severity categorization for metric logging: critical events (crashes, restart limits) now log as errors, operational events (restarts, probe/heartbeat failures) log as warnings, and standard metrics default to info level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->