### PR TITLE
fix: normalize provider base URLs

### DIFF
--- a/apps/api/src/lib/config-generator.ts
+++ b/apps/api/src/lib/config-generator.ts
@@ -20,6 +20,7 @@ import {
 } from "../db/schema/index.js";
 import { decrypt } from "./crypto.js";
 import { ServiceError } from "./error.js";
+import { normalizeProviderBaseUrl } from "./provider-base-url.js";
 
 /**
  * Load cloud connection credentials (Link gateway) in desktop mode.
@@ -402,7 +403,7 @@ export async function generatePoolConfig(
                 provider: "openai",
                 model: "google/gemini-embedding-001",
                 remote: {
-                  baseUrl: "https://openrouter.ai/api/v1/",
+                  baseUrl: "https://openrouter.ai/api/v1",
                   apiKey: process.env.OPENROUTER_API_KEY,
                 },
                 sync: {
@@ -560,7 +561,9 @@ export async function generatePoolConfig(
   for (const bp of byokProviders) {
     const providerKey =
       bp.providerId === "custom" ? `custom_${bp.id}` : bp.providerId;
-    const baseUrl = bp.baseUrl ?? byokDefaultBaseUrls[bp.providerId];
+    const baseUrl = normalizeProviderBaseUrl(
+      bp.baseUrl ?? byokDefaultBaseUrls[bp.providerId],
+    );
     if (!baseUrl) continue;
 
     const modelIds: string[] = JSON.parse(bp.modelsJson || "[]");

--- a/apps/api/src/lib/provider-base-url.ts
+++ b/apps/api/src/lib/provider-base-url.ts
@@ -1,0 +1,21 @@
+export function normalizeProviderBaseUrl(
+  baseUrl: string | null | undefined,
+): string | null {
+  if (baseUrl == null) return null;
+
+  const trimmed = baseUrl.trim();
+  if (!trimmed) return null;
+
+  return trimmed.replace(/\/+$/, "");
+}
+
+export function buildProviderUrl(
+  baseUrl: string | null | undefined,
+  path: string,
+): string | null {
+  const normalizedBaseUrl = normalizeProviderBaseUrl(baseUrl);
+  if (!normalizedBaseUrl) return null;
+
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${normalizedBaseUrl}${normalizedPath}`;
+}

--- a/apps/api/src/routes/model-routes.ts
+++ b/apps/api/src/routes/model-routes.ts
@@ -19,6 +19,10 @@ import { db, pool } from "../db/index.js";
 import { modelProviders } from "../db/schema/index.js";
 import { decrypt, encrypt } from "../lib/crypto.js";
 import { PLATFORM_MODELS } from "../lib/models.js";
+import {
+  buildProviderUrl,
+  normalizeProviderBaseUrl,
+} from "../lib/provider-base-url.js";
 
 import type { AppBindings } from "../types.js";
 
@@ -213,9 +217,10 @@ const PROVIDER_BASE_URLS: Record<string, string> = {
 };
 
 function getVerifyUrl(providerId: string, baseUrl?: string | null): string {
-  if (baseUrl) return `${baseUrl}/models`;
+  const customVerifyUrl = buildProviderUrl(baseUrl, "/models");
+  if (customVerifyUrl) return customVerifyUrl;
   const base = PROVIDER_BASE_URLS[providerId];
-  if (base) return `${base}/models`;
+  if (base) return buildProviderUrl(base, "/models") ?? "";
   return "";
 }
 
@@ -267,7 +272,9 @@ export function registerModelRoutes(app: OpenAPIHono<AppBindings>) {
       const updates: Record<string, unknown> = { updatedAt: now };
       if (body.apiKey !== undefined)
         updates.encryptedApiKey = encrypt(body.apiKey);
-      if (body.baseUrl !== undefined) updates.baseUrl = body.baseUrl;
+      if (body.baseUrl !== undefined) {
+        updates.baseUrl = normalizeProviderBaseUrl(body.baseUrl);
+      }
       if (body.enabled !== undefined) updates.enabled = body.enabled;
       if (body.displayName !== undefined)
         updates.displayName = body.displayName;
@@ -349,7 +356,7 @@ export function registerModelRoutes(app: OpenAPIHono<AppBindings>) {
       providerId,
       displayName,
       encryptedApiKey: encrypt(body.apiKey),
-      baseUrl: body.baseUrl ?? null,
+      baseUrl: normalizeProviderBaseUrl(body.baseUrl),
       enabled: body.enabled ?? true,
       modelsJson: body.modelsJson ?? "[]",
       createdAt: now,

--- a/tests/api/lib/provider-base-url.test.ts
+++ b/tests/api/lib/provider-base-url.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildProviderUrl,
+  normalizeProviderBaseUrl,
+} from "#api/lib/provider-base-url.js";
+
+describe("provider base URL helpers", () => {
+  it("removes trailing slashes from provider base URLs", () => {
+    expect(normalizeProviderBaseUrl("https://openrouter.ai/api/v1///")).toBe(
+      "https://openrouter.ai/api/v1",
+    );
+  });
+
+  it("returns null for blank provider base URLs", () => {
+    expect(normalizeProviderBaseUrl("   ")).toBeNull();
+  });
+
+  it("joins normalized base URLs with request paths", () => {
+    expect(buildProviderUrl("https://openrouter.ai/api/v1/", "/models")).toBe(
+      "https://openrouter.ai/api/v1/models",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- normalize provider base URLs by trimming trailing slashes before storing or using them
- reuse the normalized URL for provider verification requests and runtime config generation
- add tests covering trailing slash normalization and provider URL joining

## Testing
- pnpm typecheck
- pnpm lint
- pnpm exec vitest run tests/api/lib/provider-base-url.test.ts