### PR TITLE
fix: remove multi-bot restriction for integrations

### DIFF
--- a/apps/api/src/routes/__tests__/integration-routes.test.ts
+++ b/apps/api/src/routes/__tests__/integration-routes.test.ts
@@ -598,10 +598,10 @@ describe("Integration Routes", () => {
 
       expect(res.status).toBe(400);
       const body = await res.json();
-      expect(body.message).toContain("exactly one active or paused bot");
+      expect(body.message).toContain("at least one bot assigned to a pool");
     });
 
-    it("oauth2 connect rejects users with multiple active or paused bots", async () => {
+    it("oauth2 connect succeeds for users with multiple bots (uses first pooled bot)", async () => {
       await seedToolkit(setupPool, { slug: "notion" });
       await seedBot(setupPool, {
         id: "bot-1",
@@ -620,9 +620,8 @@ describe("Integration Routes", () => {
         body: JSON.stringify({ toolkitSlug: "notion" }),
       });
 
-      expect(res.status).toBe(409);
-      const body = await res.json();
-      expect(body.message).toContain("single bot");
+      // Should not be rejected — multi-bot users are allowed
+      expect(res.status).not.toBe(409);
     });
 
     it("oauth2 connect rejects users whose only bot has no pool assignment", async () => {
@@ -796,7 +795,7 @@ describe("Integration Routes", () => {
       expect(rows[0].oauth_state).toBe("pending-state");
     });
 
-    it("refresh rejects users with multiple active or paused bots", async () => {
+    it("refresh succeeds for users with multiple bots (uses first pooled bot)", async () => {
       await seedToolkit(setupPool, { slug: "notion" });
       await seedBot(setupPool, {
         id: "bot-1",
@@ -824,9 +823,8 @@ describe("Integration Routes", () => {
         },
       );
 
-      expect(res.status).toBe(409);
-      const body = await res.json();
-      expect(body.message).toContain("single bot");
+      // Should not be rejected — multi-bot users are allowed
+      expect(res.status).not.toBe(409);
     });
 
     it("refresh on active api_key_user integration returns 200 idempotently", async () => {

--- a/apps/api/src/routes/integration-routes.ts
+++ b/apps/api/src/routes/integration-routes.ts
@@ -237,39 +237,14 @@ async function resolveComposioUserContext(
       ),
     );
 
-  if (userBots.length === 0) {
+  // Find any bot with a pool to look up COMPOSIO_API_KEY
+  const bot = userBots.find((b) => b.poolId);
+  if (!bot?.poolId) {
     return {
       ok: false,
       status: 400,
       message:
-        "Composio integrations require exactly one active or paused bot for this user",
-    };
-  }
-
-  if (userBots.length > 1) {
-    return {
-      ok: false,
-      status: 409,
-      message:
-        "Composio integrations are only supported for users with a single bot",
-    };
-  }
-
-  const bot = userBots[0];
-  if (!bot) {
-    return {
-      ok: false,
-      status: 400,
-      message:
-        "Composio integrations require exactly one active or paused bot for this user",
-    };
-  }
-  if (!bot.poolId) {
-    return {
-      ok: false,
-      status: 400,
-      message:
-        "Composio integrations require the user's bot to be assigned to a pool",
+        "Composio integrations require at least one bot assigned to a pool",
     };
   }
 

--- a/apps/web/src/pages/oauth-callback.tsx
+++ b/apps/web/src/pages/oauth-callback.tsx
@@ -12,7 +12,10 @@ import {
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import "@/lib/api";
-import { postApiV1IntegrationsByIntegrationIdRefresh } from "../../lib/api/sdk.gen";
+import {
+  getApiV1Channels,
+  postApiV1IntegrationsByIntegrationIdRefresh,
+} from "../../lib/api/sdk.gen";
 
 // ─── Types ───────────────────────────────────────────────────
 
@@ -21,6 +24,11 @@ interface ToolkitInfo {
   toolkitDisplayName: string;
   toolkitIconUrl: string;
   toolkitFallbackIconUrl?: string;
+}
+
+interface SlackDeeplink {
+  nativeUrl: string;
+  webUrl: string;
 }
 
 type CallbackState =
@@ -33,6 +41,7 @@ type CallbackState =
       toolkitSlug: string;
       toolkitIconUrl: string;
       toolkitFallbackIconUrl?: string;
+      slackDeeplink?: SlackDeeplink;
     }
   | { phase: "error"; message: string };
 
@@ -127,6 +136,33 @@ export function OAuthCallbackPage() {
 
           const source = refreshed.source;
           if (source === "chat") {
+            // Fetch Slack channel info to build a deeplink back to the DM
+            let slackDeeplink: SlackDeeplink | undefined;
+            try {
+              const { data: channelsData } = await getApiV1Channels();
+              const slackChannel = channelsData?.channels?.find(
+                (ch) => ch.channelType === "slack",
+              );
+              if (slackChannel) {
+                const accountId = slackChannel.accountId ?? "";
+                const botUserId = slackChannel.botUserId;
+                const teamId = accountId.replace(/^slack-[^-]+-/, "");
+                if (teamId && botUserId) {
+                  slackDeeplink = {
+                    nativeUrl: `slack://user?team=${teamId}&id=${botUserId}`,
+                    webUrl: `https://app.slack.com/client/${teamId}/messages/${botUserId}`,
+                  };
+                } else if (teamId) {
+                  slackDeeplink = {
+                    nativeUrl: `slack://open?team=${teamId}`,
+                    webUrl: `https://app.slack.com/client/${teamId}`,
+                  };
+                }
+              }
+            } catch {
+              // Best effort — fall back to generic links
+            }
+
             setCallbackState({
               phase: "success",
               source: "chat",
@@ -135,6 +171,7 @@ export function OAuthCallbackPage() {
               toolkitSlug: refreshed.toolkit.slug,
               toolkitIconUrl: refreshed.toolkit.iconUrl,
               toolkitFallbackIconUrl: refreshed.toolkit.fallbackIconUrl,
+              slackDeeplink,
             });
           } else {
             // page source or undefined — redirect
@@ -310,18 +347,34 @@ function SuccessCard({
         {/* Return buttons for chat source */}
         {state.source === "chat" && (
           <div className="space-y-2.5 mb-4">
-            <a
-              href="https://slack.com/open"
+            <button
+              type="button"
+              onClick={() => {
+                const deeplink = state.slackDeeplink;
+                const nativeUrl = deeplink?.nativeUrl ?? "slack://open";
+                const webUrl = deeplink?.webUrl ?? "https://slack.com/open";
+
+                // Try native Slack app first; fall back to web after 3s
+                const fallbackTimer = setTimeout(() => {
+                  window.open(webUrl, "_blank", "noopener,noreferrer");
+                }, 3000);
+                const cancelFallback = () => {
+                  clearTimeout(fallbackTimer);
+                  window.removeEventListener("blur", cancelFallback);
+                };
+                window.addEventListener("blur", cancelFallback);
+                window.location.href = nativeUrl;
+              }}
               className={cn(
                 "flex items-center justify-center gap-2 w-full px-4 py-2.5 rounded-xl",
                 "bg-[#4A154B] text-white text-[13px] font-medium",
-                "hover:bg-[#3e1240] transition-colors",
+                "hover:bg-[#3e1240] transition-colors cursor-pointer",
               )}
             >
               <SlackIcon size={16} />
               Return to Slack
               <ExternalLink size={12} className="opacity-60" />
-            </a>
+            </button>
             <a
               href="https://discord.com/channels/@me"
               className={cn(


### PR DESCRIPTION
## Summary
- Remove the 409 rejection in `resolveComposioUserContext()` when users have multiple bots — integrations are one-to-one mapped to users, not bots
- Pick the first bot with a pool to resolve `COMPOSIO_API_KEY` instead of requiring exactly one bot
- Improve OAuth callback success page: "Return to Slack" now deeplinks to the bot's DM (native app first, web fallback after 3s)

## Test plan
- [ ] User with multiple bots can connect a new integration (previously got 409)
- [ ] User with multiple bots can refresh integration status
- [ ] User with single bot still works as before
- [ ] OAuth callback from Slack shows "Return to Slack" button that opens DM with bot
- [ ] Existing unit tests updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-bot users can now successfully connect OAuth integrations (previously restricted to single-bot setups).
  * Slack integration now intelligently opens the native Slack app after authorization, with automatic fallback to the web version if unavailable.

* **Bug Fixes**
  * Updated pool-based bot selection logic for more flexible multi-bot deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->