### PR TITLE
fix(desktop): restart API when PGlite restarts to prevent stale connections

### DIFF
--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -7,9 +7,16 @@ const databaseUrl =
 
 export const pool = new Pool({
   connectionString: databaseUrl,
-  max: 5,
+  max: 32,
   connectionTimeoutMillis: 5000,
   idleTimeoutMillis: 30000,
 });
+
+// Handle pool errors to prevent unhandled 'error' events from crashing the process.
+// This can happen when PGlite restarts or connections drop unexpectedly.
+pool.on("error", (err) => {
+  console.error("[pool] Unexpected error on idle client:", err.message);
+});
+
 export const db = drizzle(pool, { schema });
 export type Database = typeof db;

--- a/apps/desktop/main/runtime/daemon-supervisor.ts
+++ b/apps/desktop/main/runtime/daemon-supervisor.ts
@@ -152,7 +152,35 @@ export class RuntimeOrchestrator {
   }
 
   async stopOne(id: string): Promise<RuntimeState> {
+    const record = this.requireRecord(id);
+    // Stop dependents first (units that depend on this one)
+    const dependents = record.manifest.dependents ?? [];
+    for (const depId of dependents) {
+      if (this.units.has(depId)) {
+        await this.stopUnit(depId);
+      }
+    }
     await this.stopUnit(id);
+    return this.getRuntimeState();
+  }
+
+  async restartOne(id: string): Promise<RuntimeState> {
+    const record = this.requireRecord(id);
+    const dependents = record.manifest.dependents ?? [];
+    // Stop dependents first, then this unit
+    for (const depId of dependents) {
+      if (this.units.has(depId)) {
+        await this.stopUnit(depId);
+      }
+    }
+    await this.stopUnit(id);
+    // Start this unit, then dependents
+    await this.startUnit(id);
+    for (const depId of dependents) {
+      if (this.units.has(depId)) {
+        await this.startUnit(depId);
+      }
+    }
     return this.getRuntimeState();
   }
 

--- a/apps/desktop/main/runtime/manifests.ts
+++ b/apps/desktop/main/runtime/manifests.ts
@@ -225,6 +225,8 @@ export function createRuntimeUnitManifests(
       startupTimeoutMs: 10_000,
       autoStart: getBooleanEnv("NEXU_DESKTOP_AUTOSTART_PGLITE", true),
       logFilePath: path.resolve(logsDir, "pglite.log"),
+      // API depends on PGlite - restart API when PGlite restarts
+      dependents: ["api"],
       env: {
         PGLITE_DATA_DIR: pgliteDataPath,
         PGLITE_HOST: "127.0.0.1",

--- a/apps/desktop/main/runtime/types.ts
+++ b/apps/desktop/main/runtime/types.ts
@@ -26,6 +26,8 @@ export type RuntimeUnitManifest = {
   autoStart: boolean;
   env?: NodeJS.ProcessEnv;
   logFilePath?: string;
+  /** Units that depend on this one and should be restarted when this unit restarts. */
+  dependents?: RuntimeUnitId[];
 };
 
 export type RuntimeUnitRecord = {


### PR DESCRIPTION
## Summary

- Fix database connection timeout issue when PGlite restarts
- Add `dependents` field to RuntimeUnitManifest for restart dependencies  
- API automatically restarts when PGlite restarts, ensuring fresh connections
- Add pool error handler to prevent crashes from unexpected disconnections

## Test plan

- [ ] Start desktop app with `./apps/desktop/dev.sh start`
- [ ] Trigger PGlite restart (e.g., via control plane or by stopping/starting)
- [ ] Verify API also restarts and database queries work without timeout
- [ ] Verify Feishu connect and other DB-dependent endpoints work after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)