### PR TITLE
fix(gateway): tighten rollout readiness probes

### DIFF
--- a/deploy/helm/nexu/templates/gateway-deployment.yaml
+++ b/deploy/helm/nexu/templates/gateway-deployment.yaml
@@ -83,12 +83,28 @@ spec:
             - name: openclaw-data
               mountPath: /tmp/openclaw
               subPath: logs
+          startupProbe:
+            exec:
+              command:
+                - openclaw
+                - health
+                - --json
+                - --timeout
+                - {{ .Values.gateway.probes.cliTimeoutMs | quote }}
+            periodSeconds: {{ .Values.gateway.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.gateway.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.gateway.probes.startup.failureThreshold }}
           readinessProbe:
-            tcpSocket:
-              port: gateway
-            initialDelaySeconds: 15
-            periodSeconds: 10
-            timeoutSeconds: 5
+            exec:
+              command:
+                - openclaw
+                - health
+                - --json
+                - --timeout
+                - {{ .Values.gateway.probes.cliTimeoutMs | quote }}
+            periodSeconds: {{ .Values.gateway.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.gateway.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.gateway.probes.readiness.failureThreshold }}
           livenessProbe:
             tcpSocket:
               port: gateway

--- a/deploy/helm/nexu/values.yaml
+++ b/deploy/helm/nexu/values.yaml
@@ -94,6 +94,16 @@ gateway:
       memory: 4Gi
   persistence:
     size: 20Gi
+  probes:
+    cliTimeoutMs: 10000
+    readiness:
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 3
+    startup:
+      periodSeconds: 5
+      timeoutSeconds: 5
+      failureThreshold: 24
   sandbox:
     enabled: false
     dindImage: "docker:27-dind"


### PR DESCRIPTION
## Summary
- replace the gateway StatefulSet readiness check with an `exec` probe that runs the existing `openclaw health` CLI instead of treating an open TCP port as ready
- add a startup probe around the same CLI check so `nexu-gateway` gets explicit bootstrap headroom before readiness gating begins
- keep liveness conservative for now by leaving the TCP liveness probe unchanged while we validate rollout behavior improvement first

## Validation
- `helm template nexu deploy/helm/nexu`
- inspected rendered `startupProbe` / `readinessProbe` commands for the `nexu-gateway` StatefulSet