### PR TITLE
feat: add missing analytics tracking events

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -71,8 +71,9 @@ DD_API_KEY=
 # OTEL_EXPORTER_OTLP_ENDPOINT=
 OTEL_SERVICE_NAME=nexu-openclaw
 
-# ── Analytics (optional — Amplitude frontend tracking) ──
+# ── Analytics (optional — Amplitude tracking) ──
 VITE_AMPLITUDE_API_KEY=
+AMPLITUDE_API_KEY=
 
 # ── Server ───────────────────────────────────────────
 PORT=3000

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -21,6 +21,7 @@
     "db:seed": "tsx src/db/seed-dev.ts"
   },
   "dependencies": {
+    "@amplitude/analytics-node": "^1.5.43",
     "@hono/node-server": "^1.13.8",
     "@hono/zod-openapi": "^0.18.4",
     "@nexu/shared": "workspace:*",

--- a/apps/api/src/lib/__tests__/tracking.test.ts
+++ b/apps/api/src/lib/__tests__/tracking.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Mock @amplitude/analytics-node before importing tracking module
+vi.mock("@amplitude/analytics-node", () => ({
+  init: vi.fn(),
+  track: vi.fn(),
+}));
+
+describe("tracking", () => {
+  it("does not call ampTrack when AMPLITUDE_API_KEY is unset", async () => {
+    const { track: ampTrack } = await import("@amplitude/analytics-node");
+    const { track } = await import("../tracking.js");
+
+    track("test_event", "user-123", { foo: "bar" });
+
+    // apiKey is undefined in test env, so ampTrack should not be called
+    expect(ampTrack).not.toHaveBeenCalled();
+  });
+
+  it("exports track as a function with correct signature", async () => {
+    const { track } = await import("../tracking.js");
+    expect(typeof track).toBe("function");
+    // 3 params: event, userId, properties (all counted since none have defaults)
+    expect(track.length).toBe(3);
+  });
+});

--- a/apps/api/src/lib/tracking.ts
+++ b/apps/api/src/lib/tracking.ts
@@ -1,0 +1,18 @@
+import { track as ampTrack, init } from "@amplitude/analytics-node";
+import { logger } from "./logger.js";
+
+const apiKey = process.env.AMPLITUDE_API_KEY;
+
+if (apiKey) {
+  init(apiKey, { logLevel: 0 });
+  logger.info("amplitude_initialized");
+}
+
+export function track(
+  event: string,
+  userId: string,
+  properties?: Record<string, unknown>,
+): void {
+  if (!apiKey) return;
+  ampTrack(event, properties, { user_id: userId });
+}

--- a/apps/api/src/routes/session-routes.ts
+++ b/apps/api/src/routes/session-routes.ts
@@ -20,6 +20,7 @@ import { decrypt } from "../lib/crypto.js";
 import { BaseError, ServiceError } from "../lib/error.js";
 import { logger } from "../lib/logger.js";
 import { Span } from "../lib/trace-decorator.js";
+import { track } from "../lib/tracking.js";
 import { requireInternalToken } from "../middleware/internal-auth.js";
 
 import type { AppBindings } from "../types.js";
@@ -485,9 +486,9 @@ export function registerSessionInternalRoutes(app: OpenAPIHono<AppBindings>) {
     requireInternalToken(c);
     const input = c.req.valid("json");
 
-    // Verify botId exists
+    // Verify botId exists and get owner userId for tracking
     const [bot] = await db
-      .select({ id: bots.id })
+      .select({ id: bots.id, userId: bots.userId })
       .from(bots)
       .where(eq(bots.id, input.botId));
 
@@ -498,6 +499,12 @@ export function registerSessionInternalRoutes(app: OpenAPIHono<AppBindings>) {
     const now = new Date().toISOString();
     const id = createId();
     const normalizedSessionKey = normalizeStoredSessionKey(input.sessionKey);
+
+    // Check if session already exists (to distinguish insert vs update)
+    const [existing] = await db
+      .select({ id: sessions.id })
+      .from(sessions)
+      .where(eq(sessions.sessionKey, normalizedSessionKey));
 
     // Upsert on sessionKey
     await db
@@ -553,6 +560,13 @@ export function registerSessionInternalRoutes(app: OpenAPIHono<AppBindings>) {
         bot_id: input.botId,
       });
     }
+
+    // Track: new session = session_start, every upsert = task_number
+    const channelType = created.channelType ?? "unknown";
+    if (!existing) {
+      track("session_start", bot.userId, { channel_type: channelType });
+    }
+    track("task_number", bot.userId, { channel_type: channelType });
 
     return c.json(formatSession(created), 201);
   });

