### PR TITLE
fix(gateway): defer Feishu channel init to avoid probe timeout

### DIFF
--- a/apps/gateway/src/bootstrap.ts
+++ b/apps/gateway/src/bootstrap.ts
@@ -4,7 +4,7 @@ import { readFile, readdir, rename, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { checkSlackTokens, registerPool } from "./api.js";
-import { fetchInitialConfig } from "./config.js";
+import { fetchInitialConfig, pollLatestConfig } from "./config.js";
 import { env, envWarnings } from "./env.js";
 import { waitGatewayReady } from "./gateway-health.js";
 import { BaseError, GatewayError, logger } from "./log.js";
@@ -369,4 +369,23 @@ export async function bootstrapGateway(state: RuntimeState): Promise<void> {
   // Re-touch the config file so OpenClaw's file watcher picks up the
   // initial config that was written before the watcher was ready.
   await touchConfigFile();
+
+  // After other channels are ready and the event loop is idle, inject
+  // the full config (including Feishu) via hot-reload.  This avoids the
+  // 10 s Feishu bot-info probe timeout caused by event-loop saturation
+  // during concurrent Slack/Discord startup.
+  if (env.RUNTIME_DEFER_FEISHU_INIT) {
+    try {
+      const changed = await pollLatestConfig(state);
+      if (changed) {
+        logger.info("deferred feishu config injected via hot-reload");
+      }
+    } catch (error) {
+      const baseError = BaseError.from(error);
+      logger.warn(
+        { reason: baseError.message },
+        "failed to inject deferred feishu config; will retry in poll loop",
+      );
+    }
+  }
 }

--- a/apps/gateway/src/config.ts
+++ b/apps/gateway/src/config.ts
@@ -1,6 +1,7 @@
 import { chmod, mkdir, rename, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import {
+  type OpenClawConfig,
   openclawConfigSchema,
   runtimePoolConfigResponseSchema,
 } from "@nexu/shared";
@@ -71,6 +72,36 @@ export async function pollLatestConfig(state: RuntimeState): Promise<boolean> {
   return true;
 }
 
+/**
+ * Strip Feishu channels and bindings from the config so OpenClaw starts
+ * without them.  Feishu bot-info probes time out when the event loop is
+ * saturated by concurrent Slack/Discord initialization.  By deferring
+ * Feishu to a hot-reload cycle (after other channels are ready) the
+ * probes complete on an idle event loop.
+ */
+function stripFeishuFromConfig(config: OpenClawConfig): {
+  stripped: OpenClawConfig;
+  hadFeishu: boolean;
+} {
+  if (!config.channels.feishu) {
+    return { stripped: config, hadFeishu: false };
+  }
+
+  const { feishu: _, ...channelsWithoutFeishu } = config.channels;
+  const bindingsWithoutFeishu = config.bindings.filter(
+    (b) => b.match.channel !== "feishu",
+  );
+
+  return {
+    stripped: {
+      ...config,
+      channels: channelsWithoutFeishu,
+      bindings: bindingsWithoutFeishu,
+    },
+    hadFeishu: true,
+  };
+}
+
 export async function fetchInitialConfig(): Promise<void> {
   const response = await fetchJson(
     `/api/internal/pools/${env.RUNTIME_POOL_ID}/config`,
@@ -80,7 +111,19 @@ export async function fetchInitialConfig(): Promise<void> {
   );
 
   const payload = openclawConfigSchema.parse(response);
-  const configJson = JSON.stringify(payload, null, 2);
+
+  let configToWrite = payload;
+  if (env.RUNTIME_DEFER_FEISHU_INIT) {
+    const { stripped, hadFeishu } = stripFeishuFromConfig(payload);
+    if (hadFeishu) {
+      logger.info(
+        "deferred feishu channels from initial config; will inject via hot-reload",
+      );
+    }
+    configToWrite = stripped;
+  }
+
+  const configJson = JSON.stringify(configToWrite, null, 2);
   await atomicWriteConfig(configJson);
 
   // Write initial context — agentMeta not available from raw config endpoint,

--- a/apps/gateway/src/env.ts
+++ b/apps/gateway/src/env.ts
@@ -104,6 +104,7 @@ const envSchema = z.object({
     .int()
     .positive()
     .default(300_000),
+  RUNTIME_DEFER_FEISHU_INIT: booleanFromEnvSchema.default("true"),
 });
 
 function normalizeConfigPath(path: string): string {


### PR DESCRIPTION
## Summary

- Feishu bot-info probes time out (hardcoded 10s in OpenClaw) when 23+ Slack/Discord channels initialize concurrently via `Promise.all`, saturating the event loop
- Strip `channels.feishu` and Feishu-related bindings from the initial config so OpenClaw starts with only Slack + Discord
- After `waitGatewayReady()`, inject the full config (including Feishu) via `pollLatestConfig()`, triggering a hot-reload on an idle event loop
- New `RUNTIME_DEFER_FEISHU_INIT` env var (default `true`) to control this behavior

## Test plan

- [x] `pnpm typecheck && pnpm lint` pass
- [ ] After deploy, verify gateway logs show `deferred feishu channels from initial config` and `deferred feishu config injected via hot-reload`
- [ ] Verify Feishu bot responds to group chat messages (probe no longer times out)
- [ ] Set `RUNTIME_DEFER_FEISHU_INIT=false` to verify fallback to original behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)