### PR TITLE
fix: route /toolkit-icons/ to app worker

### DIFF
--- a/apps/router/src/index.ts
+++ b/apps/router/src/index.ts
@@ -25,7 +25,8 @@ export default {
       url.pathname.startsWith("/workspace") ||
       url.pathname.startsWith("/auth") ||
       url.pathname.startsWith("/invite") ||
-      url.pathname.startsWith("/assets/")
+      url.pathname.startsWith("/assets/") ||
+      url.pathname.startsWith("/toolkit-icons/")
     ) {
       return env.APP.fetch(request);
     }


### PR DESCRIPTION
## Summary

- Toolkit icon SVGs on the skills page returned 404 because the Cloudflare router didn't forward `/toolkit-icons/*` to the app worker
- Adds `/toolkit-icons/` to the router's app path list

## Test plan

- [ ] Visit `/workspace/skills` — icons should show SVGs instead of Google S2 favicons