### PR TITLE
feat(landing): sync homepage style with OpenClaw reference

### DIFF
--- a/apps/landing/src/components/FAQSection.tsx
+++ b/apps/landing/src/components/FAQSection.tsx
@@ -27,12 +27,12 @@ function FAQItem({ q, a }: { q: string; a: string }) {
 
 const FAQ_ITEMS = [
   {
-    q: "What is nexu?",
-    a: "nexu is the simplest OpenClaw for teams - deploy in under a minute, with persistent memory and 1,000+ built-in tools. Always on in Slack, Discord and Telegram. Zero data loss, always learning.",
+    q: "What is Nexu?",
+    a: "Nexu is the simplest OpenClaw for teams - deploy in under a minute, with persistent memory and 1,000+ built-in tools. Always on in Slack, Discord and Telegram. Zero data loss, always learning.",
   },
   {
-    q: "How is nexu different from self-hosting OpenClaw?",
-    a: "nexu is hosted and ready in under a minute - no YAML, no server. You get persistent memory (OpenClaw sessions are stateless), 1,000+ tools out of the box, automatic updates, and team-level context across channels.",
+    q: "How is Nexu different from self-hosting OpenClaw?",
+    a: "Nexu is hosted and ready in under a minute - no YAML, no server. You get persistent memory (OpenClaw sessions are stateless), 1,000+ tools out of the box, automatic updates, and team-level context across channels.",
   },
   {
     q: "Do I need to know how to code?",
@@ -43,8 +43,8 @@ const FAQ_ITEMS = [
     a: "Slack, Discord, and Telegram. Add the bot to your workspace or group - your AI joins in under a minute and is 24/7 next to your team.",
   },
   {
-    q: "How does nexu understand my team?",
-    a: "nexu has persistent memory and learns from everyday work chat. It understands you and your team over time - no repeating yourself. The more you use it, the sharper it gets.",
+    q: "How does Nexu understand my team?",
+    a: "Nexu has persistent memory and learns from everyday work chat. It understands you and your team over time - no repeating yourself. The more you use it, the sharper it gets.",
   },
   {
     q: "Is my data safe?",
@@ -63,7 +63,7 @@ export default function FAQSection() {
           FAQ
         </div>
         <h2 className="text-2xl font-bold tracking-tight text-text-primary">
-          You might be wondering
+          Frequently Asked Questions
         </h2>
       </div>
       <div>

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -4,15 +4,18 @@ import {
   ArrowRight,
   BarChart3,
   Blocks,
-  Brain,
+  Check,
+  ChevronDown,
   Clock,
-  Code2,
+  Cloud,
+  FileText,
   MessageSquare,
   PenTool,
   Rocket,
-  Search,
   Terminal,
+  Users,
   Workflow,
+  X,
   Zap,
 } from "lucide-react";
 import DemoSection from "../components/DemoSection";
@@ -22,8 +25,8 @@ import BrandMark from "../components/BrandMark.astro";
 
 const capabilities = [
   { Icon: Rocket, label: "Deploy in 1 min" },
-  { Icon: Workflow, label: "100% office tools & skills built-in" },
-  { Icon: Brain, label: "Zero data loss" },
+  { Icon: Cloud, label: "100% office tools & skills built-in" },
+  { Icon: Users, label: "Zero data loss" },
   { Icon: Clock, label: "Always on, 24/7" },
 ];
 
@@ -31,17 +34,17 @@ const features = [
   {
     Icon: Rocket,
     title: "Deploy in 1 min",
-    desc: "No YAML, no config. Add nexu to your team chat and start working together right away.",
+    desc: "No YAML, no config. Add Nexu to your team chat and start working together right away.",
   },
   {
-    Icon: Workflow,
+    Icon: Cloud,
     title: "100% office tools & skills built-in",
     desc: "Build, analyze, automate - right from chat. No integrations to wire up, no plugins to install.",
   },
   {
-    Icon: Brain,
+    Icon: Users,
     title: "Zero data loss",
-    desc: "nexu remembers your conversations, preferences, and context. The more you use it, the sharper it gets.",
+    desc: "Nexu remembers your conversations, preferences, and context. The more you use it, the sharper it gets.",
   },
   {
     Icon: Clock,
@@ -60,7 +63,7 @@ const steps = [
   {
     step: "02",
     title: "Say what you need",
-    desc: "Just describe the task in chat - no code, no config. nexu handles the rest.",
+    desc: "Just describe the task in chat - no code, no config. Nexu handles the rest.",
     Icon: MessageSquare,
   },
   {
@@ -73,66 +76,105 @@ const steps = [
 
 const useCases = [
   {
-    Icon: Code2,
-    tag: "App",
-    prompt: '"Build my daughter a vocabulary flashcard game — cute style"',
+    Icon: FileText,
+    tag: "Startup / Remote",
+    prompt: "Channel or multi-channel daily digest",
     result:
-      "Creates React game from scratch · 48 word cards · pronunciation · auto-deployed, share the link to play",
-    time: "~45s",
+      "Turn hundreds of messages into one structured daily: decisions, progress, todos, risks. Everyone catches up in 30 seconds.",
+    time: "Daily",
   },
   {
     Icon: BarChart3,
-    tag: "Data",
-    prompt: '"Find the fastest-growing category in this sales data"',
+    tag: "E-commerce",
+    prompt: "Customer feedback daily",
     result:
-      "Analyzes 12,000+ records · generates trend charts + category rankings + growth forecast dashboard",
-    time: "~35s",
+      "Turn hundreds of support messages into a daily customer feedback report. See what's working and what's not in 30 seconds.",
+    time: "Daily",
   },
   {
     Icon: PenTool,
-    tag: "Content",
-    prompt:
-      '"Write a blog post + Twitter Thread from this week\'s product updates"',
-    result: "1,200-word blog + 8-tweet thread + SEO summary, ready to publish",
-    time: "~30s",
+    tag: "Startup / Remote",
+    prompt: "Quotes -> brand cards",
+    result:
+      "Auto-detect great quotes and turn them into shareable brand cards. Team thinking becomes external content.",
+    time: "Real-time",
   },
   {
-    Icon: Code2,
-    tag: "Tool",
-    prompt: '"Build a customer feedback form that exports to CSV"',
+    Icon: MessageSquare,
+    tag: "E-commerce",
+    prompt: "24/7 support auto-reply",
     result:
-      "Full-stack form app · ratings + text + tag filters + one-click export · live in seconds",
-    time: "~40s",
+      "Auto-answer FAQs in the group; escalate complex questions to humans. No more repeating \"how to use\" or \"when it ships.\"",
+    time: "24/7",
+  },
+  {
+    Icon: Users,
+    tag: "Content creator",
+    prompt: "Multi-group digest",
+    result:
+      "One digest across all your groups, ranked by importance. See every group's highlights in 5 minutes-no scrolling.",
+    time: "On demand",
   },
   {
     Icon: Workflow,
-    tag: "Automation",
-    prompt:
-      '"Every Friday, summarize our Slack discussions and send a newsletter"',
+    tag: "Content creator",
+    prompt: "Weekly highlights -> Newsletter",
     result:
-      "Scheduled workflow · auto-fetch → AI summary → format → send email, fully hands-free",
-    time: "~20s",
-  },
-  {
-    Icon: Search,
-    tag: "Research",
-    prompt:
-      '"Research AI coding competitors and build a pricing comparison table"',
-    result:
-      "Covers 6 competitors · feature comparison + pricing matrix + differentiation recommendations",
-    time: "~60s",
+      "Filter a week of group chat into highlights and get a Newsletter draft. 2 hours of manual work -> 5 minutes.",
+    time: "Weekly",
   },
 ];
 
 const stats = [
   { num: "24/7", label: "Always on", sub: "Your AI never sleeps" },
-  {
-    num: "1,000+",
-    label: "Built-in tools",
-    sub: "No integrations needed",
-  },
+  { num: "1,000+", label: "Built-in tools", sub: "No integrations needed" },
   { num: "<1", label: "Minute to get started", sub: "No YAML, no setup" },
   { num: "0", label: "Servers to manage", sub: "Fully hosted, auto-updated" },
+];
+
+const compareRows = [
+  {
+    feature: "Setup / Deploy",
+    nexu: "Under 1 minute, no code needed",
+    openclaw: ">24 h (YAML / env / keys)",
+    good: false,
+  },
+  {
+    feature: "Data & memory",
+    nexu: "Persistent - zero data loss, learns your team",
+    openclaw: "Session stateless, no persistent learning",
+    good: true,
+  },
+  {
+    feature: "Tools & skills",
+    nexu: "1,000+ built in, out of the box",
+    openclaw: "You build or plug in integrations",
+    good: true,
+  },
+  {
+    feature: "IM platforms",
+    nexu: "Slack, Discord, Telegram",
+    openclaw: "You build integrations",
+    good: true,
+  },
+  {
+    feature: "Hosting",
+    nexu: "Fully hosted, 24/7",
+    openclaw: "Self-hosted, uptime depends on you",
+    good: true,
+  },
+  {
+    feature: "Updates",
+    nexu: "Automatic",
+    openclaw: "Manual pull / upgrade",
+    good: true,
+  },
+  {
+    feature: "Team context",
+    nexu: "Multi-user, cross-channel awareness",
+    openclaw: "Mostly single-session",
+    good: true,
+  },
 ];
 ---
 
@@ -166,22 +208,20 @@ const stats = [
   <body>
     <LobsterCursorEffect client:load />
     <div class="min-h-full bg-surface-0 relative">
-
-      {/* Nav */}
       <nav class="sticky top-0 z-50 border-b backdrop-blur-md border-border bg-surface-0/85">
         <div class="flex justify-between items-center px-4 sm:px-6 mx-auto max-w-5xl h-14">
           <div class="flex items-center gap-2.5">
             <BrandMark className="w-7 h-7" />
             <span class="text-sm font-semibold tracking-tight text-text-primary">Nexu</span>
           </div>
-          <div class="hidden md:flex items-center gap-6 text-[13px] text-text-tertiary">
-             <a href="#scenarios" class="transition-colors hover:text-text-primary">Demos</a>
-             <a href="#features" class="transition-colors hover:text-text-primary">Why Nexu</a>
-             <a href="#vs-openclaw" class="transition-colors hover:text-text-primary">VS OpenClaw</a>
-             <a href="#how" class="transition-colors hover:text-text-primary">How it works</a>
-             <a href="#faq" class="transition-colors hover:text-text-primary">FAQ</a>
-          </div>
-          <div class="flex items-center">
+          <div class="flex items-center gap-6 text-[13px] text-text-tertiary">
+            <div class="hidden md:flex items-center gap-6">
+              <a href="#scenarios" class="transition-colors hover:text-text-primary">Demos</a>
+              <a href="#features" class="transition-colors hover:text-text-primary">Why Nexu</a>
+              <a href="#vs-openclaw" class="transition-colors hover:text-text-primary">VS OpenClaw</a>
+              <a href="#how" class="transition-colors hover:text-text-primary">How it works</a>
+              <a href="#faq" class="transition-colors hover:text-text-primary">FAQ</a>
+            </div>
             <a href="/auth" class="px-3 sm:px-4 py-1.5 bg-accent hover:bg-accent-hover text-accent-fg rounded-md text-[12px] sm:text-[13px] font-medium transition-colors inline-flex items-center gap-1.5">
               Get started free <ArrowRight size={14} />
             </a>
@@ -189,8 +229,7 @@ const stats = [
         </div>
       </nav>
 
-      {/* Hero */}
-      <section class="overflow-hidden relative">
+      <section class="relative z-10">
         <div class="absolute inset-0 bg-[radial-gradient(ellipse_at_top,rgba(var(--color-accent-rgb,99,102,241),0.06)_0%,transparent_50%)]"></div>
         <div class="absolute inset-0 opacity-15" style="background-image: linear-gradient(rgba(0,0,0,0.03) 1px, transparent 1px), linear-gradient(90deg, rgba(0,0,0,0.03) 1px, transparent 1px); background-size: 56px 56px;"></div>
         <div class="relative px-4 sm:px-6 pt-16 sm:pt-20 md:pt-24 pb-14 sm:pb-16 md:pb-20 mx-auto max-w-4xl text-center">
@@ -198,13 +237,16 @@ const stats = [
             <Zap size={12} /> Free during beta
           </div>
           <h1 class="text-[32px] sm:text-[40px] md:text-[42px] font-bold text-text-primary mb-5 sm:mb-6 leading-[1.15] tracking-tight">
-            The simplest OpenClaw🦞 for teams<br />
+            The simplest OpenClaw🦞 for teams
+            <br class="hidden sm:block" />
             <span class="text-accent">Deploy in 1 min. Zero data loss.</span>
           </h1>
           <p class="mx-auto mb-7 sm:mb-8 max-w-2xl text-base sm:text-lg leading-relaxed text-text-tertiary">
-            The simplest OpenClaw in team chat - deploy in 1 minute, no YAML, no setup.<br class="hidden sm:block" />
+            The simplest OpenClaw in team chat - deploy in 1 minute, no YAML, no setup.
+            <br class="hidden sm:block" />
             100% office tools and skills built-in, 24/7 next to you in Slack, Discord and Telegram. Always on, always learning.
           </p>
+
           <div class="flex flex-wrap gap-2 justify-center mb-10">
             {capabilities.map((cap) => (
               <span class="inline-flex gap-1.5 items-center px-3 py-1.5 rounded-full text-[13px] font-medium border transition-colors bg-surface-1 text-text-secondary border-border hover:border-border-hover">
@@ -213,10 +255,39 @@ const stats = [
               </span>
             ))}
           </div>
-          <div class="flex gap-3 justify-center items-center mx-auto mb-6 max-w-md">
-            <a href="/auth" class="flex gap-2 items-center px-6 sm:px-8 py-3 text-sm font-semibold rounded-lg transition-all bg-accent hover:bg-accent-hover text-accent-fg hover:shadow-lg hover:shadow-accent/20">
+
+          <div class="flex flex-col sm:flex-row gap-3 justify-center items-center mx-auto mb-6 max-w-md">
+            <a href="/auth" class="flex gap-2 items-center justify-center px-6 sm:px-8 py-3 text-sm font-semibold rounded-lg transition-all bg-accent hover:bg-accent-hover text-accent-fg hover:shadow-lg hover:shadow-accent/20 w-full sm:w-auto">
               Get started free <ArrowRight size={14} />
             </a>
+            <details class="relative w-full sm:w-auto">
+              <summary class="list-none cursor-pointer flex gap-2 items-center justify-center px-6 py-3 text-sm font-semibold rounded-lg border transition-all text-text-primary border-border hover:border-border-hover hover:bg-surface-1 w-full sm:w-auto">
+                Add to your team chat <ChevronDown size={14} />
+              </summary>
+              <div class="absolute left-0 top-full mt-2 w-full sm:w-56 bg-surface-0 border border-border rounded-lg shadow-lg z-50">
+                <a href="#" class="flex items-center gap-3 px-4 py-3 hover:bg-surface-1 transition-colors">
+                  <div class="w-8 h-8 flex items-center justify-center shrink-0 text-lg">💬</div>
+                  <div class="flex-1 min-w-0 text-left">
+                    <div class="text-sm font-medium text-text-primary">Slack</div>
+                    <div class="text-[11px] text-text-muted">Join group to try</div>
+                  </div>
+                </a>
+                <a href="#" class="flex items-center gap-3 px-4 py-3 hover:bg-surface-1 transition-colors">
+                  <div class="w-8 h-8 flex items-center justify-center shrink-0 text-lg">🎮</div>
+                  <div class="flex-1 min-w-0 text-left">
+                    <div class="text-sm font-medium text-text-primary">Discord</div>
+                    <div class="text-[11px] text-text-muted">Join group to try</div>
+                  </div>
+                </a>
+                <a href="/auth" class="flex items-center gap-3 px-4 py-3 hover:bg-surface-1 transition-colors">
+                  <div class="w-8 h-8 flex items-center justify-center shrink-0 text-lg">🟢</div>
+                  <div class="flex-1 min-w-0 text-left">
+                    <div class="text-sm font-medium text-text-primary">WhatsApp</div>
+                    <div class="text-[11px] text-text-muted">Scan QR to join group</div>
+                  </div>
+                </a>
+              </div>
+            </details>
           </div>
           <div class="flex items-center justify-center text-[13px] text-text-muted">
             <span>The simplest OpenClaw. Free to get started.</span>
@@ -224,15 +295,32 @@ const stats = [
         </div>
       </section>
 
-      {/* Demo (React island — interactive tabs) */}
+      <section class="px-4 sm:px-6 py-12 sm:py-16 mx-auto max-w-3xl text-center">
+        <h2 class="text-xl sm:text-2xl font-bold tracking-tight text-text-primary mb-3">
+          Works where your team already works
+        </h2>
+        <p class="text-sm text-text-tertiary leading-relaxed mb-10">
+          One AI, all your communication channels-add the bot to Slack, Discord, or Telegram in under a minute.
+        </p>
+        <div class="flex flex-wrap gap-4 justify-center mb-6">
+          <div class="flex flex-col items-center gap-2 w-20 py-4 rounded-xl border border-border bg-surface-1 hover:border-border-hover transition-colors"><span class="text-2xl">💬</span><span class="text-[12px] font-medium text-text-secondary">Slack</span></div>
+          <div class="flex flex-col items-center gap-2 w-20 py-4 rounded-xl border border-border bg-surface-1 hover:border-border-hover transition-colors"><span class="text-2xl">🎮</span><span class="text-[12px] font-medium text-text-secondary">Discord</span></div>
+          <div class="flex flex-col items-center gap-2 w-20 py-4 rounded-xl border border-border bg-surface-1 hover:border-border-hover transition-colors"><span class="text-2xl">✈️</span><span class="text-[12px] font-medium text-text-secondary">Telegram</span></div>
+          <div class="flex flex-col items-center gap-2 w-20 py-4 rounded-xl border border-border bg-surface-1 hover:border-border-hover transition-colors"><span class="text-2xl">🟢</span><span class="text-[12px] font-medium text-text-secondary">WhatsApp</span></div>
+          <div class="flex flex-col items-center gap-2 w-20 py-4 rounded-xl border border-border bg-surface-1 hover:border-border-hover transition-colors"><span class="text-2xl">👥</span><span class="text-[12px] font-medium text-text-secondary">Teams</span></div>
+        </div>
+        <p class="text-[12px] text-text-muted">Signal, Matrix, WebChat and more coming soon.</p>
+      </section>
+
       <DemoSection client:visible />
 
-      {/* Features */}
       <section id="features" class="px-4 sm:px-6 py-16 sm:py-20 md:py-24 mx-auto max-w-4xl">
         <div class="mb-14 text-center">
-          <div class="text-[11px] font-semibold text-accent mb-3 tracking-widest uppercase">Capabilities</div>
+          <div class="text-[11px] font-semibold text-accent mb-3 tracking-widest uppercase">Why Nexu</div>
           <h2 class="text-2xl font-bold tracking-tight text-text-primary">The simplest OpenClaw. Built for your team.</h2>
-          <p class="mx-auto mt-3 max-w-lg text-sm leading-relaxed text-text-tertiary">The simplest OpenClaw - ready in under a minute, with persistent memory and every tool your team needs. Always on in Slack, Discord and Telegram.</p>
+          <p class="mx-auto mt-3 max-w-lg text-sm leading-relaxed text-text-tertiary">
+            The simplest OpenClaw - ready in under a minute, with persistent memory and every tool your team needs. Always on in Slack, Discord and Telegram.
+          </p>
         </div>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-5">
           {features.map((f) => (
@@ -249,11 +337,10 @@ const stats = [
 
       <div class="px-4 sm:px-6 mx-auto max-w-4xl"><div class="border-t border-border"></div></div>
 
-      {/* VS OpenClaw */}
       <section id="vs-openclaw" class="px-4 sm:px-6 py-16 sm:py-20 md:py-24 mx-auto max-w-4xl">
         <div class="mb-14 text-center">
           <div class="text-[11px] font-semibold text-accent mb-3 tracking-widest uppercase">Compare</div>
-          <h2 class="text-2xl font-bold tracking-tight text-text-primary">How nexu stacks up</h2>
+          <h2 class="text-2xl font-bold tracking-tight text-text-primary">How Nexu stacks up</h2>
           <p class="mx-auto mt-3 max-w-lg text-sm leading-relaxed text-text-tertiary">Compared to self-hosting OpenClaw and other hosted options.</p>
         </div>
         <div class="overflow-x-auto rounded-xl border border-border bg-surface-1">
@@ -261,53 +348,41 @@ const stats = [
             <thead>
               <tr class="border-b border-border">
                 <th class="px-5 py-4 font-semibold text-text-primary">Feature</th>
-                <th class="px-5 py-4 font-semibold text-accent">nexu</th>
+                <th class="px-5 py-4 font-semibold text-accent">Nexu</th>
                 <th class="px-5 py-4 font-semibold text-text-secondary">OpenClaw (Self-Hosted)</th>
               </tr>
             </thead>
             <tbody class="text-text-secondary">
-              <tr class="border-b border-border">
-                <td class="px-5 py-3 font-medium text-text-primary">Setup / Deploy</td>
-                <td class="px-5 py-3">Under 1 minute, no code needed</td>
-                <td class="px-5 py-3">&gt;24 h (YAML / env / keys)</td>
-              </tr>
-              <tr class="border-b border-border">
-                <td class="px-5 py-3 font-medium text-text-primary">Data & memory</td>
-                <td class="px-5 py-3">Persistent - zero data loss, learns your team</td>
-                <td class="px-5 py-3">Session stateless, no persistent learning</td>
-              </tr>
-              <tr class="border-b border-border">
-                <td class="px-5 py-3 font-medium text-text-primary">Tools & skills</td>
-                <td class="px-5 py-3">1,000+ built in, out of the box</td>
-                <td class="px-5 py-3">You build or plug in integrations</td>
-              </tr>
-              <tr class="border-b border-border">
-                <td class="px-5 py-3 font-medium text-text-primary">IM platforms</td>
-                <td class="px-5 py-3">Slack, Discord, Telegram</td>
-                <td class="px-5 py-3">You build integrations</td>
-              </tr>
-              <tr class="border-b border-border">
-                <td class="px-5 py-3 font-medium text-text-primary">Hosting</td>
-                <td class="px-5 py-3">Fully hosted, 24/7</td>
-                <td class="px-5 py-3">Self-hosted, uptime depends on you</td>
-              </tr>
-              <tr>
-                <td class="px-5 py-3 font-medium text-text-primary">Updates</td>
-                <td class="px-5 py-3">Automatic</td>
-                <td class="px-5 py-3">Manual pull / upgrade</td>
-              </tr>
+              {compareRows.map((row) => (
+                <tr class="border-b border-border last:border-b-0">
+                  <td class="px-5 py-3 font-medium text-text-primary">{row.feature}</td>
+                  <td class="px-5 py-3">
+                    <span class="inline-flex items-center gap-1.5">
+                      <Check size={14} className="text-green-500 shrink-0" />
+                      {row.nexu}
+                    </span>
+                  </td>
+                  <td class="px-5 py-3">
+                    <span class="inline-flex items-center gap-1.5">
+                      <X size={14} className="text-red-400 shrink-0" />
+                      {row.openclaw}
+                    </span>
+                  </td>
+                </tr>
+              ))}
             </tbody>
           </table>
         </div>
+        <p class="mt-4 text-center text-[13px] text-text-muted">The simplest OpenClaw. Ready in under a minute, with persistent memory and 1,000+ tools - always on in Slack, Discord and Telegram.</p>
       </section>
 
       <div class="px-4 sm:px-6 mx-auto max-w-4xl"><div class="border-t border-border"></div></div>
 
-      {/* How it works */}
       <section id="how" class="px-4 sm:px-6 py-16 sm:py-20 md:py-24 mx-auto max-w-4xl">
         <div class="mb-14 text-center">
           <div class="text-[11px] font-semibold text-accent mb-3 tracking-widest uppercase">How it works</div>
-          <h2 class="text-2xl font-bold tracking-tight text-text-primary">Get your OpenClaw in 3 quick steps</h2>
+          <h2 class="text-2xl font-bold tracking-tight text-text-primary">Get Your OpenClaw in 3 Quick Steps</h2>
+          <p class="mx-auto mt-2 max-w-lg text-sm leading-relaxed text-text-tertiary">Add Nexu to your team chat and start working together in minutes.</p>
         </div>
         <div class="grid grid-cols-1 md:grid-cols-3 gap-8 md:gap-10">
           {steps.map((s, i) => (
@@ -326,11 +401,11 @@ const stats = [
 
       <div class="px-4 sm:px-6 mx-auto max-w-4xl"><div class="border-t border-border"></div></div>
 
-      {/* Use Cases */}
       <section class="px-4 sm:px-6 py-16 sm:py-20 md:py-24 mx-auto max-w-5xl">
         <div class="mb-14 text-center">
           <div class="text-[11px] font-semibold text-accent mb-3 tracking-widest uppercase">Use cases</div>
-          <h2 class="text-2xl font-bold tracking-tight text-text-primary">You chat. nexu executes.</h2>
+          <h2 class="text-2xl font-bold tracking-tight text-text-primary">You chat in your team. Nexu gets it done.</h2>
+          <p class="mx-auto mt-2 max-w-lg text-sm leading-relaxed text-text-tertiary">Startup/remote teams · E-commerce · Creators & multi-group users. Slack, Discord, Telegram.</p>
         </div>
         <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6">
           {useCases.map((c) => (
@@ -355,7 +430,6 @@ const stats = [
 
       <div class="px-4 sm:px-6 mx-auto max-w-4xl"><div class="border-t border-border"></div></div>
 
-      {/* Numbers */}
       <section class="px-4 sm:px-6 py-16 sm:py-20 md:py-24 mx-auto max-w-4xl">
         <div class="grid grid-cols-2 md:grid-cols-4 gap-8 text-center">
           {stats.map((n) => (
@@ -370,15 +444,13 @@ const stats = [
 
       <div class="px-4 sm:px-6 mx-auto max-w-4xl"><div class="border-t border-border"></div></div>
 
-      {/* FAQ (React island — interactive accordion) */}
       <FAQSection client:visible />
 
-      {/* Final CTA */}
       <section class="overflow-hidden relative">
         <div class="absolute inset-0 bg-[radial-gradient(ellipse_at_center,rgba(var(--color-accent-rgb,99,102,241),0.05)_0%,transparent_60%)]"></div>
         <div class="relative px-4 sm:px-6 py-16 sm:py-20 md:py-24 mx-auto max-w-3xl text-center">
-          <h2 class="mb-4 text-3xl font-bold tracking-tight text-text-primary">Give your lobster a real workplace.</h2>
-          <p class="mb-8 text-base text-text-tertiary">The simplest OpenClaw. Always on, always learning.</p>
+          <h2 class="mb-4 text-3xl font-bold tracking-tight text-text-primary">The simplest OpenClaw. Always on, always learning.</h2>
+          <p class="mb-8 text-base text-text-tertiary">Free to get started. Works in Slack, Discord and Telegram.</p>
           <div class="flex gap-3 justify-center">
             <a href="/auth" class="flex gap-2 items-center px-6 sm:px-8 py-3 text-sm font-semibold rounded-lg transition-all bg-accent hover:bg-accent-hover text-accent-fg hover:shadow-lg hover:shadow-accent/20">
               Get started free <ArrowRight size={14} />
@@ -387,7 +459,6 @@ const stats = [
         </div>
       </section>
 
-      {/* Footer */}
       <footer class="border-t border-border">
         <div class="flex flex-col gap-4 md:flex-row md:justify-between md:items-center px-4 sm:px-6 py-8 mx-auto max-w-5xl">
           <div class="flex items-center gap-2.5">
@@ -402,7 +473,6 @@ const stats = [
           </div>
         </div>
       </footer>
-
     </div>
     <script>
       import * as amplitude from "@amplitude/unified";


### PR DESCRIPTION
## Summary
- sync the `apps/landing` homepage visual structure and copy direction to match the OpenClaw reference landing style while preserving existing Nexu routes
- update hero/navigation/IM platform showcase, comparison table, use-case cards, and final CTA sections for closer parity with the reference page
- refine FAQ wording and heading casing for a consistent landing narrative

## Validation
- pnpm --filter @nexu/landing typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive "Add to your team chat" dropdown with integration options for Slack, Discord, and WhatsApp.
  * Introduced new "Works where your team already works" section showcasing multi-platform support.
  * Redesigned product comparison table with clearer feature highlights.

* **Style**
  * Updated branding capitalization throughout.
  * Refreshed section headers and layout organization.
  * Improved copy and formatting for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->