### PR TITLE
fix: preserve Origin header in preview worker proxy

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -153,8 +153,6 @@ jobs:
                 const target = new URL(url.pathname + url.search, origin);
                 const headers = new Headers(request.headers);
                 headers.set("Host", origin.host);
-                headers.set("Origin", origin.origin);
-                headers.set("Referer", origin.origin + "/");
                 return fetch(target, { method: request.method, headers, body: request.body });
               }
               return env.ASSETS.fetch(request);


### PR DESCRIPTION
## Summary
- The CF Worker proxy was overwriting `Origin` and `Referer` headers with the Fly.io API domain
- Better Auth checks `Origin` against `trustedOrigins` (which is the frontend domain)
- Worker sent `Origin: https://nexu-api-preview-xxx.fly.dev` but trustedOrigins expects `https://xxx.preview.nexu.io`
- Fix: remove `Origin` and `Referer` override — let the browser's original headers pass through

## Root cause chain
1. Browser sends `Origin: https://xxx.preview.nexu.io`
2. Worker overwrites to `Origin: https://nexu-api-preview-xxx.fly.dev`
3. Better Auth compares against `trustedOrigins: ["https://xxx.preview.nexu.io"]`
4. Mismatch → `INVALID_ORIGIN`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed API proxy request handling by adjusting header forwarding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->