### PR TITLE
fix(api): add slack gateway forward failure signal

### DIFF
--- a/apps/api/src/routes/slack-events.ts
+++ b/apps/api/src/routes/slack-events.ts
@@ -441,6 +441,7 @@ class SlackEventsTraceHandler {
         const respBody = await gatewayResp.text();
         logger.info({
           message: "slack_events_gateway_response",
+          operation: "slack_event_gateway_forward",
           event_type: fwdEvent?.type ?? "none",
           status: gatewayResp.status,
           body_length: respBody.length,
@@ -451,11 +452,14 @@ class SlackEventsTraceHandler {
         });
       } catch (err) {
         const unknownError = BaseError.from(err);
-        logger.warn({
+        logger.error({
           message: "slack_events_gateway_forward_failed",
+          operation: "slack_event_gateway_forward",
+          status: "error",
           scope: "slack_events_gateway_forward",
           pool_id: route.poolId,
           account_id: accountId,
+          event_type: fwdEvent?.type ?? "none",
           ...unknownError.toJSON(),
         });
         return c.json({ accepted: true }, 202);


### PR DESCRIPTION
## Summary
- add a stable `operation:slack_event_gateway_forward` log field to the Slack gateway forwarding path so Datadog can query the signal consistently
- promote repeated gateway forwarding failures to `error` logs with `status:error` and event context for one focused log alert
- keep the change scoped to the Slack forwarding path without changing request handling behavior

## Validation
- `pnpm --filter @nexu/api typecheck`
- `pnpm typecheck` *(currently blocked on existing `apps/gateway/src/metrics.ts` missing `dd-trace` type resolution on `origin/main`)*
- `pnpm lint` *(currently blocked by the same existing gateway typecheck failure because lint runs recursive typecheck)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced logging for Slack event forwarding to provide better visibility into both successful and failed operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->