### PR TITLE
fix: safely resolve pino-pretty transport to prevent crash in production

### DIFF
--- a/apps/api/src/lib/logger.ts
+++ b/apps/api/src/lib/logger.ts
@@ -3,6 +3,25 @@ import pino from "pino";
 const env = process.env.DD_ENV ?? process.env.NODE_ENV ?? "development";
 const version = process.env.DD_VERSION ?? process.env.COMMIT_HASH ?? "unknown";
 
+function getPinoTransport(): pino.TransportSingleOptions | undefined {
+  if (env === "production") return undefined;
+  try {
+    require.resolve("pino-pretty");
+    return {
+      target: "pino-pretty",
+      options: {
+        colorize: true,
+        ignore: "pid,hostname,service,env,version",
+        translateTime: "HH:MM:ss.l",
+      },
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+const transport = getPinoTransport();
+
 export const logger = pino({
   level: process.env.LOG_LEVEL ?? (env === "production" ? "info" : "debug"),
   base: {
@@ -11,16 +30,5 @@ export const logger = pino({
     version,
   },
   timestamp: pino.stdTimeFunctions.isoTime,
-  ...(env !== "production"
-    ? {
-        transport: {
-          target: "pino-pretty",
-          options: {
-            colorize: true,
-            ignore: "pid,hostname,service,env,version",
-            translateTime: "HH:MM:ss.l",
-          },
-        },
-      }
-    : {}),
+  ...(transport ? { transport } : {}),
 });


### PR DESCRIPTION
## Summary

- **Root cause:** `DD_ENV=prod` in K8s secret, but logger checks `env !== "production"` → evaluates to `true` → tries to load `pino-pretty` which isn't in the production image → crash
- Adds `require.resolve("pino-pretty")` check before configuring transport, so it gracefully falls back when the module isn't available

## Test plan

- [ ] Verify API pod starts without CrashLoopBackOff after deploy
- [ ] Verify `pino-pretty` still works in local dev (`pnpm --filter @nexu/api dev`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved logging configuration handling to provide better consistency and reliability across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->