### PR TITLE
fix: disable sandbox browser to prevent missing image error

### DIFF
--- a/apps/api/src/lib/config-generator.ts
+++ b/apps/api/src/lib/config-generator.ts
@@ -329,8 +329,7 @@ export async function generatePoolConfig(
                   },
                 },
                 browser: {
-                  enabled: true,
-                  allowHostControl: true,
+                  enabled: false,
                 },
                 prune: {
                   idleHours: 4,


### PR DESCRIPTION
## Summary
- Disable sandbox browser (`enabled: false`) in config-generator to fix production agent failures caused by missing `openclaw-sandbox-browser:bookworm-slim` Docker image

## Test plan
- [ ] Verify agents no longer fail with "Sandbox browser image not found" error after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)