### PR TITLE
fix: skip root install scripts in gateway image build

### DIFF
--- a/apps/gateway/Dockerfile
+++ b/apps/gateway/Dockerfile
@@ -33,7 +33,7 @@ COPY apps/gateway ./apps/gateway
 COPY packages/shared ./packages/shared
 
 RUN pnpm --filter @nexu/gateway... build
-RUN pnpm --filter @nexu/gateway... install --prod --frozen-lockfile
+RUN pnpm --filter @nexu/gateway... install --prod --frozen-lockfile --ignore-scripts
 
 FROM base AS runtime
 


### PR DESCRIPTION
## Summary
- skip workspace install scripts during the gateway Docker production install step so the image build does not invoke repo-root `openclaw-runtime` hooks
- keep the gateway image dependency install focused on runtime packages needed for `@nexu/gateway` and `@nexu/shared`
- fixes the failing `Deploy EKS Test` gateway docker job; validated by successful workflow run `23178242372`