### PR TITLE
chore: gitignore .wrangler/ and harden desktop safeWrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ apps/desktop/.dist-runtime/
 apps/desktop/.cache/
 apps/desktop/build-config.json
 .claude/settings.local.json
+.wrangler/

--- a/apps/desktop/main/bootstrap.ts
+++ b/apps/desktop/main/bootstrap.ts
@@ -2,17 +2,25 @@ import { existsSync, mkdirSync } from "node:fs";
 import { resolve } from "node:path";
 import { app } from "electron";
 
+function isIgnorableWriteError(error: unknown): boolean {
+  if (!(error instanceof Error) || !("code" in error)) return false;
+  const code = String(error.code);
+  return code === "EIO" || code === "EPIPE" || code === "ERR_STREAM_DESTROYED";
+}
+
 function safeWrite(stream: NodeJS.WriteStream, message: string): void {
   if (stream.destroyed || !stream.writable) {
     return;
   }
 
   try {
-    stream.write(message);
+    stream.write(message, (err) => {
+      if (err && !isIgnorableWriteError(err)) {
+        console.error("[safeWrite] async write error:", err);
+      }
+    });
   } catch (error) {
-    const errorCode =
-      error instanceof Error && "code" in error ? String(error.code) : null;
-    if (errorCode === "EIO" || errorCode === "EPIPE") {
+    if (isIgnorableWriteError(error)) {
       return;
     }
     throw error;

--- a/apps/desktop/main/runtime/daemon-supervisor.ts
+++ b/apps/desktop/main/runtime/daemon-supervisor.ts
@@ -30,17 +30,25 @@ function nowIso(): string {
   return new Date().toISOString();
 }
 
+function isIgnorableWriteError(error: unknown): boolean {
+  if (!(error instanceof Error) || !("code" in error)) return false;
+  const code = String(error.code);
+  return code === "EIO" || code === "EPIPE" || code === "ERR_STREAM_DESTROYED";
+}
+
 function safeWrite(stream: NodeJS.WriteStream, message: string): void {
   if (stream.destroyed || !stream.writable) {
     return;
   }
 
   try {
-    stream.write(message);
+    stream.write(message, (err) => {
+      if (err && !isIgnorableWriteError(err)) {
+        console.error("[safeWrite] async write error:", err);
+      }
+    });
   } catch (error) {
-    const errorCode =
-      error instanceof Error && "code" in error ? String(error.code) : null;
-    if (errorCode === "EIO" || errorCode === "EPIPE") {
+    if (isIgnorableWriteError(error)) {
       return;
     }
     throw error;

--- a/apps/desktop/main/runtime/runtime-logger.ts
+++ b/apps/desktop/main/runtime/runtime-logger.ts
@@ -22,9 +22,9 @@ const version =
   process.env.npm_package_version;
 
 function isIgnorableWriteError(error: unknown): boolean {
-  const errorCode =
-    error instanceof Error && "code" in error ? String(error.code) : null;
-  return errorCode === "EIO" || errorCode === "EPIPE";
+  if (!(error instanceof Error) || !("code" in error)) return false;
+  const code = String(error.code);
+  return code === "EIO" || code === "EPIPE" || code === "ERR_STREAM_DESTROYED";
 }
 
 let stdioErrorHandlersAttached = false;


### PR DESCRIPTION
## Summary

- Add `.wrangler/` to `.gitignore` — prevents local Miniflare R2 blobs and SQLite state from being committed
- Unify `isIgnorableWriteError()` across `bootstrap.ts`, `daemon-supervisor.ts`, and `runtime-logger.ts` to also handle `ERR_STREAM_DESTROYED`
- Add async write error callback to `safeWrite()` in bootstrap and daemon-supervisor

## Test plan

- [ ] `pnpm desktop:start` / `pnpm desktop:stop` cycle works without stream errors
- [ ] `.wrangler/` directory no longer shows in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)