### PR TITLE
fix(web,landing): align browser tab titles with route names

### DIFF
--- a/apps/landing/src/layouts/LegalLayout.astro
+++ b/apps/landing/src/layouts/LegalLayout.astro
@@ -15,7 +15,7 @@ const pageTitle = frontmatter?.title ?? title ?? "Nexu";
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>{pageTitle} - Nexu</title>
+    <title>{pageTitle} · Nexu</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&family=Noto+Sans+SC:wght@400;500;600;700&display=swap" rel="stylesheet" />

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -157,7 +157,7 @@ const stats = [
         media.addListener(updateFavicon);
       })();
     </script>
-    <title>Nexu - The simplest OpenClaw for teams</title>
+    <title>Your Digital Coworker · Nexu</title>
     <meta name="description" content="The simplest OpenClaw in team chat - deploy in 1 minute, no YAML, no setup. 100% office tools and skills built-in, always on and always learning." />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -17,7 +17,7 @@
         media.addEventListener("change", updateFavicon);
       })();
     </script>
-    <title>Nexu - OpenClaw Dashboard</title>
+    <title>Nexu</title>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -1,4 +1,5 @@
-import { Navigate, Route, Routes } from "react-router-dom";
+import { useEffect } from "react";
+import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 import { AuthLayout } from "./layouts/auth-layout";
 import { InviteGuardLayout } from "./layouts/invite-guard-layout";
 import { WorkspaceLayout } from "./layouts/workspace-layout";
@@ -8,27 +9,49 @@ import { OnboardingPage } from "./pages/onboarding";
 import { SessionsPage } from "./pages/sessions";
 import { SlackOAuthCallbackPage } from "./pages/slack-oauth-callback";
 
+function DocumentTitleSync() {
+  const location = useLocation();
+
+  useEffect(() => {
+    const titleByPathname: Record<string, string> = {
+      "/auth": "Sign In · Nexu",
+      "/onboarding": "Get Started · Nexu",
+      "/workspace": "Workspace · Nexu",
+    };
+
+    document.title = titleByPathname[location.pathname] ?? "Nexu";
+  }, [location.pathname]);
+
+  return null;
+}
+
 export function App() {
   return (
-    <Routes>
-      <Route path="/" element={<Navigate to="/workspace" replace />} />
-      <Route path="/auth" element={<AuthPage />} />
-      <Route element={<AuthLayout />}>
-        <Route element={<InviteGuardLayout />}>
-          <Route path="/onboarding" element={<OnboardingPage />} />
-          <Route element={<WorkspaceLayout />}>
-            <Route path="/workspace" element={<SessionsPage />} />
-            <Route path="/workspace/sessions" element={<SessionsPage />} />
-            <Route path="/workspace/sessions/:id" element={<SessionsPage />} />
-            <Route path="/workspace/channels" element={<ChannelsPage />} />
-            <Route
-              path="/workspace/channels/slack/callback"
-              element={<SlackOAuthCallbackPage />}
-            />
+    <>
+      <DocumentTitleSync />
+      <Routes>
+        <Route path="/" element={<Navigate to="/workspace" replace />} />
+        <Route path="/auth" element={<AuthPage />} />
+        <Route element={<AuthLayout />}>
+          <Route element={<InviteGuardLayout />}>
+            <Route path="/onboarding" element={<OnboardingPage />} />
+            <Route element={<WorkspaceLayout />}>
+              <Route path="/workspace" element={<SessionsPage />} />
+              <Route path="/workspace/sessions" element={<SessionsPage />} />
+              <Route
+                path="/workspace/sessions/:id"
+                element={<SessionsPage />}
+              />
+              <Route path="/workspace/channels" element={<ChannelsPage />} />
+              <Route
+                path="/workspace/channels/slack/callback"
+                element={<SlackOAuthCallbackPage />}
+              />
+            </Route>
           </Route>
         </Route>
-      </Route>
-      <Route path="*" element={<Navigate to="/" replace />} />
-    </Routes>
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- update the landing and legal page titles to match the requested browser tab copy
- add route-based document title syncing in the web app for auth, onboarding, and workspace
- fall back to `Nexu` for unspecified web routes instead of the old dashboard title

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized page title formatting and branding text across landing and web apps (new interpunct separator and updated branding).

* **New Features**
  * Dynamic document titles now update with navigation, showing contextual titles like Sign In, Get Started, Workspace, and a default app title.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->