### PR TITLE
feat: enable AUTO_SEED for preview deployments

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -88,6 +88,7 @@ jobs:
             BETTER_AUTH_URL="https://${{ steps.slug.outputs.branch_slug }}.${{ env.PREVIEW_DOMAIN_SUFFIX }}" \
             WEB_URL="https://${{ steps.slug.outputs.branch_slug }}.${{ env.PREVIEW_DOMAIN_SUFFIX }}" \
             RESEND_API_KEY="${{ secrets.RESEND_API_KEY }}" \
+            AUTO_SEED="true" \
             --app "$APP"
           # flyctl resolves dockerfile relative to fly.toml dir; normalize for old branches
           sed -i 's|dockerfile = "apps/api/Dockerfile.fly"|dockerfile = "Dockerfile.fly"|' apps/api/fly.toml


### PR DESCRIPTION
## Summary
- Add `AUTO_SEED="true"` to preview API secrets
- On startup, the API will auto-run `seedDev()` which creates invite code `NEXU2026` and gateway pool
- Uses `ON CONFLICT DO NOTHING` so safe to run repeatedly
- Same mechanism already used in docker-compose for local dev

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment preview configuration to improve the deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->