### PR TITLE
[REF-1496]fix: resolve ambiguous session key resolution for channel artifacts

### DIFF
--- a/apps/api/src/routes/__tests__/artifact-routes.test.ts
+++ b/apps/api/src/routes/__tests__/artifact-routes.test.ts
@@ -590,6 +590,42 @@ describe("Artifact Internal Routes", () => {
       expect(body.message).toBe("Ambiguous session resolution for chatId");
     });
 
+    it("resolves correctly when legacy and truncated session keys exist", async () => {
+      const now = new Date().toISOString();
+      // Seed 3 sessions for the same bot+channel with different key formats:
+      // 1. Legacy pre-agent format
+      // 2. Truncated (missing :channel:xxx)
+      // 3. Valid agent:*:channel:* format
+      await setupPool.query(
+        `INSERT INTO sessions (id, bot_id, session_key, channel_type, channel_id, title, status, created_at, updated_at)
+         VALUES
+         ('sess-legacy', 'bot-test-1', 'slack_T09CNAG1BP0_C0AJKG60H6D', 'slack', 'c0ajkg60h6d', 'Legacy Session', 'active', $1, $2),
+         ('sess-truncated', 'bot-test-1', 'agent:bot-test-1:slack', 'slack', 'c0ajkg60h6d', 'Truncated Session', 'active', $1, $2),
+         ('sess-valid', 'bot-test-1', 'agent:bot-test-1:slack:channel:c0ajkg60h6d', 'slack', 'c0ajkg60h6d', 'Valid Session', 'active', $1, $2)`,
+        [now, now],
+      );
+
+      const res = await app.request("/api/internal/artifacts", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-internal-token": TOKEN,
+        },
+        body: JSON.stringify({
+          botId: "bot-test-1",
+          title: "Deploy with Legacy Data",
+          chatId: "channel:C0AJKG60H6D",
+          channelType: "slack",
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.sessionKey).toBe(
+        "agent:bot-test-1:slack:channel:c0ajkg60h6d",
+      );
+    });
+
     it("returns 400 when channel chatId has no exact session", async () => {
       const res = await app.request("/api/internal/artifacts", {
         method: "POST",

--- a/apps/api/src/routes/artifact-routes.ts
+++ b/apps/api/src/routes/artifact-routes.ts
@@ -101,16 +101,36 @@ async function resolveArtifactSessionKey(input: {
     return { error: "No matching session found for chatId" };
   }
 
+  // Filter to only valid agent:*:channel:* session keys.
+  // Prod data may contain legacy formats (e.g. "slack_T09CNAG_C09CNAG")
+  // or truncated keys (e.g. "agent:bot:slack" without :channel:).
+  const normalizedChannelId = channelId.toLowerCase();
+  const validRows = rows.filter((row) => {
+    const key = normalizeSessionKey(row.sessionKey);
+    return (
+      key.startsWith("agent:") &&
+      key.includes(`:channel:${normalizedChannelId}`)
+    );
+  });
+
+  if (validRows.length === 0) {
+    return { error: "No matching session found for chatId" };
+  }
+
+  // Strip thread suffixes to get base channel keys, then deduplicate
+  const stripThread = (key: string) => key.replace(/:thread:.*$/, "");
   const uniqueBaseKeys = new Set(
-    rows.map((row) => normalizeSessionKey(row.sessionKey)),
+    validRows.map((row) => stripThread(normalizeSessionKey(row.sessionKey))),
   );
   if (uniqueBaseKeys.size !== 1) {
     return { error: "Ambiguous session resolution for chatId" };
   }
 
-  const baseKey = rows[0]?.sessionKey
-    ? normalizeSessionKey(rows[0].sessionKey)
-    : undefined;
+  const firstValid = validRows[0];
+  if (!firstValid) {
+    return { error: "No matching session found for chatId" };
+  }
+  const baseKey = stripThread(normalizeSessionKey(firstValid.sessionKey));
   if (!baseKey) {
     return { error: "No matching session found for chatId" };
   }


### PR DESCRIPTION
## Summary

- Fixes "Ambiguous session resolution for chatId" error that blocked artifact creation (deploy) in production
- Root cause: prod DB contains legacy/truncated session keys alongside valid ones for the same bot+channel:
  - `slack_T09CNAG1BP0_C09CNAGC33Q` (legacy pre-agent format)
  - `agent:botId:slack` (truncated, missing `:channel:xxx`)
  - `agent:botId:slack:channel:c09cnagc33q` (valid)
- The old code treated all 3 as distinct keys, triggering false ambiguity
- Fix: filter to only `agent:*:channel:*` format keys before deduplication, and strip thread suffixes when comparing base keys

## Test plan

- [x] Updated existing "ambiguous resolution" test to use genuinely different base keys (slack vs discord channel types)
- [x] Added new test: "resolves correctly when legacy and truncated session keys exist" — seeds 3 sessions with different formats, verifies only the valid one is used
- [x] All 24 artifact-routes tests pass
- [x] Typecheck passes
- [x] Lint passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session key validation and resolution to properly handle legacy and truncated formats, ensuring more reliable artifact processing and preventing resolution errors in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->