### PR TITLE
feat(helm): add ECR authentication for gateway sandbox

### DIFF
--- a/deploy/helm/nexu/templates/gateway-deployment.yaml
+++ b/deploy/helm/nexu/templates/gateway-deployment.yaml
@@ -23,6 +23,9 @@ spec:
         {{- include "nexu.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: gateway
     spec:
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default (include "nexu.fullname" .) }}
+      {{- end }}
       containers:
         - name: gateway
           image: "{{ .Values.gateway.image.repository }}:{{ .Values.gateway.image.tag }}"
@@ -149,12 +152,97 @@ spec:
               mountPath: /var/lib/docker
             - name: openclaw-data
               mountPath: /data/openclaw
+            {{- if .Values.gateway.sandbox.ecr.enabled }}
+            - name: docker-config
+              mountPath: /root/.docker
+            {{- end }}
           resources:
             {{- toYaml .Values.gateway.sandbox.dindResources | nindent 12 }}
+        {{- if .Values.gateway.sandbox.ecr.enabled }}
+        # ECR credential refresher sidecar
+        # Generates docker config.json with ECR credentials and refreshes every 6 hours
+        # Requires IRSA: serviceAccount must have eks.amazonaws.com/role-arn annotation
+        # with a role that has ecr:GetAuthorizationToken permission
+        - name: ecr-refresher
+          image: {{ .Values.gateway.sandbox.ecr.image | quote }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              ECR_REGISTRY="{{ .Values.gateway.sandbox.ecr.registry }}"
+              REGION="{{ .Values.gateway.sandbox.ecr.region }}"
+              SANDBOX_IMAGE="{{ .Values.gateway.sandbox.sandboxImage }}"
+              REFRESH_INTERVAL={{ .Values.gateway.sandbox.ecr.refreshIntervalSeconds | default 21600 }}
+
+              refresh_ecr_token() {
+                echo "$(date -Iseconds) Refreshing ECR token for $ECR_REGISTRY..."
+                TOKEN=$(aws ecr get-login-password --region "$REGION")
+                if [ -z "$TOKEN" ]; then
+                  echo "$(date -Iseconds) ERROR: Failed to get ECR token"
+                  return 1
+                fi
+                AUTH=$(echo -n "AWS:$TOKEN" | base64 | tr -d '\n')
+                mkdir -p /docker-config
+                cat > /docker-config/config.json <<EOF
+              {
+                "auths": {
+                  "$ECR_REGISTRY": {
+                    "auth": "$AUTH"
+                  }
+                }
+              }
+              EOF
+                echo "$(date -Iseconds) ECR token refreshed successfully"
+              }
+
+              prepull_sandbox_image() {
+                echo "$(date -Iseconds) Waiting for Docker daemon..."
+                until docker info >/dev/null 2>&1; do
+                  sleep 2
+                done
+                echo "$(date -Iseconds) Pre-pulling sandbox image: $SANDBOX_IMAGE"
+                if docker pull "$SANDBOX_IMAGE"; then
+                  echo "$(date -Iseconds) Sandbox image pulled successfully"
+                else
+                  echo "$(date -Iseconds) WARNING: Failed to pull sandbox image"
+                fi
+              }
+
+              # Initial token refresh
+              refresh_ecr_token
+
+              # Pre-pull sandbox image in background
+              prepull_sandbox_image &
+
+              # Refresh loop
+              while true; do
+                sleep "$REFRESH_INTERVAL"
+                refresh_ecr_token || true
+              done
+          env:
+            - name: DOCKER_HOST
+              value: "tcp://localhost:2375"
+            - name: AWS_DEFAULT_REGION
+              value: {{ .Values.gateway.sandbox.ecr.region | quote }}
+          volumeMounts:
+            - name: docker-config
+              mountPath: /docker-config
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+        {{- end }}
         {{- end }}
       volumes:
         - name: openclaw-config
           emptyDir: {}
+        {{- if and .Values.gateway.sandbox.enabled .Values.gateway.sandbox.ecr.enabled }}
+        - name: docker-config
+          emptyDir: {}
+        {{- end }}
   volumeClaimTemplates:
     - metadata:
         name: openclaw-data

--- a/deploy/helm/nexu/templates/serviceaccount.yaml
+++ b/deploy/helm/nexu/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name | default (include "nexu.fullname" .) }}
+  namespace: {{ include "nexu.namespace" . }}
+  labels:
+    {{- include "nexu.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/nexu/values.yaml
+++ b/deploy/helm/nexu/values.yaml
@@ -1,6 +1,16 @@
 nameOverride: ""
 fullnameOverride: ""
 
+serviceAccount:
+  # Set to true to create a ServiceAccount for gateway pods
+  # Required for ECR authentication via IRSA
+  create: false
+  # Name of the ServiceAccount (defaults to release fullname)
+  name: ""
+  # Annotations for the ServiceAccount
+  # For IRSA, add: eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT:role/ROLE_NAME
+  annotations: {}
+
 namespace:
   create: false
   name: nexu
@@ -116,6 +126,18 @@ gateway:
         cpu: "1"
         memory: 1Gi
     dindStorageSize: 10Gi
+    # ECR authentication for private sandbox images
+    # Requires IRSA: serviceAccount.create=true with proper IAM role annotation
+    ecr:
+      enabled: false
+      # AWS CLI image for ECR credential refresh
+      image: "amazon/aws-cli:2.15.0"
+      # ECR registry URL (e.g., 123456789.dkr.ecr.us-east-1.amazonaws.com)
+      registry: ""
+      # AWS region for ECR
+      region: "us-east-1"
+      # Token refresh interval in seconds (default: 6 hours, ECR tokens expire in 12h)
+      refreshIntervalSeconds: 21600
   hpa:
     enabled: true
     minReplicas: 1


### PR DESCRIPTION
## Summary
- Add ServiceAccount template with IRSA annotation support
- Add ECR refresher sidecar for automatic ECR authentication
- Pre-pull sandbox image on startup

## Problem
dind container cannot inherit Kubernetes imagePullSecrets. When sandbox image is in private ECR, dind fails to pull it.

## Solution
Add `ecr-refresher` sidecar that:
1. Uses AWS CLI to get ECR authorization token (via IRSA)
2. Generates docker config.json and writes to shared volume
3. Refreshes token every 6 hours (ECR tokens expire in 12h)
4. Pre-pulls sandbox image after dind is ready

## Configuration
```yaml
serviceAccount:
  create: true
  annotations:
    eks.amazonaws.com/role-arn: "arn:aws:iam::xxx:role/xxx"

gateway:
  sandbox:
    ecr:
      enabled: true
      registry: "xxx.dkr.ecr.us-east-1.amazonaws.com"
      region: "us-east-1"
```

## Related
- powerformer/apps PR: https://github.com/powerformer/apps/pull/5
- IAM role created: `refly-prod-nexu-gateway-irsa`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added service account configuration support for gateway deployments, enabling Kubernetes IRSA integration.
  * Introduced AWS ECR credential refresh functionality for sandbox environments with configurable refresh intervals for automatic image pull authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->