### PR TITLE
fix: update landing chat dropdown link

### DIFF
--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -265,17 +265,10 @@ const compareRows = [
                 Add to your team chat <ChevronDown size={14} />
               </summary>
               <div class="absolute left-0 top-full mt-2 w-full sm:w-56 bg-surface-0 border border-border rounded-lg shadow-lg z-50">
-                <a href="#" class="flex items-center gap-3 px-4 py-3 hover:bg-surface-1 transition-colors">
+                <a href="https://join.slack.com/t/nexu-ixl1131/shared_invite/zt-3ridrx1sn-Cbu6IFNcdjKq4c1p27ZGUw" target="_blank" rel="noreferrer" class="flex items-center gap-3 px-4 py-3 hover:bg-surface-1 transition-colors">
                   <div class="w-8 h-8 flex items-center justify-center shrink-0 text-lg">💬</div>
                   <div class="flex-1 min-w-0 text-left">
                     <div class="text-sm font-medium text-text-primary">Slack</div>
-                    <div class="text-[11px] text-text-muted">Join group to try</div>
-                  </div>
-                </a>
-                <a href="#" class="flex items-center gap-3 px-4 py-3 hover:bg-surface-1 transition-colors">
-                  <div class="w-8 h-8 flex items-center justify-center shrink-0 text-lg">🎮</div>
-                  <div class="flex-1 min-w-0 text-left">
-                    <div class="text-sm font-medium text-text-primary">Discord</div>
                     <div class="text-[11px] text-text-muted">Join group to try</div>
                   </div>
                 </a>


### PR DESCRIPTION
## Summary
- remove the Discord option from the landing page \"Add to your team chat\" dropdown
- keep the Slack option and point it to the shared Slack invite link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Slack link in navigation dropdown to point to a functional external invite.
  * Removed Discord option from navigation dropdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->