### PR TITLE
fix(api): remove link/ prefix from cloud model IDs

### DIFF
--- a/apps/api/src/routes/model-routes.ts
+++ b/apps/api/src/routes/model-routes.ts
@@ -54,10 +54,12 @@ function readCachedCloudModels(): {
 
 /**
  * In desktop mode, load cloud models from credentials file.
+ * Model IDs are passed through as-is (no prefix) since gateway routes them
+ * to Link gateway based on cloud-credentials.json configuration.
  */
 function getCloudModels(): Model[] {
   return readCachedCloudModels().map((m) => ({
-    id: `link/${m.id}`,
+    id: m.id,
     name: m.name || m.id,
     provider: m.provider ?? "nexu",
     description: "Cloud model via Nexu Link",


### PR DESCRIPTION
## Summary
- Remove `link/` prefix from cloud model IDs in desktop mode
- Model IDs are passed through as-is since gateway routes them to the Link gateway based on `cloud-credentials.json` configuration
- The `link/` prefix was causing model ID mismatch

## Test plan
- [ ] Verify cloud models appear with correct IDs in desktop mode
- [ ] Verify gateway correctly routes model requests to Link

🤖 Generated with [Claude Code](https://claude.com/claude-code)