### PR TITLE
fix: improve desktop build config and diagnostics

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -108,9 +108,16 @@ jobs:
           CLOUD_URL: ${{ inputs.cloud_url }}
           LINK_URL: ${{ inputs.link_url }}
           UPDATE_FEED_URL: ${{ inputs.update_feed_url }}
-          SENTRY_DSN: ${{ secrets.NEXU_DESKTOP_SENTRY_DSN }}
+          SENTRY_DSN_TEST: ${{ secrets.SENTRY_DSN_NEXU_DESKTOP_TEST }}
+          SENTRY_DSN_PROD: ${{ secrets.SENTRY_DSN_NEXU_DESKTOP_PROD }}
+          TARGET_ENVIRONMENT: ${{ inputs.environment }}
         run: |
           node -e '
+            const sentryDsnByEnvironment = {
+              test: process.env.SENTRY_DSN_TEST,
+              prod: process.env.SENTRY_DSN_PROD,
+            };
+            const sentryDsn = sentryDsnByEnvironment[process.env.TARGET_ENVIRONMENT] ?? "";
             const config = {
               NEXU_CLOUD_URL: process.env.CLOUD_URL,
               NEXU_LINK_URL: process.env.LINK_URL === "null" ? null : process.env.LINK_URL,
@@ -118,8 +125,8 @@ jobs:
             if (process.env.UPDATE_FEED_URL) {
               config.NEXU_UPDATE_FEED_URL = process.env.UPDATE_FEED_URL;
             }
-            if (process.env.SENTRY_DSN) {
-              config.NEXU_DESKTOP_SENTRY_DSN = process.env.SENTRY_DSN;
+            if (sentryDsn) {
+              config.NEXU_DESKTOP_SENTRY_DSN = sentryDsn;
             }
             require("fs").writeFileSync(
               "apps/desktop/build-config.json",

--- a/apps/desktop/scripts/notarize.cjs
+++ b/apps/desktop/scripts/notarize.cjs
@@ -1,7 +1,6 @@
 const { access } = require("node:fs/promises");
 const { constants } = require("node:fs");
 const path = require("node:path");
-const { notarize: notarizeApp } = require("@electron/notarize");
 
 module.exports = async function notarize(context) {
   if (context.electronPlatformName !== "darwin") {
@@ -48,6 +47,8 @@ module.exports = async function notarize(context) {
     );
     return;
   }
+
+  const { notarize: notarizeApp } = await import("@electron/notarize");
 
   await notarizeApp({
     appPath,

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -61,6 +61,24 @@ if (rendererSentryDsn) {
   initializeRendererSentry(rendererSentryDsn);
 }
 
+function maskSentryDsn(dsn: string | null | undefined): string {
+  if (!dsn) {
+    return "missing";
+  }
+
+  const match = dsn.match(/^(https?:\/\/)([^@]+)@(.+)$/);
+
+  if (!match) {
+    return "configured";
+  }
+
+  const [, protocol, publicKey, hostAndPath] = match;
+  const visibleKey = publicKey.slice(-6);
+  const maskedKey = `${"*".repeat(Math.max(publicKey.length - 6, 3))}${visibleKey}`;
+
+  return `${protocol}${maskedKey}@${hostAndPath}`;
+}
+
 if (amplitudeApiKey) {
   amplitude.initAll(amplitudeApiKey, {
     analytics: { autocapture: true },
@@ -211,12 +229,14 @@ function SurfaceButton({
 function SummaryCard({
   label,
   value,
+  className,
 }: {
   label: string;
   value: string | number;
+  className?: string;
 }) {
   return (
-    <div>
+    <div className={className}>
       <dt>{label}</dt>
       <dd>{value}</dd>
     </div>
@@ -848,10 +868,6 @@ function DiagnosticsPage() {
           value={appInfo ? (appInfo.isDev ? "development" : "packaged") : "-"}
         />
         <SummaryCard
-          label="Crash dumps"
-          value={diagnosticsInfo?.crashDumpsPath ?? "-"}
-        />
-        <SummaryCard
           label="Native crashes"
           value={
             diagnosticsInfo
@@ -862,23 +878,15 @@ function DiagnosticsPage() {
           }
         />
         <SummaryCard
-          label="Sentry main"
-          value={
-            diagnosticsInfo
-              ? diagnosticsInfo.sentryMainEnabled
-                ? "enabled"
-                : "off"
-              : "-"
-          }
+          label="Crash dumps"
+          className="diagnostics-summary-wide"
+          value={diagnosticsInfo?.crashDumpsPath ?? "-"}
         />
         <SummaryCard
-          label="Sentry renderer"
+          label="Sentry DSN"
+          className="diagnostics-summary-wide"
           value={
-            diagnosticsInfo
-              ? diagnosticsInfo.sentryMainEnabled
-                ? "enabled"
-                : "off"
-              : "-"
+            diagnosticsInfo ? maskSentryDsn(diagnosticsInfo.sentryDsn) : "-"
           }
         />
       </section>

--- a/apps/desktop/src/runtime-page.css
+++ b/apps/desktop/src/runtime-page.css
@@ -408,6 +408,14 @@ body,
   font-weight: 600;
 }
 
+.diagnostics-summary-wide {
+  grid-column: 1 / -1;
+}
+
+.diagnostics-summary-wide dd {
+  overflow-wrap: anywhere;
+}
+
 .runtime-pane-layout {
   max-width: 1080px;
   margin: 0 auto;


### PR DESCRIPTION
## Summary

This PR ensures the desktop build config uses environment-specific Sentry DSNs, notarization helper imports lazily, and diagnostics UI masks DSN details while keeping crash dump info visible.

## Changes

- add TEST/PROD SENTRY DSN inputs and resolve the correct value before writing `build-config.json`
- lazily import `@electron/notarize` so the helper only loads when notarization runs
- mask rendered Sentry DSN values and give crash dump/Sentry summary cards a wider layout with matching styles