### PR TITLE
fix(desktop): load API env file during local bootstrap

### DIFF
--- a/apps/desktop/main/bootstrap.ts
+++ b/apps/desktop/main/bootstrap.ts
@@ -1,6 +1,22 @@
-import { mkdirSync } from "node:fs";
+import { existsSync, mkdirSync } from "node:fs";
 import { resolve } from "node:path";
 import { app } from "electron";
+
+function loadDesktopDevEnv(): void {
+  const workspaceRoot = process.env.NEXU_WORKSPACE_ROOT;
+
+  if (!workspaceRoot || app.isPackaged) {
+    return;
+  }
+
+  const apiEnvPath = resolve(workspaceRoot, "apps/api/.env");
+
+  if (!existsSync(apiEnvPath)) {
+    return;
+  }
+
+  process.loadEnvFile(apiEnvPath);
+}
 
 function configureLocalDevPaths(): void {
   const runtimeRoot = process.env.NEXU_DESKTOP_RUNTIME_ROOT;
@@ -27,6 +43,7 @@ function configureLocalDevPaths(): void {
   );
 }
 
+loadDesktopDevEnv();
 configureLocalDevPaths();
 
 await import("./index");


### PR DESCRIPTION
## Summary

This PR makes the desktop app load API development environment variables from `apps/api/.env` during local startup so the desktop runtime stack can reuse the same local config.

## Changes

- Added a desktop bootstrap helper that reads `apps/api/.env` from the workspace root in local development
- Skipped env loading when the app is packaged or the API env file does not exist
- Kept the existing local runtime path setup flow intact after env initialization