### PR TITLE
Create _run-api-tests.yml and add CI support files

### DIFF
--- a/.github/workflows/_run-api-tests.yml
+++ b/.github/workflows/_run-api-tests.yml
@@ -1,0 +1,71 @@
+name: _run-api-tests (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+      test_tag:
+        required: true
+        type: string
+    secrets:
+      ENV_FILE:
+        required: true
+      NEXU_AUTOMATION_PAT:
+        required: true
+
+jobs:
+  run:
+    name: Run on ${{ inputs.environment }}
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+
+    steps:
+      - name: Checkout Nexu_Automation
+        uses: actions/checkout@v4
+        with:
+          repository: refly-ai/Nexu_Automation
+          token: ${{ secrets.NEXU_AUTOMATION_PAT }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Write .env file
+        env:
+          ENV_FILE: ${{ secrets.ENV_FILE }}
+        run: |
+          printf '%s' "$ENV_FILE" > .env.${{ inputs.environment }}
+          echo "Written $(wc -l < .env.${{ inputs.environment }}) lines to .env.${{ inputs.environment }}"
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run API tests
+        run: >
+          ENV=${{ inputs.environment }}
+          npx playwright test tests/api-generated/
+          --project=api
+          --grep "${{ inputs.test_tag }}"
+
+      - name: Generate Allure Report
+        if: always()
+        run: |
+          npm install -g allure-commandline --quiet
+          allure generate allure-results -o allure-report --clean
+
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: report-${{ inputs.environment }}-${{ github.run_number }}
+          path: |
+            reports/
+            allure-report/
+          retention-days: 14


### PR DESCRIPTION
Add CI support files for reusable API test execution.

## Summary
- Add a reusable GitHub Actions workflow for running API tests across environments.
- Set up Node.js, browser dependencies, filtered test execution, and automatic Allure report generation.
- Upload test artifacts with configurable environment variables and 14-day retention.