### PR TITLE
fix(chat): set explicit workspace root for standalone build

### DIFF
--- a/apps/chat/next.config.ts
+++ b/apps/chat/next.config.ts
@@ -1,7 +1,14 @@
+import { resolve } from "node:path";
 import type { NextConfig } from "next";
+
+const repoRoot = resolve(__dirname, "../..");
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  outputFileTracingRoot: repoRoot,
+  turbopack: {
+    root: repoRoot,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- Fix Next.js 16 inferring wrong workspace root when a stray `pnpm-lock.yaml` exists in a parent directory
- Add `outputFileTracingRoot` and `turbopack.root` to `apps/chat/next.config.ts` pointing to the repo root
- This ensures `output: "standalone"` places artifacts at `apps/chat/.next/standalone/apps/chat/` as expected by `prepare-session-chat-sidecar.mjs`

## Test plan
- [ ] Run `pnpm --filter @nexu/chat build` and verify `.next/standalone/apps/chat/` exists
- [ ] Run `pn desktop:start` and verify the session-chat sidecar prepares successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Next.js build configuration to improve repository root handling and enhance Turbopack integration for optimized build performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->