### PR TITLE
fix: show return button only for user's actual chat channel

### DIFF
--- a/apps/web/src/pages/oauth-callback.tsx
+++ b/apps/web/src/pages/oauth-callback.tsx
@@ -145,9 +145,7 @@ export function OAuthCallbackPage() {
               const channels = channelsData?.channels ?? [];
               chatChannels = [
                 ...new Set(
-                  channels
-                    .map((ch) => ch.channelType)
-                    .filter((t) => !!t),
+                  channels.map((ch) => ch.channelType).filter((t) => !!t),
                 ),
               ];
 


### PR DESCRIPTION
## Summary
- On the OAuth callback success page, only show "Return to Slack" when the user has a Slack channel connected, and "Return to Discord" when they have a Discord channel
- Previously both buttons were always shown regardless of which platform the user came from
- Fetches the user's channels via API and filters buttons by `channelType`

## Test plan
- [ ] User with only Slack sees only "Return to Slack" button after OAuth success
- [ ] User with only Discord sees only "Return to Discord" button
- [ ] User with both Slack and Discord sees both buttons
- [ ] If channels API fails, no return buttons shown (graceful degradation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth callback page now detects available chat channels and shows channel-specific return actions (e.g., Slack, Discord) so users see only relevant options.
  * Return actions are conditionally displayed based on detected channels, replacing previous hard-coded options.

* **Bug Fixes**
  * Improved fallback behavior for error cases to ensure appropriate return actions are shown when channel detection is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->