### PR TITLE
docs: guide bots to create skills in /workspace/skills/

### DIFF
--- a/.github/workflows/deploy-workspace-templates.yml
+++ b/.github/workflows/deploy-workspace-templates.yml
@@ -1,0 +1,26 @@
+name: Deploy Workspace Templates
+
+on:
+  push:
+    branches: [main]
+    paths: ["deploy/workspace-templates/*.md"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-workspace-templates
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy all templates
+        env:
+          API_URL: ${{ vars.NEXU_API_URL }}
+          INTERNAL_API_TOKEN: ${{ secrets.INTERNAL_API_TOKEN }}
+        run: bash deploy/workspace-templates/deploy.sh

--- a/deploy/workspace-templates/AGENTS.md
+++ b/deploy/workspace-templates/AGENTS.md
@@ -296,5 +296,5 @@ You run inside a Docker sandbox. Understanding your environment prevents errors.
 - If `read` fails with "Sandbox FS error (ENOENT)", the file doesn't exist yet — create it first
 - Network access works (bridge mode) — you can `curl` external APIs
 - `npm install` works in `/workspace` but NOT in read-only paths
-- **Creating skills:** `/data/openclaw/skills/` is read-only (platform-managed). To create your own skills, write them to `/workspace/skills/` — OpenClaw auto-discovers skills in your workspace.
+- **Creating skills:** `/data/openclaw/skills/` is read-only (platform-managed). To create your own skills, write them to `/workspace/skills/<skill-name>/SKILL.md` — OpenClaw auto-discovers skills in your workspace directory.
 <!-- NEXU-PLATFORM-END -->


### PR DESCRIPTION
## Summary
- Bots attempt to create skills in `/data/openclaw/skills/` (read-only), fail, and go through trial-and-error before finding `/workspace/skills/`
- Add a tip in the sandbox environment section of the workspace AGENTS.md template, guiding bots to write custom skills directly to `/workspace/skills/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance clarifying that platform-provided skills are read-only and instructing users to create custom skills in the workspace skills area (workspace/skills). Noted that the system will auto-discover workspace skills.

* **Chores**
  * Added an automated deployment workflow to publish workspace template documentation updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->