### PR TITLE
style(web): highlight GitHub Star card on home page

### DIFF
--- a/apps/web/src/pages/home.tsx
+++ b/apps/web/src/pages/home.tsx
@@ -275,6 +275,9 @@ function FeishuIconChat({ size = 14 }: { size?: number }) {
 const actionCardBaseClass =
   "block group rounded-[18px] border border-border/70 bg-surface-1/95 px-3.5 py-2.5 text-left transition-all duration-200 hover:border-border-hover hover:bg-surface-1 hover:shadow-[0_4px_12px_rgba(0,0,0,0.035)]";
 
+const actionCardHighlightClass =
+  "block group rounded-[18px] border border-accent/30 bg-accent/[0.03] px-3.5 py-2.5 text-left transition-all duration-200 hover:border-accent/50 hover:bg-accent/[0.06] hover:shadow-md";
+
 export function HomePage() {
   const { t } = useTranslation();
   const [modalChannel, setModalChannel] = useState<
@@ -973,11 +976,11 @@ export function HomePage() {
             href={GITHUB_URL}
             target="_blank"
             rel="noopener noreferrer"
-            className={actionCardBaseClass}
+            className={actionCardHighlightClass}
           >
             <div className="flex items-center justify-between gap-3">
               <div className="flex items-center gap-2.5 min-w-0">
-                <div className="w-6 h-6 rounded-lg bg-[#111]/8 dark:bg-white/8 flex items-center justify-center shrink-0">
+                <div className="w-6 h-6 rounded-lg bg-accent/10 flex items-center justify-center shrink-0">
                   {GITHUB_SVG}
                 </div>
                 <div className="text-[14px] font-semibold text-text-primary truncate">


### PR DESCRIPTION
## Summary
- 为首页 GitHub Star 卡片添加 accent 主题色高亮样式，使其与其他操作卡片形成视觉区分
- GitHub 图标背景从灰色改为 accent 色调，与卡片整体风格统一

## Test plan
- [ ] `pnpm --filter @nexu/web dev` 查看首页，确认 Star 卡片视觉上更突出
- [ ] 检查 dark mode 下的显示效果
- [ ] 确认 hover 效果正常（边框加深、背景加深、阴影）

🤖 Generated with [Claude Code](https://claude.com/claude-code)