### PR TITLE
feat(ci): trigger db migrate apply after merges to main

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -1,0 +1,185 @@
+name: DB Migrate (MVP)
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: db-migrate-mvp-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  migrate-apply:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect migration SQL and generate manifest
+        id: detect-migrations
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          BEFORE_SHA="${{ github.event.before }}"
+          HEAD_SHA="${{ github.sha }}"
+          DIFF_FROM="${BEFORE_SHA}"
+          DIFF_TO="${HEAD_SHA}"
+
+          if [[ "${BEFORE_SHA}" == "0000000000000000000000000000000000000000" ]]; then
+            DIFF_FROM="${HEAD_SHA}^"
+          fi
+
+          echo "Diff range: ${DIFF_FROM}...${DIFF_TO}"
+
+          mapfile -t changed_files < <(git diff --name-only "${DIFF_FROM}" "${DIFF_TO}" -- "apps/api/migrations" | sort -u)
+
+          sql_files=()
+          for file in "${changed_files[@]}"; do
+            if [[ "$file" == *.sql && -f "$file" ]]; then
+              sql_files+=("$file")
+            fi
+          done
+
+          if [[ ${#sql_files[@]} -eq 0 ]]; then
+            echo "No changed migration SQL files found in push range. Skip."
+            echo "has_migrations=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "## DB Migrate"
+              echo "- Result: skipped (no changed migration SQL files)"
+              echo "- Diff range: \`${DIFF_FROM}...${DIFF_TO}\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          printf '%s\n' "${sql_files[@]}" > "$RUNNER_TEMP/migration-files.txt"
+
+          manifest_path="$RUNNER_TEMP/nexu-db-migration-manifest.json"
+          MIGRATION_FILE_LIST="$RUNNER_TEMP/migration-files.txt" MANIFEST_PATH="$manifest_path" node <<'NODE'
+          const crypto = require("node:crypto");
+          const fs = require("node:fs");
+
+          const listPath = process.env.MIGRATION_FILE_LIST;
+          const manifestPath = process.env.MANIFEST_PATH;
+
+          if (!listPath || !manifestPath) {
+            throw new Error("Missing required environment variables for manifest generation.");
+          }
+
+          const files = fs
+            .readFileSync(listPath, "utf8")
+            .split("\n")
+            .map((entry) => entry.trim())
+            .filter((entry) => entry.length > 0)
+            .sort();
+
+          const manifest = {
+            repository: process.env.GITHUB_REPOSITORY,
+            ref: process.env.GITHUB_REF,
+            sha: process.env.GITHUB_SHA,
+            runId: process.env.GITHUB_RUN_ID,
+            eventName: process.env.GITHUB_EVENT_NAME,
+            generatedAt: new Date().toISOString(),
+            files: files.map((filePath) => {
+              const sql = fs.readFileSync(filePath, "utf8");
+              const sha256 = crypto.createHash("sha256").update(sql).digest("hex");
+              return {
+                path: filePath,
+                sha256,
+                sql,
+              };
+            }),
+          };
+
+          fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+          NODE
+
+          echo "Detected migration files:"
+          printf ' - %s\n' "${sql_files[@]}"
+
+          echo "Manifest path: ${manifest_path}"
+          echo "----- manifest.json begin -----"
+          cat "${manifest_path}"
+          echo "----- manifest.json end -----"
+
+          echo "has_migrations=true" >> "$GITHUB_OUTPUT"
+          echo "manifest_path=${manifest_path}" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## DB Migrate"
+            echo "- Result: migration files detected"
+            echo "- Diff range: \`${DIFF_FROM}...${DIFF_TO}\`"
+            echo "- Files: ${#sql_files[@]}"
+            echo ""
+            echo "### Migration Files"
+            for file in "${sql_files[@]}"; do
+              echo "- \`${file}\`"
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Apply DB migrations
+        if: steps.detect-migrations.outputs.has_migrations == 'true'
+        shell: bash
+        env:
+          MIGRATE_APPLY_URL: https://5jhbys8c46.execute-api.us-east-1.amazonaws.com/migrate/apply
+          MIGRATE_API_KEY: ${{ secrets.NEXU_DB_MIGRATE_API_KEY }}
+        run: |
+          set -euo pipefail
+
+          manifest_path="${{ steps.detect-migrations.outputs.manifest_path }}"
+          response_path="$RUNNER_TEMP/migrate-apply-response.json"
+
+          http_status="$(curl --silent --show-error --location \
+            --output "${response_path}" \
+            --write-out "%{http_code}" \
+            -X POST "${MIGRATE_APPLY_URL}" \
+            -H "content-type: application/json" \
+            -H "x-api-key: ${MIGRATE_API_KEY}" \
+            --data "@${manifest_path}")"
+
+          pretty_response_path="$RUNNER_TEMP/migrate-apply-response-pretty.json"
+          node - "${response_path}" <<'NODE' > "${pretty_response_path}"
+          const fs = require("node:fs");
+
+          const responsePath = process.argv[2];
+          const raw = fs.readFileSync(responsePath, "utf8");
+
+          try {
+            process.stdout.write(`${JSON.stringify(JSON.parse(raw), null, 2)}\n`);
+          } catch {
+            process.stdout.write(raw.endsWith("\n") ? raw : `${raw}\n`);
+          }
+          NODE
+
+          echo "Migrate apply HTTP status: ${http_status}"
+          echo "Migrate apply response body:"
+          cat "${pretty_response_path}"
+
+          apply_result="success"
+          if [[ ! "${http_status}" =~ ^2 ]]; then
+            apply_result="failed"
+          fi
+
+          {
+            echo "### Migrate Apply"
+            echo "- URL: \`${MIGRATE_APPLY_URL}\`"
+            echo "- HTTP status: \`${http_status}\`"
+            echo "- Result: ${apply_result}"
+            echo ""
+            echo "<details><summary>Response body</summary>"
+            echo ""
+            echo "\`\`\`json"
+            cat "${pretty_response_path}"
+            echo "\`\`\`"
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [[ ! "${http_status}" =~ ^2 ]]; then
+            echo "Migrate apply failed with HTTP status ${http_status}."
+            exit 1
+          fi

--- a/docs/agent-native/db-migrate-workflow-mvp.md
+++ b/docs/agent-native/db-migrate-workflow-mvp.md
@@ -1,0 +1,68 @@
+# DB Migrate Workflow MVP（Apply API）
+
+## 目标
+
+- 在 CI 中自动识别变更 migration SQL，并生成 manifest。
+- 在存在 migration 文件时，真实调用 migrate apply API 执行迁移。
+- 在无 migration 文件时安全跳过，不阻塞流水线。
+
+## 当前实现
+
+- Workflow 文件：`.github/workflows/db-migrate.yml`
+- 触发方式：`push` 到 `main`（用于 PR 合并后触发）
+- 并发控制：同一分支仅保留最新一次运行（`cancel-in-progress: true`）
+- API Endpoint：`https://5jhbys8c46.execute-api.us-east-1.amazonaws.com/migrate/apply`
+- 认证方式：`x-api-key: ${{ secrets.NEXU_DB_MIGRATE_API_KEY }}`（仅 Secret 注入，不明文输出）
+
+## 执行逻辑
+
+1. `checkout` 仓库（`fetch-depth: 0`）。
+2. 使用 `github.event.before...github.sha` 作为本次 push 的 diff range。
+3. 过滤该范围内 `apps/api/migrations/**/*.sql` 的变更文件。
+4. 若无 SQL 变更：
+   - 设置 `has_migrations=false`
+   - 写入 Step Summary（`skipped` + diff range）
+   - 直接结束，不调用 API。
+5. 若有 SQL 变更：
+   - 生成 manifest（`$RUNNER_TEMP/nexu-db-migration-manifest.json`）
+   - 设置 `has_migrations=true` 与 `manifest_path`
+   - 调用 migrate apply API（`POST`，`--data @manifest`）
+   - 输出 HTTP 状态码 + 响应体（同时写入 Step Summary）
+   - 非 2xx 直接 `exit 1` 使 Job 失败。
+
+## Manifest 结构
+
+- 顶层字段：`repository` / `ref` / `sha` / `runId` / `eventName` / `generatedAt`
+- `files[]` 字段：
+  - `path`
+  - `sha256`
+  - `sql`（完整 SQL 内容）
+
+## API 调用与输出
+
+- 请求头：
+  - `content-type: application/json`
+  - `x-api-key: ${{ secrets.NEXU_DB_MIGRATE_API_KEY }}`
+- 请求体：`--data @${manifest_path}`
+- 响应文件：
+  - 原始响应：`$RUNNER_TEMP/migrate-apply-response.json`
+  - 美化响应：`$RUNNER_TEMP/migrate-apply-response-pretty.json`
+- 可观测性：
+  - 控制台输出 `HTTP status` 与响应体
+  - `GITHUB_STEP_SUMMARY` 展示检测结果、文件列表、调用结果与响应详情
+
+## 已验证场景（2026-03-06）
+
+- 无 migration 文件：`success`，跳过调用。
+- 同 path + 同 hash 重跑：`success`，文件状态为 `skipped`。
+- 同 path + 不同 hash：`failure`，HTTP `409`（路径冲突拦截）。
+- 多个 migration SQL：`success`，可同时出现 `applied` + `skipped`。
+
+## 现阶段约束
+
+- 仍为 MVP：目前通过 `push main` 实现“PR 合并后触发”，若存在直接 push 到 main 也会触发。
+- 环境审批、OIDC、分环境路由等增强能力尚未接入。
+
+## 说明
+
+- 历史验证使用过 comment-only 的 mock migration 文件；正式合并前已移除，不会进入主分支。


### PR DESCRIPTION
## Summary
- Scope DB migrate workflow trigger to `push` on `main` so it runs after PR merge.
- Change migration file detection to diff `github.event.before...github.sha` for merged push ranges.
- Remove temporary comment-only mock migration SQL test files and update workflow docs to match current behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated database migration workflow that runs on pushes to main, detects migration SQL changes, generates a migration manifest, and applies migrations via a remote API with outcome reporting.

* **Documentation**
  * Added docs describing the migration workflow MVP, execution steps, manifest format, API behavior, observability outputs, and validated scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->