### PR TITLE
fix: increase Slack deep link timeout and cancel on blur

### DIFF
--- a/apps/web/src/pages/channels.tsx
+++ b/apps/web/src/pages/channels.tsx
@@ -259,11 +259,17 @@ function ConfiguredView({
 
     if (!nativeUrl || !webUrl) return;
 
-    // Try native app first, fall back to web after timeout
-    window.location.href = nativeUrl;
-    setTimeout(() => {
+    // Try native app first. If the app opens, the browser loses focus
+    // and we cancel the fallback. Otherwise open the web URL after 5s.
+    const fallbackTimer = setTimeout(() => {
       window.open(webUrl, "_blank", "noopener,noreferrer");
-    }, 1500);
+    }, 5000);
+    const cancelFallback = () => {
+      clearTimeout(fallbackTimer);
+      window.removeEventListener("blur", cancelFallback);
+    };
+    window.addEventListener("blur", cancelFallback);
+    window.location.href = nativeUrl;
   }, [slackTeamId, channel.botUserId]);
 
   const webhookUrl = `${window.location.origin}/api/${platform}/events`;


### PR DESCRIPTION
## Summary

- Increase native Slack app deep link fallback timeout from 1.5s to 5s to give the app more time to launch
- Add `blur` event listener to cancel the web fallback when the native app opens successfully

## Test plan

- [ ] Click "Message Bot in Slack" with Slack app installed — native app opens, no web fallback
- [ ] Click "Message Bot in Slack" without Slack app — web URL opens after 5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Slack integration: Enhanced fallback behavior with smarter detection to prevent unnecessary app launches and better timing for web fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->