### PR TITLE
fix: enable stable Feishu streaming and fix session key format

### DIFF
--- a/apps/api/src/lib/config-generator.ts
+++ b/apps/api/src/lib/config-generator.ts
@@ -429,6 +429,8 @@ export async function generatePoolConfig(
     config.channels.feishu = {
       enabled: true,
       connectionMode: "websocket",
+      streaming: true,
+      renderMode: "card",
       dmPolicy: "open",
       groupPolicy: "open",
       requireMention: true,

--- a/apps/api/src/routes/session-routes.ts
+++ b/apps/api/src/routes/session-routes.ts
@@ -433,7 +433,7 @@ class SessionSyncTraceHandler {
 
         for (const chat of allChats) {
           const sessionKey = normalizeStoredSessionKey(
-            `feishu_${ch.accountId}_${chat.chat_id}`,
+            `agent:${ch.botId}:feishu:channel:${chat.chat_id}`,
           );
           const title = chat.name || chat.chat_id;
 

--- a/packages/shared/src/schemas/openclaw-config.ts
+++ b/packages/shared/src/schemas/openclaw-config.ts
@@ -150,15 +150,19 @@ const feishuAccountSchema = z.object({
   appSecret: z.string(),
 });
 
-const feishuChannelSchema = z.object({
-  enabled: z.boolean().optional(),
-  connectionMode: z.enum(["websocket", "webhook"]).optional(),
-  dmPolicy: z.enum(["pairing", "allowlist", "open"]).optional(),
-  groupPolicy: z.enum(["open", "allowlist", "disabled"]).optional(),
-  requireMention: z.boolean().optional(),
-  allowFrom: z.array(z.string()).optional(),
-  accounts: z.record(z.string(), feishuAccountSchema),
-});
+const feishuChannelSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    connectionMode: z.enum(["websocket", "webhook"]).optional(),
+    streaming: z.boolean().optional(),
+    renderMode: z.enum(["auto", "raw", "card"]).optional(),
+    dmPolicy: z.enum(["pairing", "allowlist", "open"]).optional(),
+    groupPolicy: z.enum(["open", "allowlist", "disabled"]).optional(),
+    requireMention: z.boolean().optional(),
+    allowFrom: z.array(z.string()).optional(),
+    accounts: z.record(z.string(), feishuAccountSchema),
+  })
+  .passthrough();
 
 const channelsConfigSchema = z
   .object({


### PR DESCRIPTION
## Summary
- Add `streaming: true` and `renderMode: "card"` to Feishu channel config so all replies consistently use Card Kit streaming output, instead of only triggering for markdown-heavy content under `auto` mode.
- Fix Feishu session sync `sessionKey` format from legacy `feishu_{accountId}_{chatId}` to standard `agent:{botId}:feishu:channel:{chatId}` (matching Discord's pattern), resolving "No matching session found for chatId" errors during artifact deploy in Feishu group chats.

## Test plan
- [ ] Deploy and verify Feishu replies always use streaming card output
- [ ] Trigger artifact deploy in a Feishu group chat — should no longer fail with session not found
- [ ] Verify Feishu DM scenarios are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)