### PR TITLE
fix(desktop): eliminate startup page flash in packaged builds

### DIFF
--- a/apps/desktop/preload/index.ts
+++ b/apps/desktop/preload/index.ts
@@ -23,6 +23,7 @@ const runtimeConfig = getDesktopRuntimeConfig(process.env, {
 const hostBridge: HostBridge = {
   bootstrap: {
     sentryDsn: runtimeConfig.sentryDsn,
+    isPackaged: !process.defaultApp,
   },
 
   invoke<TChannel extends HostInvokeChannel>(

--- a/apps/desktop/shared/host.ts
+++ b/apps/desktop/shared/host.ts
@@ -270,6 +270,7 @@ export type HostBridge = {
 
 export type HostBootstrap = {
   sentryDsn: string | null;
+  isPackaged: boolean;
 };
 
 export type UpdateSource = "r2" | "github";

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -931,8 +931,13 @@ function DiagnosticsPage() {
 }
 
 function DesktopShell() {
-  const [activeSurface, setActiveSurface] = useState<DesktopSurface>("control");
-  const [chromeMode, setChromeMode] = useState<DesktopChromeMode>("full");
+  const isPackaged = window.nexuHost.bootstrap.isPackaged;
+  const [activeSurface, setActiveSurface] = useState<DesktopSurface>(
+    isPackaged ? "web" : "control",
+  );
+  const [chromeMode, setChromeMode] = useState<DesktopChromeMode>(
+    isPackaged ? "immersive" : "full",
+  );
   const [webSurfaceVersion, setWebSurfaceVersion] = useState(0);
   const [runtimeConfig, setRuntimeConfig] =
     useState<DesktopRuntimeConfig | null>(null);
@@ -941,16 +946,6 @@ function DesktopShell() {
   useEffect(() => {
     void getRuntimeConfig()
       .then(setRuntimeConfig)
-      .catch(() => null);
-
-    // In packaged builds, default to web surface in immersive mode
-    void getAppInfo()
-      .then((info) => {
-        if (!info.isDev) {
-          setActiveSurface("web");
-          setChromeMode("immersive");
-        }
-      })
       .catch(() => null);
   }, []);
 


### PR DESCRIPTION
## Summary

- Fixes packaged builds flashing through Control Plane page before reaching the welcome page
- Root cause: `DesktopShell` initialized with `activeSurface="control"` (dev default), then asynchronously switched to `"web"` after an IPC round-trip to `getAppInfo()` — causing a visible page transition
- Fix: expose `isPackaged` synchronously via the preload `bootstrap` object (using `process.defaultApp`), so the renderer initializes with the correct surface/chrome mode from the first render frame
- Packaged builds now start directly in `web` + `immersive` mode — user sees only the loading spinner → welcome page (single clean transition)

## Changes

| File | Change |
|------|--------|
| `shared/host.ts` | Add `isPackaged: boolean` to `HostBootstrap` type |
| `preload/index.ts` | Set `isPackaged: !process.defaultApp` in bootstrap |
| `src/main.tsx` | Use sync `bootstrap.isPackaged` for initial state instead of async `getAppInfo()` |

## Test plan

- [ ] Dev mode: still shows Control Plane as default surface
- [ ] Packaged build: starts directly in web/immersive mode, no Control Plane flash
- [ ] Switching surfaces via menu/command still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)