### PR TITLE
feat: add desktop diagnostics experience

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -108,6 +108,7 @@ jobs:
           CLOUD_URL: ${{ inputs.cloud_url }}
           LINK_URL: ${{ inputs.link_url }}
           UPDATE_FEED_URL: ${{ inputs.update_feed_url }}
+          SENTRY_DSN: ${{ secrets.NEXU_DESKTOP_SENTRY_DSN }}
         run: |
           node -e '
             const config = {
@@ -116,6 +117,9 @@ jobs:
             };
             if (process.env.UPDATE_FEED_URL) {
               config.NEXU_UPDATE_FEED_URL = process.env.UPDATE_FEED_URL;
+            }
+            if (process.env.SENTRY_DSN) {
+              config.NEXU_DESKTOP_SENTRY_DSN = process.env.SENTRY_DSN;
             }
             require("fs").writeFileSync(
               "apps/desktop/build-config.json",

--- a/apps/desktop/.env.example
+++ b/apps/desktop/.env.example
@@ -1,5 +1,8 @@
 VITE_API_BASE_URL=http://127.0.0.1:50800
 
+# Optional: desktop Sentry DSN for both the Electron main and renderer processes.
+NEXU_DESKTOP_SENTRY_DSN=
+
 # Optional: Apple notarization for `pnpm --filter @nexu/desktop dist:mac`
 APPLE_API_ISSUER=
 APPLE_API_KEY_ID=

--- a/apps/desktop/main/index.ts
+++ b/apps/desktop/main/index.ts
@@ -1,10 +1,12 @@
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import * as Sentry from "@sentry/electron/main";
 import {
   BrowserWindow,
   Menu,
   type MenuItemConstructorOptions,
   app,
+  crashReporter,
   session,
   shell,
 } from "electron";
@@ -45,6 +47,46 @@ const orchestrator = new RuntimeOrchestrator(
 );
 
 app.setName("Nexu Desktop");
+
+const sentryDsn = runtimeConfig.sentryDsn;
+
+if (sentryDsn) {
+  Sentry.init({
+    dsn: sentryDsn,
+    environment: app.isPackaged ? "production" : "development",
+    release: `@nexu/desktop@${app.getVersion()}`,
+    beforeSend(event) {
+      const testTitle =
+        typeof event.tags?.["nexu.test_title"] === "string"
+          ? event.tags["nexu.test_title"]
+          : typeof event.extra?.["nexu.test_title"] === "string"
+            ? event.extra["nexu.test_title"]
+            : null;
+
+      if (!testTitle) {
+        return event;
+      }
+
+      return {
+        ...event,
+        message: testTitle,
+        fingerprint: [testTitle],
+      };
+    },
+  });
+} else {
+  crashReporter.start({
+    companyName: "Nexu",
+    productName: app.getName(),
+    submitURL: "https://127.0.0.1/desktop-crash-reporter-disabled",
+    uploadToServer: false,
+    compress: true,
+    ignoreSystemCrashHandler: false,
+    extra: {
+      environment: app.isPackaged ? "production" : "development",
+    },
+  });
+}
 
 let mainWindow: BrowserWindow | null = null;
 
@@ -391,7 +433,7 @@ app.on("web-contents-created", (_event, contents) => {
 app.whenReady().then(async () => {
   installApplicationMenu();
   installDesktopAuthRecoveryHooks();
-  registerIpcHandlers(orchestrator);
+  registerIpcHandlers(orchestrator, runtimeConfig);
 
   void (async () => {
     const healthCheck = new StartupHealthCheck();

--- a/apps/desktop/main/ipc.ts
+++ b/apps/desktop/main/ipc.ts
@@ -1,10 +1,14 @@
+import * as Sentry from "@sentry/electron/main";
 import { BrowserWindow, app, ipcMain, shell } from "electron";
 import {
   type HostInvokePayloadMap,
   type HostInvokeResultMap,
   hostInvokeChannels,
 } from "../shared/host";
-import { getDesktopRuntimeConfig } from "../shared/runtime-config";
+import {
+  type DesktopRuntimeConfig,
+  getDesktopRuntimeConfig,
+} from "../shared/runtime-config";
 import { ensureDesktopAuthSession } from "./desktop-bootstrap";
 import type { RuntimeOrchestrator } from "./runtime/daemon-supervisor";
 import type { ComponentUpdater } from "./updater/component-updater";
@@ -14,6 +18,27 @@ const validChannels = new Set<string>(hostInvokeChannels);
 
 let updateManager: UpdateManager | null = null;
 let componentUpdater: ComponentUpdater | null = null;
+
+const nativeCrashTestTitles = {
+  main: "desktop.main.crash",
+  renderer: "desktop.renderer.crash",
+} as const;
+
+async function prepareNativeCrashScope(
+  title: (typeof nativeCrashTestTitles)[keyof typeof nativeCrashTestTitles],
+): Promise<void> {
+  if (!Sentry.isInitialized()) {
+    return;
+  }
+
+  const scope = Sentry.getCurrentScope();
+  scope.setTag("nexu.test_title", title);
+  scope.setTag("nexu.test_kind", "native_crash");
+  scope.setExtra("nexu.test_title", title);
+  scope.setFingerprint([title]);
+
+  await new Promise((resolve) => setTimeout(resolve, 50));
+}
 
 export function setUpdateManager(manager: UpdateManager): void {
   updateManager = manager;
@@ -31,7 +56,10 @@ function assertValidChannel(
   }
 }
 
-export function registerIpcHandlers(orchestrator: RuntimeOrchestrator): void {
+export function registerIpcHandlers(
+  orchestrator: RuntimeOrchestrator,
+  runtimeConfig: DesktopRuntimeConfig,
+): void {
   orchestrator.subscribe((runtimeEvent) => {
     for (const window of BrowserWindow.getAllWindows()) {
       window.webContents.send("host:runtime-event", runtimeEvent);
@@ -53,6 +81,38 @@ export function registerIpcHandlers(orchestrator: RuntimeOrchestrator): void {
           };
 
           return result;
+        }
+
+        case "diagnostics:get-info": {
+          const sentryDsn = runtimeConfig.sentryDsn;
+          const sentryMainEnabled = Boolean(sentryDsn);
+          const result: HostInvokeResultMap["diagnostics:get-info"] = {
+            crashDumpsPath: app.getPath("crashDumps"),
+            processType: process.type,
+            sentryMainEnabled,
+            sentryDsn,
+            nativeCrashPipeline: sentryMainEnabled ? "sentry" : "local-only",
+          };
+
+          return result;
+        }
+
+        case "diagnostics:crash-main": {
+          await prepareNativeCrashScope(nativeCrashTestTitles.main);
+          process.crash();
+          return undefined;
+        }
+
+        case "diagnostics:crash-renderer": {
+          const browserWindow = BrowserWindow.fromWebContents(_event.sender);
+
+          if (!browserWindow) {
+            throw new Error("Could not resolve the active browser window.");
+          }
+
+          await prepareNativeCrashScope(nativeCrashTestTitles.renderer);
+          browserWindow.webContents.forcefullyCrashRenderer();
+          return undefined;
         }
 
         case "env:get-api-base-url": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -32,6 +32,7 @@
     "@radix-ui/react-separator": "^1.1.2",
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-tabs": "^1.1.3",
+    "@sentry/electron": "^7.10.0",
     "@tanstack/react-query": "^5.66.9",
     "better-auth": "^1.4.19",
     "class-variance-authority": "^0.7.1",

--- a/apps/desktop/preload/index.ts
+++ b/apps/desktop/preload/index.ts
@@ -12,10 +12,19 @@ import {
   hostInvokeChannels,
   updaterEvents,
 } from "../shared/host";
+import { getDesktopRuntimeConfig } from "../shared/runtime-config";
 
 const validChannels = new Set<string>(hostInvokeChannels);
 
+const runtimeConfig = getDesktopRuntimeConfig(process.env, {
+  resourcesPath: process.resourcesPath,
+});
+
 const hostBridge: HostBridge = {
+  bootstrap: {
+    sentryDsn: runtimeConfig.sentryDsn,
+  },
+
   invoke<TChannel extends HostInvokeChannel>(
     channel: TChannel,
     payload: HostInvokePayloadMap[TChannel],

--- a/apps/desktop/shared/host.ts
+++ b/apps/desktop/shared/host.ts
@@ -3,6 +3,9 @@ export type { DesktopRuntimeConfig } from "./runtime-config";
 
 export const hostInvokeChannels = [
   "app:get-info",
+  "diagnostics:get-info",
+  "diagnostics:crash-main",
+  "diagnostics:crash-renderer",
   "env:get-api-base-url",
   "env:get-runtime-config",
   "runtime:get-state",
@@ -41,6 +44,9 @@ export type RuntimeEventQueryResult = {
 
 export type HostInvokePayloadMap = {
   "app:get-info": undefined;
+  "diagnostics:get-info": undefined;
+  "diagnostics:crash-main": undefined;
+  "diagnostics:crash-renderer": undefined;
   "env:get-api-base-url": undefined;
   "env:get-runtime-config": undefined;
   "runtime:get-state": undefined;
@@ -74,6 +80,9 @@ export type HostInvokePayloadMap = {
 
 export type HostInvokeResultMap = {
   "app:get-info": AppInfo;
+  "diagnostics:get-info": DiagnosticsInfo;
+  "diagnostics:crash-main": undefined;
+  "diagnostics:crash-renderer": undefined;
   "env:get-api-base-url": {
     apiBaseUrl: string;
   };
@@ -117,7 +126,15 @@ export type AppInfo = {
   isDev: boolean;
 };
 
-export type DesktopSurface = "web" | "openclaw" | "control";
+export type DiagnosticsInfo = {
+  crashDumpsPath: string;
+  processType: string;
+  sentryMainEnabled: boolean;
+  sentryDsn: string | null;
+  nativeCrashPipeline: "local-only" | "sentry";
+};
+
+export type DesktopSurface = "web" | "openclaw" | "control" | "diagnostics";
 
 export type DesktopChromeMode = "full" | "immersive";
 
@@ -228,12 +245,17 @@ export type RuntimeState = {
 };
 
 export type HostBridge = {
+  bootstrap: HostBootstrap;
   invoke<TChannel extends HostInvokeChannel>(
     channel: TChannel,
     payload: HostInvokePayloadMap[TChannel],
   ): Promise<HostInvokeResultMap[TChannel]>;
   onDesktopCommand(listener: (command: HostDesktopCommand) => void): () => void;
   onRuntimeEvent(listener: (event: RuntimeEvent) => void): () => void;
+};
+
+export type HostBootstrap = {
+  sentryDsn: string | null;
 };
 
 export type UpdateSource = "r2" | "github";

--- a/apps/desktop/shared/runtime-config.ts
+++ b/apps/desktop/shared/runtime-config.ts
@@ -68,6 +68,7 @@ export type DesktopRuntimeConfig = {
     appUserId: string;
     onboardingRole: string;
   };
+  sentryDsn: string | null;
 };
 
 export function getDesktopRuntimeConfig(
@@ -141,5 +142,9 @@ export function getDesktopRuntimeConfig(
       appUserId: "desktop-local-user",
       onboardingRole: "Founder / Manager",
     },
+    sentryDsn:
+      env.NEXU_DESKTOP_SENTRY_DSN ??
+      buildConfig.NEXU_DESKTOP_SENTRY_DSN ??
+      null,
   };
 }

--- a/apps/desktop/src/lib/host-api.ts
+++ b/apps/desktop/src/lib/host-api.ts
@@ -1,6 +1,7 @@
 import type {
   AppInfo,
   DesktopRuntimeConfig,
+  DiagnosticsInfo,
   HostDesktopCommand,
   RuntimeEvent,
   RuntimeEventQuery,
@@ -21,6 +22,18 @@ function getHostBridge() {
 
 export async function getAppInfo(): Promise<AppInfo> {
   return getHostBridge().invoke("app:get-info", undefined);
+}
+
+export async function getDiagnosticsInfo(): Promise<DiagnosticsInfo> {
+  return getHostBridge().invoke("diagnostics:get-info", undefined);
+}
+
+export async function triggerMainProcessCrash(): Promise<void> {
+  await getHostBridge().invoke("diagnostics:crash-main", undefined);
+}
+
+export async function triggerRendererProcessCrash(): Promise<void> {
+  await getHostBridge().invoke("diagnostics:crash-renderer", undefined);
 }
 
 export async function getApiBaseUrl(): Promise<string> {

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -1,13 +1,16 @@
 import * as amplitude from "@amplitude/unified";
 import { Identify } from "@amplitude/unified";
+import * as Sentry from "@sentry/electron/renderer";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import ReactDOM from "react-dom/client";
 import { Toaster, toast } from "sonner";
 import type {
+  AppInfo,
   DesktopChromeMode,
   DesktopRuntimeConfig,
   DesktopSurface,
+  DiagnosticsInfo,
   RuntimeEvent,
   RuntimeLogEntry,
   RuntimeState,
@@ -20,6 +23,8 @@ import { UpdateBanner } from "./components/update-banner";
 import { useAutoUpdate } from "./hooks/use-auto-update";
 import {
   checkComponentUpdates,
+  getAppInfo,
+  getDiagnosticsInfo,
   getRuntimeConfig,
   getRuntimeState,
   installComponent,
@@ -28,10 +33,33 @@ import {
   showRuntimeLogFile,
   startUnit,
   stopUnit,
+  triggerMainProcessCrash,
+  triggerRendererProcessCrash,
 } from "./lib/host-api";
 import "./runtime-page.css";
 
 const amplitudeApiKey = import.meta.env.VITE_AMPLITUDE_API_KEY;
+const rendererSentryDsn =
+  typeof window === "undefined" ? null : window.nexuHost.bootstrap.sentryDsn;
+
+let rendererSentryInitialized = false;
+
+function initializeRendererSentry(dsn: string): void {
+  if (rendererSentryInitialized) {
+    return;
+  }
+
+  Sentry.init({
+    dsn,
+    environment: import.meta.env.MODE,
+  });
+
+  rendererSentryInitialized = true;
+}
+
+if (rendererSentryDsn) {
+  initializeRendererSentry(rendererSentryDsn);
+}
 
 if (amplitudeApiKey) {
   amplitude.initAll(amplitudeApiKey, {
@@ -664,6 +692,219 @@ function EmbeddedControlPlane() {
   );
 }
 
+type DiagnosticsActionId =
+  | "renderer-exception"
+  | "renderer-crash"
+  | "main-crash";
+
+function DiagnosticsActionCard({
+  description,
+  disabled,
+  label,
+  onClick,
+}: {
+  description: string;
+  disabled: boolean;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <article className="diagnostics-action-card">
+      <div>
+        <strong>{label}</strong>
+        <p>{description}</p>
+      </div>
+      <button disabled={disabled} onClick={onClick} type="button">
+        Trigger
+      </button>
+    </article>
+  );
+}
+
+function DiagnosticsPage() {
+  const [appInfo, setAppInfo] = useState<AppInfo | null>(null);
+  const [diagnosticsInfo, setDiagnosticsInfo] =
+    useState<DiagnosticsInfo | null>(null);
+  const [busyAction, setBusyAction] = useState<DiagnosticsActionId | null>(
+    null,
+  );
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [lastAction, setLastAction] = useState<string>(
+    "Ready for diagnostics.",
+  );
+
+  useEffect(() => {
+    void Promise.all([getAppInfo(), getDiagnosticsInfo()])
+      .then(([nextAppInfo, nextDiagnosticsInfo]) => {
+        setAppInfo(nextAppInfo);
+        setDiagnosticsInfo(nextDiagnosticsInfo);
+        setErrorMessage(null);
+      })
+      .catch((error) => {
+        setErrorMessage(
+          error instanceof Error
+            ? error.message
+            : "Failed to load diagnostics metadata.",
+        );
+      });
+  }, []);
+
+  const runAction = useCallback(
+    async (actionId: DiagnosticsActionId, action: () => Promise<void>) => {
+      setBusyAction(actionId);
+      setErrorMessage(null);
+
+      try {
+        await action();
+      } catch (error) {
+        setErrorMessage(
+          error instanceof Error ? error.message : "Diagnostics action failed.",
+        );
+      } finally {
+        setBusyAction(null);
+      }
+    },
+    [],
+  );
+
+  const triggerRendererException = useCallback(() => {
+    const title = "desktop.renderer.exception";
+    setLastAction(
+      `Renderer exception scheduled at ${new Date().toLocaleTimeString()}.`,
+    );
+
+    window.setTimeout(() => {
+      throw new Error(title);
+    }, 0);
+  }, []);
+
+  const triggerRendererCrash = useCallback(() => {
+    setLastAction(
+      `Renderer crash requested at ${new Date().toLocaleTimeString()}.`,
+    );
+
+    void runAction("renderer-crash", async () => {
+      await triggerRendererProcessCrash();
+    });
+  }, [runAction]);
+
+  const triggerMainCrash = useCallback(() => {
+    setLastAction(
+      `Main crash requested at ${new Date().toLocaleTimeString()}.`,
+    );
+
+    void runAction("main-crash", async () => {
+      await triggerMainProcessCrash();
+    });
+  }, [runAction]);
+
+  return (
+    <div className="runtime-page diagnostics-page">
+      <header className="runtime-header diagnostics-header">
+        <div>
+          <span className="runtime-eyebrow">Crash Diagnostics</span>
+          <h1>Exercise the Electron failure paths on demand</h1>
+          <p>
+            Use one page to validate renderer exceptions, renderer process
+            exits, and main process crashes through the local desktop
+            observability stack.
+          </p>
+        </div>
+      </header>
+
+      <section className="runtime-summary diagnostics-summary">
+        <SummaryCard
+          label="App"
+          value={appInfo ? `${appInfo.appName} ${appInfo.appVersion}` : "-"}
+        />
+        <SummaryCard label="Platform" value={appInfo?.platform ?? "-"} />
+        <SummaryCard
+          label="Mode"
+          value={appInfo ? (appInfo.isDev ? "development" : "packaged") : "-"}
+        />
+        <SummaryCard
+          label="Crash dumps"
+          value={diagnosticsInfo?.crashDumpsPath ?? "-"}
+        />
+        <SummaryCard
+          label="Native crashes"
+          value={
+            diagnosticsInfo
+              ? diagnosticsInfo.nativeCrashPipeline === "sentry"
+                ? "sentry"
+                : "local-only"
+              : "-"
+          }
+        />
+        <SummaryCard
+          label="Sentry main"
+          value={
+            diagnosticsInfo
+              ? diagnosticsInfo.sentryMainEnabled
+                ? "enabled"
+                : "off"
+              : "-"
+          }
+        />
+        <SummaryCard
+          label="Sentry renderer"
+          value={
+            diagnosticsInfo
+              ? diagnosticsInfo.sentryMainEnabled
+                ? "enabled"
+                : "off"
+              : "-"
+          }
+        />
+      </section>
+
+      <p className="runtime-note diagnostics-note">
+        The renderer exception path keeps the process alive and is meant for
+        JavaScript error capture. The renderer crash and main crash paths
+        terminate a process and are meant for native crash capture.
+      </p>
+
+      {errorMessage ? (
+        <p className="runtime-error-banner">{errorMessage}</p>
+      ) : null}
+
+      <section className="diagnostics-grid">
+        <DiagnosticsActionCard
+          description="Throws an unhandled renderer Error named desktop.renderer.exception. Use this to validate JavaScript exception capture without killing the app."
+          disabled={busyAction !== null}
+          label="Test Renderer Exception"
+          onClick={triggerRendererException}
+        />
+        <DiagnosticsActionCard
+          description="Asks the main process to forcefully crash the current renderer process with the title desktop.renderer.crash. Use this to validate renderer crash handling and crash dump creation."
+          disabled={busyAction !== null}
+          label="Test Renderer Crash"
+          onClick={triggerRendererCrash}
+        />
+        <DiagnosticsActionCard
+          description="Invokes a deliberate main process crash with the title desktop.main.crash. Use this to validate the native crash pipeline for the Electron host itself."
+          disabled={busyAction !== null}
+          label="Test Main Crash"
+          onClick={triggerMainCrash}
+        />
+      </section>
+
+      <section className="diagnostics-status-card">
+        <div>
+          <span className="runtime-eyebrow">Last action</span>
+          <h2>{lastAction}</h2>
+          <p>
+            Renderer process type: {diagnosticsInfo?.processType ?? "unknown"}.
+            JavaScript exceptions should stay visible in the renderer and in
+            Sentry when configured. Process crashes should leave Crashpad dumps
+            and, with Sentry enabled, upload native crash events.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}
+
 function DesktopShell() {
   const [activeSurface, setActiveSurface] = useState<DesktopSurface>("control");
   const [chromeMode, setChromeMode] = useState<DesktopChromeMode>("full");
@@ -778,6 +1019,12 @@ function DesktopShell() {
             meta="Gateway control UI with local token routing"
             onClick={() => setActiveSurface("openclaw")}
           />
+          <SurfaceButton
+            active={activeSurface === "diagnostics"}
+            label="Diagnostics"
+            meta="Crash and exception test bench"
+            onClick={() => setActiveSurface("diagnostics")}
+          />
         </nav>
       </aside>
 
@@ -806,6 +1053,13 @@ function DesktopShell() {
             title="OpenClaw Gateway"
             version={0}
           />
+        </div>
+        <div
+          style={{
+            display: activeSurface === "diagnostics" ? "contents" : "none",
+          }}
+        >
+          <DiagnosticsPage />
         </div>
       </main>
 

--- a/apps/desktop/src/runtime-page.css
+++ b/apps/desktop/src/runtime-page.css
@@ -345,7 +345,7 @@ body,
 
 .runtime-summary {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: 14px;
   margin-bottom: 16px;
 }
@@ -650,6 +650,82 @@ body,
   background: #ffe7e2 !important;
 }
 
+.diagnostics-page {
+  background: radial-gradient(
+      circle at top right,
+      rgba(232, 101, 49, 0.14),
+      transparent 24%
+    ),
+    radial-gradient(
+      circle at bottom left,
+      rgba(17, 22, 29, 0.08),
+      transparent 28%
+    ), #f7f4ed;
+}
+
+.diagnostics-header,
+.diagnostics-summary,
+.diagnostics-grid,
+.diagnostics-status-card {
+  max-width: 1080px;
+  margin: 0 auto;
+}
+
+.diagnostics-note {
+  margin-bottom: 20px;
+}
+
+.diagnostics-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-bottom: 14px;
+}
+
+.diagnostics-action-card,
+.diagnostics-status-card {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 22px;
+  border: 1px solid #ddd5c5;
+  border-radius: 22px;
+  background: rgba(255, 252, 245, 0.94);
+}
+
+.diagnostics-action-card strong {
+  display: block;
+  margin-bottom: 10px;
+  font-size: 1.02rem;
+}
+
+.diagnostics-action-card p,
+.diagnostics-status-card p {
+  margin: 0;
+  color: #5e636d;
+  line-height: 1.5;
+}
+
+.diagnostics-action-card button {
+  align-self: flex-start;
+  border: 1px solid #d9d0bf;
+  border-radius: 999px;
+  background: #1f242c;
+  color: #f7f4ed;
+  padding: 10px 16px;
+  cursor: pointer;
+}
+
+.diagnostics-action-card button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.diagnostics-status-card h2 {
+  margin: 0 0 8px;
+  font-size: 1.3rem;
+}
+
 /* Update Banner */
 .update-banner {
   position: fixed;
@@ -757,7 +833,8 @@ body,
 
   .runtime-pane-layout,
   .runtime-summary,
-  .runtime-grid {
+  .runtime-grid,
+  .diagnostics-grid {
     grid-template-columns: 1fr;
   }
 

--- a/deploy/helm/nexu/values.yaml
+++ b/deploy/helm/nexu/values.yaml
@@ -14,6 +14,7 @@ config:
   LOG_ERROR_STACK_LIMIT_LINES: "0"
   WEB_URL: "https://nexu.example.com"
   BETTER_AUTH_URL: "https://api.nexu.example.com"
+  NEXU_DESKTOP_SENTRY_DSN: ""
   VITE_WHATSAPP_WA_ME_URL: "https://wa.me/15551846745?text=Hello%20Nexu"
   DEFAULT_MODEL_ID: "anthropic/claude-sonnet-4"
   RUNTIME_MANAGE_OPENCLAW_PROCESS: "true"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       '@radix-ui/react-tabs':
         specifier: ^1.1.3
         version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@sentry/electron':
+        specifier: ^7.10.0
+        version: 7.10.0
       '@tanstack/react-query':
         specifier: ^5.66.9
         version: 5.90.21(react@19.2.0)
@@ -1342,6 +1345,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@fastify/otel@0.16.0':
+    resolution: {integrity: sha512-2304BdM5Q/kUvQC9qJO1KZq3Zn1WWsw+WWkVmFEaj1UE2hEIiuFqrPeglQOwEtw/ftngisqfQ3v70TWMmwhhHA==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+
   '@floating-ui/core@1.7.4':
     resolution: {integrity: sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==}
 
@@ -1637,6 +1645,18 @@ packages:
     resolution: {integrity: sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  '@opentelemetry/api-logs@0.207.0':
+    resolution: {integrity: sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api-logs@0.208.0':
+    resolution: {integrity: sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api-logs@0.211.0':
+    resolution: {integrity: sha512-swFdZq8MCdmdR22jTVGQDhwqDzcI4M10nhjXkLr1EsIzXgZBqm4ZlmmcWsg3TSNf+3mzgOiqveXmBLZuDi2Lgg==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api-logs@0.212.0':
     resolution: {integrity: sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg==}
     engines: {node: '>=8.0.0'}
@@ -1644,6 +1664,200 @@ packages:
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/context-async-hooks@2.6.0':
+    resolution: {integrity: sha512-L8UyDwqpTcbkIK5cgwDRDYDoEhQoj8wp8BwsO19w3LB1Z41yEQm2VJyNfAi9DrLP/YTqXqWpKHyZfR9/tFYo1Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.5.0':
+    resolution: {integrity: sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.6.0':
+    resolution: {integrity: sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/instrumentation-amqplib@0.58.0':
+    resolution: {integrity: sha512-fjpQtH18J6GxzUZ+cwNhWUpb71u+DzT7rFkg5pLssDGaEber91Y2WNGdpVpwGivfEluMlNMZumzjEqfg8DeKXQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-connect@0.54.0':
+    resolution: {integrity: sha512-43RmbhUhqt3uuPnc16cX6NsxEASEtn8z/cYV8Zpt6EP4p2h9s4FNuJ4Q9BbEQ2C0YlCCB/2crO1ruVz/hWt8fA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-dataloader@0.28.0':
+    resolution: {integrity: sha512-ExXGBp0sUj8yhm6Znhf9jmuOaGDsYfDES3gswZnKr4MCqoBWQdEFn6EoDdt5u+RdbxQER+t43FoUihEfTSqsjA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-express@0.59.0':
+    resolution: {integrity: sha512-pMKV/qnHiW/Q6pmbKkxt0eIhuNEtvJ7sUAyee192HErlr+a1Jx+FZ3WjfmzhQL1geewyGEiPGkmjjAgNY8TgDA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-fs@0.30.0':
+    resolution: {integrity: sha512-n3Cf8YhG7reaj5dncGlRIU7iT40bxPOjsBEA5Bc1a1g6e9Qvb+JFJ7SEiMlPbUw4PBmxE3h40ltE8LZ3zVt6OA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-generic-pool@0.54.0':
+    resolution: {integrity: sha512-8dXMBzzmEdXfH/wjuRvcJnUFeWzZHUnExkmFJ2uPfa31wmpyBCMxO59yr8f/OXXgSogNgi/uPo9KW9H7LMIZ+g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-graphql@0.58.0':
+    resolution: {integrity: sha512-+yWVVY7fxOs3j2RixCbvue8vUuJ1inHxN2q1sduqDB0Wnkr4vOzVKRYl/Zy7B31/dcPS72D9lo/kltdOTBM3bQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-hapi@0.57.0':
+    resolution: {integrity: sha512-Os4THbvls8cTQTVA8ApLfZZztuuqGEeqog0XUnyRW7QVF0d/vOVBEcBCk1pazPFmllXGEdNbbat8e2fYIWdFbw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-http@0.211.0':
+    resolution: {integrity: sha512-n0IaQ6oVll9PP84SjbOCwDjaJasWRHi6BLsbMLiT6tNj7QbVOkuA5sk/EfZczwI0j5uTKl1awQPivO/ldVtsqA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-ioredis@0.59.0':
+    resolution: {integrity: sha512-875UxzBHWkW+P4Y45SoFM2AR8f8TzBMD8eO7QXGCyFSCUMP5s9vtt/BS8b/r2kqLyaRPK6mLbdnZznK3XzQWvw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-kafkajs@0.20.0':
+    resolution: {integrity: sha512-yJXOuWZROzj7WmYCUiyT27tIfqBrVtl1/TwVbQyWPz7rL0r1Lu7kWjD0PiVeTCIL6CrIZ7M2s8eBxsTAOxbNvw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-knex@0.55.0':
+    resolution: {integrity: sha512-FtTL5DUx5Ka/8VK6P1VwnlUXPa3nrb7REvm5ddLUIeXXq4tb9pKd+/ThB1xM/IjefkRSN3z8a5t7epYw1JLBJQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-koa@0.59.0':
+    resolution: {integrity: sha512-K9o2skADV20Skdu5tG2bogPKiSpXh4KxfLjz6FuqIVvDJNibwSdu5UvyyBzRVp1rQMV6UmoIk6d3PyPtJbaGSg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+
+  '@opentelemetry/instrumentation-lru-memoizer@0.55.0':
+    resolution: {integrity: sha512-FDBfT7yDGcspN0Cxbu/k8A0Pp1Jhv/m7BMTzXGpcb8ENl3tDj/51U65R5lWzUH15GaZA15HQ5A5wtafklxYj7g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mongodb@0.64.0':
+    resolution: {integrity: sha512-pFlCJjweTqVp7B220mCvCld1c1eYKZfQt1p3bxSbcReypKLJTwat+wbL2YZoX9jPi5X2O8tTKFEOahO5ehQGsA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mongoose@0.57.0':
+    resolution: {integrity: sha512-MthiekrU/BAJc5JZoZeJmo0OTX6ycJMiP6sMOSRTkvz5BrPMYDqaJos0OgsLPL/HpcgHP7eo5pduETuLguOqcg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mysql2@0.57.0':
+    resolution: {integrity: sha512-nHSrYAwF7+aV1E1V9yOOP9TchOodb6fjn4gFvdrdQXiRE7cMuffyLLbCZlZd4wsspBzVwOXX8mpURdRserAhNA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mysql@0.57.0':
+    resolution: {integrity: sha512-HFS/+FcZ6Q7piM7Il7CzQ4VHhJvGMJWjx7EgCkP5AnTntSN5rb5Xi3TkYJHBKeR27A0QqPlGaCITi93fUDs++Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-pg@0.63.0':
+    resolution: {integrity: sha512-dKm/ODNN3GgIQVlbD6ZPxwRc3kleLf95hrRWXM+l8wYo+vSeXtEpQPT53afEf6VFWDVzJK55VGn8KMLtSve/cg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-redis@0.59.0':
+    resolution: {integrity: sha512-JKv1KDDYA2chJ1PC3pLP+Q9ISMQk6h5ey+99mB57/ARk0vQPGZTTEb4h4/JlcEpy7AYT8HIGv7X6l+br03Neeg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-tedious@0.30.0':
+    resolution: {integrity: sha512-bZy9Q8jFdycKQ2pAsyuHYUHNmCxCOGdG6eg1Mn75RvQDccq832sU5OWOBnc12EFUELI6icJkhR7+EQKMBam2GA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-undici@0.21.0':
+    resolution: {integrity: sha512-gok0LPUOTz2FQ1YJMZzaHcOzDFyT64XJ8M9rNkugk923/p6lDGms/cRW1cqgqp6N6qcd6K6YdVHwPEhnx9BWbw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.7.0
+
+  '@opentelemetry/instrumentation@0.207.0':
+    resolution: {integrity: sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation@0.208.0':
+    resolution: {integrity: sha512-Eju0L4qWcQS+oXxi6pgh7zvE2byogAkcsVv0OjHF/97iOz1N/aKE6etSGowYkie+YA1uo6DNwdSxaaNnLvcRlA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation@0.211.0':
+    resolution: {integrity: sha512-h0nrZEC/zvI994nhg7EgQ8URIHt0uDTwN90r3qQUdZORS455bbx+YebnGeEuFghUT0HlJSrLF4iHw67f+odY+Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/redis-common@0.38.2':
+    resolution: {integrity: sha512-1BCcU93iwSRZvDAgwUxC/DV4T/406SkMfxGqu5ojc3AvNI+I9GhV7v0J1HljsczuuhcnFLYqD5VmwVXfCGHzxA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+
+  '@opentelemetry/resources@2.6.0':
+    resolution: {integrity: sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.6.0':
+    resolution: {integrity: sha512-g/OZVkqlxllgFM7qMKqbPV9c1DUPhQ7d4n3pgZFcrnrNft9eJXZM2TNHTPYREJBrtNdRytYyvwjgL5geDKl3EQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.40.0':
+    resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/sql-common@0.41.2':
+    resolution: {integrity: sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
 
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
@@ -1674,6 +1888,11 @@ packages:
 
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
+
+  '@prisma/instrumentation@7.2.0':
+    resolution: {integrity: sha512-Rh9Z4x5kEj1OdARd7U18AtVrnL6rmLSI0qYShaB4W7Wx5BKbgzndWF+QnuzMb7GLfVdlT5aYCXoPQVYuYtVu0g==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.8
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -2176,6 +2395,79 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sentry-internal/browser-utils@10.42.0':
+    resolution: {integrity: sha512-HCEICKvepxN4/6NYfnMMMlppcSwIEwtS66X6d1/mwaHdi2ivw0uGl52p7Nfhda/lIJArbrkWprxl0WcjZajhQA==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/feedback@10.42.0':
+    resolution: {integrity: sha512-lpPcHsog10MVYFTWE0Pf8vQRqQWwZHJpkVl2FEb9/HDdHFyTBUhCVoWo1KyKaG7GJl9AVKMAg7bp9SSNArhFNQ==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay-canvas@10.42.0':
+    resolution: {integrity: sha512-am3m1Fj8ihoPfoYo41Qq4KeCAAICn4bySso8Oepu9dMNe9Lcnsf+reMRS2qxTPg3pZDc4JEMOcLyNCcgnAfrHw==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay@10.42.0':
+    resolution: {integrity: sha512-Zh3EoaH39x2lqVY1YyVB2vJEyCIrT+YLUQxYl1yvP0MJgLxaR6akVjkgxbSUJahan4cX5DxpZiEHfzdlWnYPyQ==}
+    engines: {node: '>=18'}
+
+  '@sentry/browser@10.42.0':
+    resolution: {integrity: sha512-iXxYjXNEBwY1MH4lDSDZZUNjzPJDK7/YLwVIJq/3iBYpIQVIhaJsoJnf3clx9+NfJ8QFKyKfcvgae61zm+hgTA==}
+    engines: {node: '>=18'}
+
+  '@sentry/core@10.42.0':
+    resolution: {integrity: sha512-L4rMrXMqUKBanpjpMT+TuAVk6xAijz6AWM6RiEYpohAr7SGcCEc1/T0+Ep1eLV8+pwWacfU27OvELIyNeOnGzA==}
+    engines: {node: '>=18'}
+
+  '@sentry/electron@7.10.0':
+    resolution: {integrity: sha512-RwifPIBQds31giWL5KF87R/owzcVamMcXkL2ctoe/ybsxV861cbNhXxba/XCI6YmYOGIaixqiCAasxeZ+mx1SA==}
+    peerDependencies:
+      '@sentry/node-native': 10.42.0
+    peerDependenciesMeta:
+      '@sentry/node-native':
+        optional: true
+
+  '@sentry/node-core@10.42.0':
+    resolution: {integrity: sha512-9tf3fPV6M071aps72D+PEtdQPTuj+SuqO2+PpTfdPP5ZL4TTKYo3VK0li76SL+5wGdTFGV5qmsokHq9IRBA0iA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/context-async-hooks': ^1.30.1 || ^2.1.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/instrumentation': '>=0.57.1 <1'
+      '@opentelemetry/resources': ^1.30.1 || ^2.1.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+      '@opentelemetry/semantic-conventions': ^1.39.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/context-async-hooks':
+        optional: true
+      '@opentelemetry/core':
+        optional: true
+      '@opentelemetry/instrumentation':
+        optional: true
+      '@opentelemetry/resources':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+      '@opentelemetry/semantic-conventions':
+        optional: true
+
+  '@sentry/node@10.42.0':
+    resolution: {integrity: sha512-ZZfU3Fnni7Aj0lTX4e3QpY3UxK4FGuzfM20316UAJycBGnripm+sDHwcekPMGfLnk/FrN9wa1atspVlHvOI0WQ==}
+    engines: {node: '>=18'}
+
+  '@sentry/opentelemetry@10.42.0':
+    resolution: {integrity: sha512-5vsYz683iihzlIj3sT1+tEixf0awwXK86a+aYsnMHrTXJDrkBDq4U0ZT+yxdPfJlkaxRtYycFR08SXr2pSm7Eg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/context-async-hooks': ^1.30.1 || ^2.1.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+      '@opentelemetry/semantic-conventions': ^1.39.0
+
   '@shikijs/core@3.23.0':
     resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
 
@@ -2344,6 +2636,9 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
   '@types/css-font-loading-module@0.0.7':
     resolution: {integrity: sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==}
 
@@ -2377,6 +2672,9 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/mysql@2.15.27':
+    resolution: {integrity: sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==}
+
   '@types/nlcst@2.0.3':
     resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
 
@@ -2385,6 +2683,12 @@ packages:
 
   '@types/node@25.3.2':
     resolution: {integrity: sha512-RpV6r/ij22zRRdyBPcxDeKAzH43phWVKEjL2iksqo1Vz3CuBUrgmPpPhALKiRfU7OMCmeeO9vECBMsV0hMTG8Q==}
+
+  '@types/pg-pool@2.0.7':
+    resolution: {integrity: sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==}
+
+  '@types/pg@8.15.6':
+    resolution: {integrity: sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==}
 
   '@types/pg@8.16.0':
     resolution: {integrity: sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==}
@@ -2402,6 +2706,9 @@ packages:
 
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
+
+  '@types/tedious@4.0.14':
+    resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -3476,6 +3783,9 @@ packages:
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
+
+  forwarded-parse@2.1.2:
+    resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -4804,6 +5114,10 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
 
   resedit@1.7.2:
     resolution: {integrity: sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==}
@@ -6811,6 +7125,16 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
+  '@fastify/otel@0.16.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.208.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      minimatch: 10.2.4
+    transitivePeerDependencies:
+      - supports-color
+
   '@floating-ui/core@1.7.4':
     dependencies:
       '@floating-ui/utils': 0.2.10
@@ -7064,13 +7388,278 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  '@opentelemetry/api-logs@0.207.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/api-logs@0.208.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/api-logs@0.211.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
   '@opentelemetry/api-logs@0.212.0':
     dependencies:
       '@opentelemetry/api': 1.9.0
     optional: true
 
-  '@opentelemetry/api@1.9.0':
-    optional: true
+  '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/context-async-hooks@2.6.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/instrumentation-amqplib@0.58.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-connect@0.54.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/connect': 3.4.38
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-dataloader@0.28.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-express@0.59.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-fs@0.30.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-generic-pool@0.54.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-graphql@0.58.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-hapi@0.57.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-http@0.211.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.5.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      forwarded-parse: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-ioredis@0.59.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/redis-common': 0.38.2
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-kafkajs@0.20.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-knex@0.55.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-koa@0.59.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-lru-memoizer@0.55.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mongodb@0.64.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mongoose@0.57.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mysql2@0.57.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mysql@0.57.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/mysql': 2.15.27
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-pg@0.63.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@opentelemetry/sql-common': 0.41.2(@opentelemetry/api@1.9.0)
+      '@types/pg': 8.15.6
+      '@types/pg-pool': 2.0.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-redis@0.59.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/redis-common': 0.38.2
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-tedious@0.30.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/tedious': 4.0.14
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-undici@0.21.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.207.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.207.0
+      import-in-the-middle: 2.0.6
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.208.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.208.0
+      import-in-the-middle: 2.0.6
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.211.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.211.0
+      import-in-the-middle: 2.0.6
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/redis-common@0.38.2': {}
+
+  '@opentelemetry/resources@2.6.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/semantic-conventions@1.40.0': {}
+
+  '@opentelemetry/sql-common@0.41.2(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
 
   '@oslojs/encoding@1.1.0': {}
 
@@ -7101,6 +7690,13 @@ snapshots:
       supports-color: 10.2.2
 
   '@poppinss/exception@1.2.3': {}
+
+  '@prisma/instrumentation@7.2.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.207.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
 
   '@radix-ui/number@1.1.1': {}
 
@@ -7824,6 +8420,105 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
+  '@sentry-internal/browser-utils@10.42.0':
+    dependencies:
+      '@sentry/core': 10.42.0
+
+  '@sentry-internal/feedback@10.42.0':
+    dependencies:
+      '@sentry/core': 10.42.0
+
+  '@sentry-internal/replay-canvas@10.42.0':
+    dependencies:
+      '@sentry-internal/replay': 10.42.0
+      '@sentry/core': 10.42.0
+
+  '@sentry-internal/replay@10.42.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 10.42.0
+      '@sentry/core': 10.42.0
+
+  '@sentry/browser@10.42.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 10.42.0
+      '@sentry-internal/feedback': 10.42.0
+      '@sentry-internal/replay': 10.42.0
+      '@sentry-internal/replay-canvas': 10.42.0
+      '@sentry/core': 10.42.0
+
+  '@sentry/core@10.42.0': {}
+
+  '@sentry/electron@7.10.0':
+    dependencies:
+      '@sentry/browser': 10.42.0
+      '@sentry/core': 10.42.0
+      '@sentry/node': 10.42.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sentry/node-core@10.42.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.211.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.40.0)':
+    dependencies:
+      '@sentry/core': 10.42.0
+      '@sentry/opentelemetry': 10.42.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.40.0)
+      import-in-the-middle: 2.0.6
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/context-async-hooks': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@sentry/node@10.42.0':
+    dependencies:
+      '@fastify/otel': 0.16.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/context-async-hooks': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-amqplib': 0.58.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-connect': 0.54.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-dataloader': 0.28.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-express': 0.59.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-fs': 0.30.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-generic-pool': 0.54.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-graphql': 0.58.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-hapi': 0.57.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-http': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-ioredis': 0.59.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-kafkajs': 0.20.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-knex': 0.55.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-koa': 0.59.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-lru-memoizer': 0.55.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-mongodb': 0.64.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-mongoose': 0.57.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-mysql': 0.57.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-mysql2': 0.57.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-pg': 0.63.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-redis': 0.59.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-tedious': 0.30.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-undici': 0.21.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@prisma/instrumentation': 7.2.0(@opentelemetry/api@1.9.0)
+      '@sentry/core': 10.42.0
+      '@sentry/node-core': 10.42.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.211.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.40.0)
+      '@sentry/opentelemetry': 10.42.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.40.0)
+      import-in-the-middle: 2.0.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sentry/opentelemetry@10.42.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.40.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/context-async-hooks': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@sentry/core': 10.42.0
+
   '@shikijs/core@3.23.0':
     dependencies:
       '@shikijs/types': 3.23.0
@@ -8012,6 +8707,10 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 25.3.2
+
   '@types/css-font-loading-module@0.0.7': {}
 
   '@types/debug@4.1.12':
@@ -8044,6 +8743,10 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/mysql@2.15.27':
+    dependencies:
+      '@types/node': 25.3.2
+
   '@types/nlcst@2.0.3':
     dependencies:
       '@types/unist': 3.0.3
@@ -8055,6 +8758,16 @@ snapshots:
   '@types/node@25.3.2':
     dependencies:
       undici-types: 7.18.2
+
+  '@types/pg-pool@2.0.7':
+    dependencies:
+      '@types/pg': 8.16.0
+
+  '@types/pg@8.15.6':
+    dependencies:
+      '@types/node': 25.3.2
+      pg-protocol: 1.11.0
+      pg-types: 2.2.0
 
   '@types/pg@8.16.0':
     dependencies:
@@ -8077,6 +8790,10 @@ snapshots:
       csstype: 3.2.3
 
   '@types/responselike@1.0.3':
+    dependencies:
+      '@types/node': 25.3.2
+
+  '@types/tedious@4.0.14':
     dependencies:
       '@types/node': 25.3.2
 
@@ -9395,6 +10112,8 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
+
+  forwarded-parse@2.1.2: {}
 
   fs-constants@1.0.0:
     optional: true
@@ -11063,6 +11782,13 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
 
   resedit@1.7.2:
     dependencies:

--- a/specs/change/20260317-desktop-crash-reporting/spec.md
+++ b/specs/change/20260317-desktop-crash-reporting/spec.md
@@ -1,0 +1,115 @@
+---
+id: "20260317-desktop-crash-reporting"
+name: "Desktop Crash Reporting"
+status: new
+created: "2026-03-17"
+---
+
+## Overview
+
+- Add observable crash reporting to the Electron desktop app and provide deterministic test entry points for validation.
+- Split desktop failure testing into three paths: renderer JavaScript exception, renderer process crash, and main process crash.
+- Keep local verification possible before remote monitoring, then route both exception and native crash signals into Sentry.
+
+## Research
+
+### Existing system
+
+- `apps/desktop` had no dedicated crash lab surface and no Sentry integration.
+- Electron native `crashReporter` captures process crashes only; it does not capture renderer JavaScript exceptions.
+- `@sentry/electron` combines two different pipelines:
+  - renderer JS exceptions through the renderer SDK
+  - native crashes through Electron/Crashpad minidumps handled by the main SDK
+
+### Options considered
+
+1. Use only Electron `crashReporter`
+   - Good for local native crash validation
+   - Does not cover renderer exceptions
+2. Use only manual Sentry exception capture
+   - Good for JavaScript errors
+   - Does not validate native crash handling
+3. Use all three test paths with Electron crash reporting plus Sentry integration (chosen)
+   - Covers the full desktop observability surface
+   - Makes it easy to verify local and remote behavior separately
+
+### Findings
+
+- `Throw Renderer Error` should be treated as an exception test, not a crash test.
+- `BrowserWindow.webContents.forcefullyCrashRenderer()` reliably simulates a renderer process crash.
+- `process.crash()` reliably simulates a main process native crash.
+- Once Sentry native crash handling is enabled, Sentry may own minidump upload and native issue titles may stay platform-derived.
+
+## Design
+
+### Architecture
+
+`Diagnostics UI` -> `host bridge` -> `IPC` -> `main/renderer failure path`
+
+`renderer exception` -> `@sentry/electron/renderer`
+
+`renderer crash` / `main crash` -> `Electron crashReporter / Crashpad` -> `@sentry/electron/main`
+
+### Implementation choices
+
+- Add a dedicated `Diagnostics` top-level surface instead of placing dangerous controls in `Home`.
+- Expose three explicit buttons:
+  - `Test Renderer Exception`
+  - `Test Renderer Crash`
+  - `Test Main Crash`
+- Show runtime diagnostics metadata on the page, including crash dump path and Sentry enablement.
+- Initialize Sentry main from runtime env `NEXU_DESKTOP_SENTRY_DSN`.
+- Bootstrap the renderer Sentry DSN through preload so renderer Sentry starts before React render.
+- Keep a fallback local-only Electron `crashReporter` path when no Sentry DSN is present.
+
+### Key file changes
+
+- `apps/desktop/src/main.tsx` - Diagnostics surface, renderer exception trigger, renderer Sentry init, updated copy
+- `apps/desktop/main/ipc.ts` - diagnostics IPC handlers and native crash metadata setup
+- `apps/desktop/main/index.ts` - main Sentry init and local crashReporter fallback
+- `apps/desktop/preload/index.ts` - preload bootstrap data for renderer Sentry
+- `apps/desktop/shared/host.ts` - shared bridge contracts for diagnostics/bootstrap data
+- `apps/desktop/.env.example` - desktop Sentry env example
+- `deploy/helm/nexu/values.yaml` - desktop Sentry env placeholder
+
+### Verification summary
+
+- Local-only mode:
+  - renderer exception does not create Crashpad dumps
+  - renderer crash creates a local native dump
+  - main crash creates a local native dump
+- Sentry mode:
+  - renderer exception appears in Sentry as `desktop.renderer.exception.test`
+  - native renderer/main crashes upload successfully, but Sentry may still display service-derived native titles such as `<unknown>` or `electron::ElectronBindings::Crash`
+
+## Plan
+
+- [x] Phase 1: Add deterministic desktop test entry points
+  - [x] Create a top-level `Diagnostics` navigation surface
+  - [x] Add renderer exception, renderer crash, and main crash buttons
+  - [x] Show local crash/Sentry runtime state in the UI
+- [x] Phase 2: Wire crash reporting backends
+  - [x] Add Electron `crashReporter` local fallback for native crash validation
+  - [x] Integrate `@sentry/electron` in both main and renderer processes
+  - [x] Pass runtime bootstrap data through preload for early renderer init
+- [x] Phase 3: Validate behavior
+  - [x] Confirm renderer exception stays alive locally and reaches Sentry remotely
+  - [x] Confirm renderer crash is recorded locally and remotely
+  - [x] Confirm main crash is recorded locally and remotely
+
+## Further actions
+
+- [x] Provision the Sentry project via Terraform (currently dev-only and not Terraform-managed).
+- [x] Wire `NEXU_DESKTOP_SENTRY_DSN` into CI nightly builds via GitHub Actions secrets (`desktop-build.yml` → `build-config.json` bake-in pattern, covering both test and prod nightlies).
+- [x] Fix DSN bake-in: `NEXU_DESKTOP_SENTRY_DSN` is now read from `build-config.json` at runtime (same pattern as `NEXU_CLOUD_URL`) rather than from `process.env`, which is empty in packaged apps. Changes span `runtime-config.ts`, `main/index.ts`, `main/ipc.ts`, and `preload/index.ts`.
+- [ ] Set the `NEXU_DESKTOP_SENTRY_DSN` GitHub secret (repo-level or per GitHub Environment) once the Terraform-managed Sentry project DSN is confirmed.
+- [ ] Verify the prod DSN is pointing to the correct Sentry project before enabling crash reporting in production.
+
+## Notes
+
+- Native crash issue titles are harder to force than JavaScript exception titles because Sentry groups minidump-native events with platform-derived metadata.
+- Current semantic test names are:
+  - `desktop.renderer.exception.test`
+  - `desktop.renderer.crash.test`
+  - `desktop.main.crash.test`
+- If needed later, native crash differentiation should rely on tags/context/fingerprint rather than expecting Sentry issue titles to be fully customizable.


### PR DESCRIPTION
## Summary

This PR adds a crash diagnostics surface to the desktop runtime and wires the optional desktop Sentry DSN into both renderer/main crash reporting so the host can use native reporting when configured.

## Changes

- propagate `NEXU_DESKTOP_SENTRY_DSN` through runtime config, bootstrap, and Helm values so the desktop app either boots Sentry or falls back to crashReporter
- expose diagnostics host APIs, renderer bootstrap data, and crash triggers so the UI can request diagnostics metadata and force renderer/main failures
- implement the Diagnostics surface with cards, summaries, layout tweaks, and new CSS to drive native crash testing and reporting
- add `@sentry/electron` and refresh the lockfile so the desktop app can ship with the native client