--- a/apps/web/src/components/channel-setup/discord-setup-view.tsx
+++ b/apps/web/src/components/channel-setup/discord-setup-view.tsx
@@ -70,7 +70,10 @@ export function DiscordSetupView({
         return;
       }
       toast.success(`Discord server "${data?.teamName ?? ""}" connected!`);
-      track("channel_ready", { channel: "discord" });
+      track("channel_ready", {
+        channel: "discord",
+        channel_type: "discord_token",
+      });
       identify({ channels_connected: 1 });
       onConnected();
     } catch {

--- a/apps/web/src/components/channel-setup/slack-oauth-view.tsx
+++ b/apps/web/src/components/channel-setup/slack-oauth-view.tsx
@@ -210,7 +210,7 @@ export function SlackOAuthView({
         return;
       }
       toast.success(`Slack workspace "${data?.teamName ?? ""}" connected!`);
-      track("channel_ready", { channel: "slack" });
+      track("channel_ready", { channel: "slack", channel_type: "slack_token" });
       identify({ channels_connected: 1 });
       onConnected();
     } catch {

--- a/apps/web/src/pages/sessions.tsx
+++ b/apps/web/src/pages/sessions.tsx
@@ -99,7 +99,7 @@ export function SessionsPage() {
   const { id } = useParams<{ id: string }>();
 
   useEffect(() => {
-    if (id) track("session_start");
+    if (id) track("session_detail_view");
   }, [id]);
 
   const { data: session } = useQuery({
@@ -240,6 +240,7 @@ export function SessionsPage() {
                           target="_blank"
                           rel="noreferrer"
                           className="text-[11px] text-emerald-600 shrink-0 hover:underline"
+                          onClick={() => track("channel_detail_deploy_preview")}
                         >
                           Preview <ExternalLink size={9} className="inline" />
                         </a>

--- a/apps/web/src/pages/slack-oauth-callback.tsx
+++ b/apps/web/src/pages/slack-oauth-callback.tsx
@@ -5,6 +5,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { identify, track } from "@/lib/tracking";
 import { useQueryClient } from "@tanstack/react-query";
 import { CheckCircle, Loader2 } from "lucide-react";
 import { useEffect } from "react";
@@ -31,6 +32,8 @@ export function SlackOAuthCallbackPage() {
       // Success path: show brief confirmation, then redirect
       queryClient.invalidateQueries({ queryKey: ["channels"] });
       toast.success(`Slack workspace "${teamName}" connected!`);
+      track("channel_ready", { channel: "slack", channel_type: "slack_auth" });
+      identify({ channels_connected: 1 });
 
       const timer = setTimeout(() => {
         if (returnTo === "/onboarding") {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@amplitude/analytics-node':
+        specifier: ^1.5.43
+        version: 1.5.43
       '@hono/node-server':
         specifier: ^1.13.8
         version: 1.19.9(hono@4.12.2)
@@ -267,6 +270,12 @@ packages:
 
   '@amplitude/analytics-core@2.40.2':
     resolution: {integrity: sha512-bKQyB0gFEmYiI1pHJSaCjXlml0NvQsx/S8RXoIVmI+pwh6hb1y6NlsHx4BJaYpUxw8/2ww+1UClSUMkP/aFNjQ==}
+
+  '@amplitude/analytics-core@2.41.3':
+    resolution: {integrity: sha512-UujceP+22zVi/0hl4ccrKEQ94rsCTOVtNZIeM2UxELYLZj24fqjUgdTX+x+gUuzgzOSDRiohkRLwRt6hiBmgmw==}
+
+  '@amplitude/analytics-node@1.5.43':
+    resolution: {integrity: sha512-L19baK7bmITYzsV0tBzL1WAZX0Njrf9oowJ+RnpEfg8dz67Xox54Z+GrjRdNY9PQMyoPA2FJTRPSC2aVzDllhw==}
 
   '@amplitude/analytics-types@1.4.0':
     resolution: {integrity: sha512-RiMPHBqdrJ8ktTqG+Wzj2htnN/PCG9jGZG0SXtTFnWwVvcAJYbYm55/nrP1TTyrx1OlLhvF2VG3lVUP/xGAU8w==}
@@ -3863,7 +3872,7 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   thread-stream@4.0.0:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
@@ -4449,6 +4458,9 @@ packages:
   zen-observable-ts@1.1.0:
     resolution: {integrity: sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==}
 
+  zen-observable@0.10.0:
+    resolution: {integrity: sha512-iI3lT0iojZhKwT5DaFy2Ce42n3yFcLdFyOh01G7H0flMY60P8MJuVFEoJoNwXlmAyQ45GrjL6AcZmmlv8A5rbw==}
+
   zen-observable@0.8.15:
     resolution: {integrity: sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==}
 
@@ -4499,6 +4511,19 @@ snapshots:
       safe-json-stringify: 1.2.0
       tslib: 2.8.1
       zen-observable-ts: 1.1.0
+
+  '@amplitude/analytics-core@2.41.3':
+    dependencies:
+      '@amplitude/analytics-connector': 1.6.4
+      '@types/zen-observable': 0.8.3
+      safe-json-stringify: 1.2.0
+      tslib: 2.8.1
+      zen-observable: 0.10.0
+
+  '@amplitude/analytics-node@1.5.43':
+    dependencies:
+      '@amplitude/analytics-core': 2.41.3
+      tslib: 2.8.1
 
   '@amplitude/analytics-types@1.4.0': {}
 
@@ -8879,6 +8904,8 @@ snapshots:
     dependencies:
       '@types/zen-observable': 0.8.3
       zen-observable: 0.8.15
+
+  zen-observable@0.10.0: {}
 
   zen-observable@0.8.15: {}
 


### PR DESCRIPTION
## Summary
- Add server-side Amplitude SDK (`@amplitude/analytics-node`) for backend event tracking
- Track `session_start` when a new IM session is created (Slack/Discord/Feishu)
- Track `task_number` on every session upsert (each user conversation)
- Add `channel_detail_deploy_preview` click tracking on Preview links
- Add `channel_type` property to `channel_ready` events (`slack_auth`, `slack_token`, `discord_token`)
- Add `channel_ready` tracking to Slack OAuth callback page
- Fix: rename web-side `session_start` to `session_detail_view` (was incorrectly firing on dashboard page view instead of IM conversation)

## Event Summary

| Event | Location | Trigger |
|---|---|---|
| `session_start` | Backend (session upsert) | New session created from IM |
| `task_number` | Backend (session upsert) | Every conversation with Nexu |
| `channel_detail_deploy_preview` | Frontend (sessions.tsx) | Click Preview link |
| `channel_ready` + `channel_type` | Frontend (slack/discord setup) | Channel connected |
| `session_detail_view` | Frontend (sessions.tsx) | View session detail page |

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] New `tracking.test.ts` unit test passes (no-op when API key unset)
- [ ] Set `AMPLITUDE_API_KEY` in API `.env`, verify events appear in Amplitude dashboard
- [ ] Click Preview link on sessions page, verify `channel_detail_deploy_preview` fires
- [ ] Connect Slack via OAuth, verify `channel_ready` with `channel_type: "slack_auth"` fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced analytics tracking to capture comprehensive user interaction data including session creation and activity, channel integration events, and deployment preview access
  * Improved Discord and Slack channel integration tracking with granular channel type information
  * Added server-side analytics support for enhanced event tracking and insights

<!-- end of auto-generated comment: release notes by coderabbit.ai -->