### PR TITLE
fix: Add --ignore-scripts to Dockerfile pnpm install

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -10,7 +10,7 @@ COPY pnpm-lock.yaml pnpm-workspace.yaml package.json tsconfig.base.json ./
 COPY packages/shared/package.json packages/shared/
 COPY apps/api/package.json apps/api/
 
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile --ignore-scripts
 
 # Copy source and build
 COPY packages/shared/ packages/shared/
@@ -33,7 +33,7 @@ COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY packages/shared/package.json packages/shared/
 COPY apps/api/package.json apps/api/
 
-RUN pnpm install --frozen-lockfile --prod
+RUN pnpm install --frozen-lockfile --prod --ignore-scripts
 
 # Copy built output
 COPY --from=builder /app/packages/shared/dist/ packages/shared/dist/

--- a/apps/gateway/Dockerfile
+++ b/apps/gateway/Dockerfile
@@ -27,7 +27,7 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
 COPY apps/gateway/package.json apps/gateway/package.json
 COPY packages/shared/package.json packages/shared/package.json
 
-RUN pnpm install --filter @nexu/gateway... --frozen-lockfile
+RUN pnpm install --filter @nexu/gateway... --frozen-lockfile --ignore-scripts
 
 COPY apps/gateway ./apps/gateway
 COPY packages/shared ./packages/shared

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -10,7 +10,7 @@ COPY pnpm-lock.yaml pnpm-workspace.yaml package.json tsconfig.base.json ./
 COPY packages/shared/package.json packages/shared/
 COPY apps/web/package.json apps/web/
 
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile --ignore-scripts
 
 # Copy source and build
 COPY packages/shared/ packages/shared/


### PR DESCRIPTION
## Summary

- Add `--ignore-scripts` flag to `pnpm install` in all Dockerfiles
- Fixes Docker build failures caused by preinstall scripts referencing `openclaw-runtime` directory

## Problem

The root `package.json` has preinstall/postinstall scripts:
```json
"preinstall": "npm --prefix ./openclaw-runtime run clean",
"postinstall": "npm --prefix ./openclaw-runtime run install:pruned"
```

These scripts are for local development only. Docker builds fail because `openclaw-runtime` is not copied into the build context.

## Solution

Add `--ignore-scripts` to skip these scripts during Docker builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)