### PR TITLE
chore(desktop): bump version to 0.1.1

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexu/desktop",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "main": "dist-electron/main/bootstrap.js",


### PR DESCRIPTION
## Summary
- Bump desktop version from 0.1.0 to 0.1.1
- Needed to trigger auto-update on test clients (electron-updater compares version numbers)

## Test plan
- [ ] Merge and trigger test nightly build
- [ ] Verify installed 0.1.0 clients detect 0.1.1 update

🤖 Generated with [Claude Code](https://claude.com/claude-code)