### PR TITLE
fix: correct WEB_URL for preview deploy (fixes INVALID_ORIGIN)

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -86,7 +86,7 @@ jobs:
             DATABASE_URL="${{ secrets.DATABASE_URL }}" \
             BETTER_AUTH_SECRET="${{ secrets.BETTER_AUTH_SECRET }}" \
             BETTER_AUTH_URL="https://${{ steps.slug.outputs.branch_slug }}.${{ env.PREVIEW_DOMAIN_SUFFIX }}" \
-            WEB_URL="https://${{ steps.slug.outputs.app_name }}.preview.nexu.io" \
+            WEB_URL="https://${{ steps.slug.outputs.branch_slug }}.${{ env.PREVIEW_DOMAIN_SUFFIX }}" \
             RESEND_API_KEY="${{ secrets.RESEND_API_KEY }}" \
             --app "$APP"
           # flyctl resolves dockerfile relative to fly.toml dir; normalize for old branches


### PR DESCRIPTION
## Summary
- `WEB_URL` was using `app_name` (e.g. `nexu-api-preview-xxx`) instead of `branch_slug` (e.g. `xxx`)
- This caused `WEB_URL` to resolve to `https://nexu-api-preview-xxx.preview.nexu.io` instead of `https://xxx.preview.nexu.io`
- Better Auth uses `WEB_URL` as `trustedOrigins`, so requests from the actual frontend domain were rejected with `INVALID_ORIGIN`
- Fix: use `branch_slug` + `PREVIEW_DOMAIN_SUFFIX` for `WEB_URL`, same pattern as `BETTER_AUTH_URL`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated preview deployment URL configuration to use branch slug for domain construction instead of app name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->