### PR TITLE
feat(web): auto-detect Chinese locale on landing

### DIFF
--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -4,6 +4,7 @@ import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 import { AuthLayout } from "./layouts/auth-layout";
 import { InviteGuardLayout } from "./layouts/invite-guard-layout";
 import { WorkspaceLayout } from "./layouts/workspace-layout";
+import { shouldAutoRedirectToZh } from "./lib/locale";
 import { AuthPage } from "./pages/auth";
 import { ChannelsPage } from "./pages/channels";
 import { CommunitySkillDetailPage } from "./pages/community-skill-detail";
@@ -46,12 +47,23 @@ function DocumentTitleSync() {
   return null;
 }
 
+function LandingRoute() {
+  const location = useLocation();
+
+  if (shouldAutoRedirectToZh(location.pathname)) {
+    return <Navigate to="/zh" replace />;
+  }
+
+  return <WelcomePage />;
+}
+
 export function App() {
   return (
     <>
       <DocumentTitleSync />
       <Routes>
-        <Route path="/" element={<WelcomePage />} />
+        <Route path="/" element={<LandingRoute />} />
+        <Route path="/zh" element={<WelcomePage />} />
         <Route path="/auth" element={<AuthPage />} />
         <Route path="/claim" element={<SlackClaimPage />} />
         <Route path="/feishu/bind" element={<FeishuBindPage />} />
@@ -89,6 +101,7 @@ export function App() {
             </Route>
           </Route>
         </Route>
+        <Route path="/zh/*" element={<Navigate to="/zh" replace />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </>

--- a/apps/web/src/components/language-switcher.tsx
+++ b/apps/web/src/components/language-switcher.tsx
@@ -1,6 +1,7 @@
 import { ChevronDown, Globe } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
-import { type Locale, useLocale } from "../hooks/use-locale";
+import { useLocale } from "../hooks/use-locale";
+import type { Locale } from "../lib/locale";
 
 interface Props {
   variant?: "light" | "dark" | "muted";

--- a/apps/web/src/hooks/use-locale.tsx
+++ b/apps/web/src/hooks/use-locale.tsx
@@ -6,26 +6,16 @@ import {
   useContext,
   useState,
 } from "react";
-
-export type Locale = "en" | "zh";
+import {
+  type Locale,
+  detectPreferredLocale,
+  persistLocale,
+} from "../lib/locale";
 
 interface LocaleCtx {
   locale: Locale;
   setLocale: (l: Locale) => void;
   t: (key: string) => string;
-}
-
-const STORAGE_KEY = "nexu_locale";
-
-function detectDefault(): Locale {
-  try {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored === "en" || stored === "zh") return stored;
-  } catch {
-    /* ignore */
-  }
-  const lang = navigator.language || "";
-  return lang.startsWith("zh") ? "zh" : "en";
 }
 
 const LocaleContext = createContext<LocaleCtx>({
@@ -35,16 +25,12 @@ const LocaleContext = createContext<LocaleCtx>({
 });
 
 export function LocaleProvider({ children }: { children: ReactNode }) {
-  const [locale, setLocaleState] = useState<Locale>(detectDefault);
+  const [locale, setLocaleState] = useState<Locale>(detectPreferredLocale);
 
   const setLocale = useCallback((l: Locale) => {
     setLocaleState(l);
     i18n.changeLanguage(l);
-    try {
-      localStorage.setItem(STORAGE_KEY, l);
-    } catch {
-      /* ignore */
-    }
+    persistLocale(l);
   }, []);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: locale dependency forces re-render on language change

--- a/apps/web/src/i18n/index.ts
+++ b/apps/web/src/i18n/index.ts
@@ -1,27 +1,15 @@
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
+import { detectPreferredLocale } from "../lib/locale";
 import en from "./locales/en";
 import zhCN from "./locales/zh-CN";
-
-const STORAGE_KEY = "nexu_locale";
-
-function detectLocale(): string {
-  try {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored === "en" || stored === "zh") return stored;
-  } catch {
-    /* ignore */
-  }
-  const lang = navigator.language || "";
-  return lang.startsWith("zh") ? "zh" : "en";
-}
 
 i18n.use(initReactI18next).init({
   resources: {
     en: { translation: en },
     zh: { translation: zhCN },
   },
-  lng: detectLocale(),
+  lng: detectPreferredLocale(),
   fallbackLng: "en",
   interpolation: { escapeValue: false },
 });

--- a/apps/web/src/layouts/workspace-layout.tsx
+++ b/apps/web/src/layouts/workspace-layout.tsx
@@ -1,6 +1,7 @@
 import { BrandMark } from "@/components/brand-mark";
-import { type Locale, useLocale } from "@/hooks/use-locale";
+import { useLocale } from "@/hooks/use-locale";
 import { authClient } from "@/lib/auth-client";
+import type { Locale } from "@/lib/locale";
 import { track } from "@/lib/tracking";
 import { cn } from "@/lib/utils";
 import { useQuery } from "@tanstack/react-query";

--- a/apps/web/src/lib/locale.ts
+++ b/apps/web/src/lib/locale.ts
@@ -1,0 +1,69 @@
+export type Locale = "en" | "zh";
+
+export const LOCALE_STORAGE_KEY = "nexu_locale";
+
+function readStoredLocale(): Locale | null {
+  try {
+    const stored = localStorage.getItem(LOCALE_STORAGE_KEY);
+    if (stored === "en" || stored === "zh") {
+      return stored;
+    }
+  } catch {
+    /* ignore */
+  }
+
+  return null;
+}
+
+function readEnvironmentLanguages(): string[] {
+  if (typeof navigator === "undefined") {
+    return [];
+  }
+
+  const languages = Array.isArray(navigator.languages)
+    ? navigator.languages
+    : [];
+
+  return [...languages, navigator.language].filter((value): value is string =>
+    Boolean(value),
+  );
+}
+
+function isZhLanguage(language: string): boolean {
+  return language.toLowerCase().startsWith("zh");
+}
+
+export function detectPreferredLocale(): Locale {
+  const stored = readStoredLocale();
+  if (stored) {
+    return stored;
+  }
+
+  const environmentLanguages = readEnvironmentLanguages();
+  if (environmentLanguages.some(isZhLanguage)) {
+    return "zh";
+  }
+
+  try {
+    const runtimeLocale = Intl.DateTimeFormat().resolvedOptions().locale;
+    if (runtimeLocale && isZhLanguage(runtimeLocale)) {
+      return "zh";
+    }
+  } catch {
+    /* ignore */
+  }
+
+  return "en";
+}
+
+export function shouldAutoRedirectToZh(pathname: string): boolean {
+  return pathname === "/" && detectPreferredLocale() === "zh";
+}
+
+export function persistLocale(locale: Locale): void {
+  try {
+    localStorage.setItem(LOCALE_STORAGE_KEY, locale);
+  } catch {
+    /* ignore */
+  }
+}


### PR DESCRIPTION
## Summary
- centralize locale detection so the web app consistently prefers saved language settings and falls back to browser or OS Chinese detection
- redirect visitors from `/` to `/zh` automatically when a Chinese locale is detected while keeping the existing welcome page behavior intact
- reuse the shared locale utility across i18n bootstrapping and locale switching so initial language and landing redirect stay in sync