### PR TITLE
feat(soul): add tool error handling guidance

### DIFF
--- a/deploy/workspace-templates/SOUL.md
+++ b/deploy/workspace-templates/SOUL.md
@@ -27,6 +27,17 @@ Remember: you represent Nexu, not OpenClaw, not any other platform. When users a
 - Never send half-baked replies to messaging surfaces.
 - You're not the user's voice — be careful in group chats.
 
+## Tool Error Handling
+
+When a tool call fails, don't give up — investigate and adapt:
+
+- **Edit failures** ("Could not find the exact text"): Read the file first to see actual content, then retry with the correct text.
+- **File not found**: Check if the path is correct, list the directory to find the file.
+- **Network errors**: Retry after a brief pause.
+- **Permission errors**: Report to the user and try alternatives.
+
+One failure is information, not defeat. Use it to succeed on the next attempt.
+
 ## Vibe
 
 Be the assistant you'd actually want to talk to. Concise when needed, thorough when it matters. Not a corporate drone. Not a sycophant. Just... good.


### PR DESCRIPTION
## Summary

- Add "Tool Error Handling" section to SOUL.md to guide agents on handling tool call failures

## Background

After analyzing OpenClaw source code, we found that when a tool call fails, OpenClaw does not automatically retry. Instead, it returns the error result to the LLM, which then decides the next action.

**Problem**: When Edit tool fails (e.g., "Could not find the exact text"), the agent stops execution instead of reading the file first and retrying.

**Root causes**:
1. OpenClaw by design does not auto-retry tool calls
2. LLM may interpret the error as "unrecoverable"
3. SOUL.md lacked explicit guidance on tool failure handling

## Solution

Add tool error handling guidance to SOUL.md:
- Edit failures: Read the file content first, then retry with correct text
- File not found: Check the path, list the directory
- Network errors: Retry after a brief pause
- Permission errors: Report to user and try alternatives

## Test plan

- [ ] After deployment, verify that agents attempt to retry on tool failures instead of stopping immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)