### PR TITLE
perf(gateway): replace CLI liveness probe with HTTP fetch

### DIFF
--- a/apps/gateway/src/env.ts
+++ b/apps/gateway/src/env.ts
@@ -58,7 +58,12 @@ const envSchema = z.object({
     .number()
     .int()
     .positive()
-    .default(10000),
+    .default(15000),
+  RUNTIME_GATEWAY_HTTP_PROBE_PORT: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(18789),
   RUNTIME_GATEWAY_LIVENESS_INTERVAL_MS: z.coerce
     .number()
     .int()
@@ -68,7 +73,7 @@ const envSchema = z.object({
     .number()
     .int()
     .positive()
-    .default(30000),
+    .default(120000),
   RUNTIME_GATEWAY_FAIL_DEGRADED_THRESHOLD: z.coerce
     .number()
     .int()

--- a/apps/gateway/src/gateway-health.ts
+++ b/apps/gateway/src/gateway-health.ts
@@ -25,23 +25,74 @@ export interface GatewayProbeFailure {
 
 export type GatewayProbeResult = GatewayProbeSuccess | GatewayProbeFailure;
 
-function buildProbeArgs(probeType: GatewayProbeType): string[] {
-  const args: string[] = [];
+// ---------------------------------------------------------------------------
+// HTTP-based liveness probe — hits /health on the gateway HTTP port.
+// This avoids spawning a full Node.js CLI process (~240 MB) per check.
+// ---------------------------------------------------------------------------
 
+async function runHttpLivenessProbe(): Promise<GatewayProbeResult> {
+  const startedAt = Date.now();
+  const checkedAt = new Date().toISOString();
+  const url = `http://127.0.0.1:${env.RUNTIME_GATEWAY_HTTP_PROBE_PORT}/health`;
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(
+      () => controller.abort(),
+      env.RUNTIME_GATEWAY_CLI_TIMEOUT_MS,
+    );
+
+    const response = await fetch(url, { signal: controller.signal });
+    clearTimeout(timeout);
+
+    const latencyMs = Date.now() - startedAt;
+
+    if (!response.ok) {
+      return {
+        ok: false,
+        probeType: "liveness",
+        checkedAt,
+        latencyMs,
+        errorCode: "cli_exit_nonzero",
+        exitCode: response.status,
+      };
+    }
+
+    const body = (await response.json()) as Record<string, unknown>;
+    if (body.ok !== true) {
+      return {
+        ok: false,
+        probeType: "liveness",
+        checkedAt,
+        latencyMs,
+        errorCode: "cli_exit_nonzero",
+      };
+    }
+
+    return { ok: true, probeType: "liveness", checkedAt, latencyMs };
+  } catch (err) {
+    const latencyMs = Date.now() - startedAt;
+    const isAbort = err instanceof DOMException && err.name === "AbortError";
+    return {
+      ok: false,
+      probeType: "liveness",
+      checkedAt,
+      latencyMs,
+      errorCode: isAbort ? "cli_timeout" : "cli_spawn_error",
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI-based deep probe — still uses `openclaw status --deep` because the
+// deep status data is only available via the WebSocket protocol, not HTTP.
+// ---------------------------------------------------------------------------
+
+function buildDeepProbeArgs(): string[] {
+  const args: string[] = [];
   if (env.OPENCLAW_PROFILE) {
     args.push("--profile", env.OPENCLAW_PROFILE);
   }
-
-  if (probeType === "liveness") {
-    args.push(
-      "health",
-      "--json",
-      "--timeout",
-      String(env.RUNTIME_GATEWAY_CLI_TIMEOUT_MS),
-    );
-    return args;
-  }
-
   args.push(
     "status",
     "--deep",
@@ -70,12 +121,10 @@ function classifyExecError(error: ExecFileException): {
   return { errorCode: "cli_spawn_error" };
 }
 
-async function runCliProbe(
-  probeType: GatewayProbeType,
-): Promise<GatewayProbeResult> {
+async function runCliDeepProbe(): Promise<GatewayProbeResult> {
   const startedAt = Date.now();
   const checkedAt = new Date().toISOString();
-  const args = buildProbeArgs(probeType);
+  const args = buildDeepProbeArgs();
 
   const executionResult = await new Promise<
     | { ok: true; stdout: string }
@@ -112,7 +161,7 @@ async function runCliProbe(
   if (!executionResult.ok) {
     return {
       ok: false,
-      probeType,
+      probeType: "deep",
       checkedAt,
       latencyMs,
       errorCode: executionResult.errorCode,
@@ -125,7 +174,7 @@ async function runCliProbe(
     if (typeof parsed !== "object" || parsed === null) {
       return {
         ok: false,
-        probeType,
+        probeType: "deep",
         checkedAt,
         latencyMs,
         errorCode: "parse_error",
@@ -134,27 +183,22 @@ async function runCliProbe(
   } catch {
     return {
       ok: false,
-      probeType,
+      probeType: "deep",
       checkedAt,
       latencyMs,
       errorCode: "parse_error",
     };
   }
 
-  return {
-    ok: true,
-    probeType,
-    checkedAt,
-    latencyMs,
-  };
+  return { ok: true, probeType: "deep", checkedAt, latencyMs };
 }
 
 export async function probeGatewayLiveness(): Promise<GatewayProbeResult> {
-  return runCliProbe("liveness");
+  return runHttpLivenessProbe();
 }
 
 export async function probeGatewayDeepHealth(): Promise<GatewayProbeResult> {
-  return runCliProbe("deep");
+  return runCliDeepProbe();
 }
 
 const MAX_READY_ATTEMPTS = 120; // give up after ~2 minutes


### PR DESCRIPTION
## Summary

- **Liveness probe**: Replace `execFile("openclaw health")` with `fetch("http://127.0.0.1:18789/health")` — from forking a 240MB Node.js process to a lightweight HTTP request
- **Deep probe interval**: 30s → 120s (still uses CLI since deep status is only available via WebSocket protocol)
- **CLI timeout**: 10s → 15s to reduce false `cli_timeout` failures on deep probes
- New `RUNTIME_GATEWAY_HTTP_PROBE_PORT` env var (default 18789)

## Problem

Production `nexu-gateway-1` pod was consuming 1016m CPU and 1730Mi memory. Investigation revealed the sidecar was forking a full Node.js process every 5 seconds for liveness checks, each consuming ~240MB RSS. Combined with deep probes every 30 seconds, this produced 14 Node.js child processes per minute. These processes also became zombies after exiting (PID 1 not reaping children).

```
PID=78   PPID=1  Threads=1  RSS=         Name=openclaw  ← zombie
PID=124  PPID=1  Threads=1  RSS=         Name=openclaw  ← zombie
PID=278  PPID=1  Threads=1  RSS=         Name=openclaw  ← zombie
...(10 zombies total)
```

The OpenClaw gateway already exposes an HTTP `/health` endpoint:
```json
GET http://127.0.0.1:18789/health → {"ok":true,"status":"live"}
```

## Expected Impact

| Metric | Before | After |
|--------|--------|-------|
| Probe process forks/min | 14 (12 liveness + 2 deep) | 0.5 (deep only) |
| Per-liveness memory overhead | ~240 MB (Node.js process) | ~0 (HTTP fetch) |
| Zombie processes | Continuously accumulating | Only from deep probe (every 2min) |

## Test plan

- [x] `pnpm --filter @nexu/gateway typecheck` ✅
- [x] `pnpm --filter @nexu/gateway exec biome check src/gateway-health.ts src/env.ts` ✅
- [ ] After deployment, verify CPU/memory drop via `kubectl top pod`
- [ ] Confirm liveness probe latency drops from 1.8-4.7s to <100ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)