### PR TITLE
fix(web): hide WhatsApp from onboarding and landing

### DIFF
--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -279,6 +279,7 @@ const compareRows = [
                     <div class="text-[11px] text-text-muted">Join group to try</div>
                   </div>
                 </a>
+                <!--
                 <a href="/auth" class="flex items-center gap-3 px-4 py-3 hover:bg-surface-1 transition-colors">
                   <div class="w-8 h-8 flex items-center justify-center shrink-0 text-lg">🟢</div>
                   <div class="flex-1 min-w-0 text-left">
@@ -286,6 +287,7 @@ const compareRows = [
                     <div class="text-[11px] text-text-muted">Scan QR to join group</div>
                   </div>
                 </a>
+                -->
               </div>
             </details>
           </div>
@@ -306,7 +308,7 @@ const compareRows = [
           <div class="flex flex-col items-center gap-2 w-20 py-4 rounded-xl border border-border bg-surface-1 hover:border-border-hover transition-colors"><span class="text-2xl">💬</span><span class="text-[12px] font-medium text-text-secondary">Slack</span></div>
           <div class="flex flex-col items-center gap-2 w-20 py-4 rounded-xl border border-border bg-surface-1 hover:border-border-hover transition-colors"><span class="text-2xl">🎮</span><span class="text-[12px] font-medium text-text-secondary">Discord</span></div>
           <div class="flex flex-col items-center gap-2 w-20 py-4 rounded-xl border border-border bg-surface-1 hover:border-border-hover transition-colors"><span class="text-2xl">✈️</span><span class="text-[12px] font-medium text-text-secondary">Telegram</span></div>
-          <div class="flex flex-col items-center gap-2 w-20 py-4 rounded-xl border border-border bg-surface-1 hover:border-border-hover transition-colors"><span class="text-2xl">🟢</span><span class="text-[12px] font-medium text-text-secondary">WhatsApp</span></div>
+          <!-- <div class="flex flex-col items-center gap-2 w-20 py-4 rounded-xl border border-border bg-surface-1 hover:border-border-hover transition-colors"><span class="text-2xl">🟢</span><span class="text-[12px] font-medium text-text-secondary">WhatsApp</span></div> -->
           <div class="flex flex-col items-center gap-2 w-20 py-4 rounded-xl border border-border bg-surface-1 hover:border-border-hover transition-colors"><span class="text-2xl">👥</span><span class="text-[12px] font-medium text-text-secondary">Teams</span></div>
         </div>
         <p class="text-[12px] text-text-muted">Signal, Matrix, WebChat and more coming soon.</p>

--- a/apps/web/src/pages/onboarding.tsx
+++ b/apps/web/src/pages/onboarding.tsx
@@ -117,13 +117,13 @@ const CHANNEL_OPTIONS: ChannelOption[] = [
     color: "#5865F2",
     connectable: true,
   },
-  {
-    id: "whatsapp",
-    name: "WhatsApp",
-    protocol: "QR link",
-    color: "#25D366",
-    connectable: true,
-  },
+  // {
+  //   id: "whatsapp",
+  //   name: "WhatsApp",
+  //   protocol: "QR link",
+  //   color: "#25D366",
+  //   connectable: true,
+  // },
   {
     id: "telegram",
     name: "Telegram",


### PR DESCRIPTION
## Summary
- hide the WhatsApp option from the onboarding channel picker in the web app
- remove WhatsApp from the landing page chat dropdown and supported channel list
- keep the underlying WhatsApp integration code intact so this remains a UI-only change

## Testing
- pnpm lint
- pnpm typecheck *(fails in `apps/gateway/src/metrics.ts` due to missing `dd-trace` types; `apps/web` and `apps/landing` typechecks pass)*