### PR TITLE
docs: polish README — emoji, IM mobile, use case stories, nav links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">nexu</h1>
 
 <p align="center">
-  <strong>The Simplest OpenClaw Desktop for One Person Company</strong>
+  <strong>The Simplest OpenClaw 🦞 Desktop for One Person Company</strong>
 </p>
 
 <p align="center">
@@ -29,9 +29,9 @@
 
 ## Overview
 
-**nexu** (next to you) turns OpenClaw into a desktop experience you can start using in seconds ⚡. Download the Mac client, double-click to install, and your first AI agent is ready before you finish reading this paragraph.
+**nexu** (next to you) turns OpenClaw 🦞 into a desktop experience you can start using in seconds ⚡. Download the Mac client, double-click to install, and your first AI agent is ready before you finish reading this paragraph.
 
-Built on the open-source OpenClaw core, nexu bundles **OpenClaw Skills** and **full Feishu Skills** so agents plug directly into the workflows your team already uses 🔌. Access Claude 4.6, ChatGPT 5.4, Minimax 2.5, GLM 5.0, Kimi 2.5, and more via your nexu account—or bring your own API Key with no login required 🔓.
+Built on the open-source OpenClaw 🦞 core, nexu bundles **OpenClaw 🦞 Skills** and **full Feishu Skills** so agents plug directly into the workflows your team already uses 🔌. Access Claude 4.6, ChatGPT 5.4, Minimax 2.5, GLM 5.0, Kimi 2.5, and more via your nexu account—or bring your own API Key with no login required 🔓.
 
 Connect to Feishu, Slack, or Discord—and your AI agent goes mobile 📱. No extra app needed; just chat with your agent wherever you already are.
 
@@ -46,7 +46,7 @@ Open-source agent tools often force users through long install guides and scatte
 | Challenge | nexu |
 |-----------|------|
 | 😩 Complex CLI / env setup | ✅ One double-click install; no terminal required |
-| 🧩 Scattered skill integration | ✅ Built-in OpenClaw + full Feishu Skills, ready to use |
+| 🧩 Scattered skill integration | ✅ Built-in OpenClaw 🦞 + full Feishu Skills, ready to use |
 | 🔧 Model and API key juggling | ✅ nexu account for top models, or bring your own API Key |
 | 🎭 "Demo only" agents | ✅ A desktop client built for real team workflows |
 | 🚪 Login walls | ✅ Use your own API Key with zero sign-up |
@@ -62,9 +62,9 @@ Open-source agent tools often force users through long install guides and scatte
 
 Download, double-click, start using. No environment variables, no dependency wrestling, no long install docs. nexu's first run is as capable as it gets—ready out of the box.
 
-### 🔗 Built-in OpenClaw Skills + full Feishu Skills
+### 🔗 Built-in OpenClaw 🦞 Skills + full Feishu Skills
 
-Native OpenClaw Skills and full Feishu Skills ship together. Agents move beyond demos and into the real workflows your team already uses—without extra integration work.
+Native OpenClaw 🦞 Skills and full Feishu Skills ship together. Agents move beyond demos and into the real workflows your team already uses—without extra integration work.
 
 ### 🧠 Top-tier models, out of the box
 
@@ -224,7 +224,7 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 
 nexu is built on the shoulders of excellent open-source projects:
 
-- [OpenClaw](https://github.com/nexu-io/nexu) — The AI agent runtime
+- [OpenClaw 🦞](https://github.com/nexu-io/nexu) — The AI agent runtime
 - [Electron](https://www.electronjs.org/) — Cross-platform desktop framework
 - [React](https://react.dev/) — UI component library
 - [Tailwind CSS](https://tailwindcss.com/) — Utility-first CSS framework

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -5,7 +5,7 @@
 <h1 align="center">nexu</h1>
 
 <p align="center">
-  <strong>The Simplest OpenClaw Desktop for One Person Company</strong>
+  <strong>The Simplest OpenClaw 🦞 Desktop for One Person Company</strong>
 </p>
 
 <p align="center">
@@ -29,9 +29,9 @@
 
 ## 概述
 
-**nexu**（next to you）将 OpenClaw 变成一个桌面体验 ⚡——下载 Mac 客户端，双击安装，几秒钟内你的第一个 AI Agent 就已就绪。
+**nexu**（next to you）将 OpenClaw 🦞 变成一个桌面体验 ⚡——下载 Mac 客户端，双击安装，几秒钟内你的第一个 AI Agent 就已就绪。
 
-基于开源 OpenClaw 核心打造，nexu 预装 **OpenClaw Skills** 与 **完整飞书 Skills**，让 Agent 直接接入你团队已在用的工作流 🔌。通过 nexu 账号即可使用 Claude 4.6、ChatGPT 5.4、Minimax 2.5、GLM 5.0、Kimi 2.5 等顶级模型，也可使用自带 API Key，无需登录 🔓。
+基于开源 OpenClaw 🦞 核心打造，nexu 预装 **OpenClaw 🦞 Skills** 与 **完整飞书 Skills**，让 Agent 直接接入你团队已在用的工作流 🔌。通过 nexu 账号即可使用 Claude 4.6、ChatGPT 5.4、Minimax 2.5、GLM 5.0、Kimi 2.5 等顶级模型，也可使用自带 API Key，无需登录 🔓。
 
 连接飞书、Slack 或 Discord，你的 AI Agent 即刻上手机 📱。无需额外 App，在你常用的聊天工具里直接和 Agent 对话。
 
@@ -46,7 +46,7 @@
 | 常见问题 | nexu |
 |----------|------|
 | 😩 复杂的 CLI / 环境配置 | ✅ 双击安装，无需终端 |
-| 🧩 技能与集成东拼西凑 | ✅ 内置 OpenClaw + 完整飞书 Skills，开箱即用 |
+| 🧩 技能与集成东拼西凑 | ✅ 内置 OpenClaw 🦞 + 完整飞书 Skills，开箱即用 |
 | 🔧 模型与 API Key 配置 | ✅ nexu 账号直连顶级模型，或自带 API Key |
 | 🎭 Agent 只能"演示" | ✅ 面向真实团队工作流的桌面客户端 |
 | 🚪 必须注册才能用 | ✅ 自带 API Key 即可使用，零注册零登录 |
@@ -62,9 +62,9 @@
 
 下载、双击、开始使用。无需环境变量、无需折腾依赖、无需长文档。nexu 的首次体验与能力一致——开箱即用。
 
-### 🔗 内置 OpenClaw Skills + 完整飞书 Skills
+### 🔗 内置 OpenClaw 🦞 Skills + 完整飞书 Skills
 
-原生 OpenClaw Skills 与完整飞书 Skills 一并提供。Agent 不再停留在演示，而是直接进入团队真实工作流，无需额外集成。
+原生 OpenClaw 🦞 Skills 与完整飞书 Skills 一并提供。Agent 不再停留在演示，而是直接进入团队真实工作流，无需额外集成。
 
 ### 🧠 顶级模型，开箱即用
 
@@ -224,7 +224,7 @@ pnpm test                # 运行测试（Vitest）
 
 nexu 基于以下优秀开源项目构建：
 
-- [OpenClaw](https://github.com/nexu-io/nexu) — AI Agent 运行时
+- [OpenClaw 🦞](https://github.com/nexu-io/nexu) — AI Agent 运行时
 - [Electron](https://www.electronjs.org/) — 跨平台桌面框架
 - [React](https://react.dev/) — UI 组件库
 - [Tailwind CSS](https://tailwindcss.com/) — 实用优先的 CSS 框架


### PR DESCRIPTION
## Summary

- Add emoji throughout section headers and descriptions for better visual appeal
- Add IM-connected mobile-ready messaging in Overview, Why nexu table, and Features
- Replace flat use case descriptions with vivid first-person user stories (each mentioning specific IM tools)
- Update top nav links to: Website → Download → Docs → Feishu → Discord (removed Wiki)
- Add `nexu (next to you)` brand meaning in Overview
- Use full "One Person Company" instead of OPC abbreviation
- Remove Telegram references (not yet supported), keep Feishu/Slack/Discord
- Fix duplicate separator line before Community section
- Add Contributors avatar wall (contrib.rocks) in Community

## Test plan

- [ ] Verify README renders correctly on GitHub (EN & CN)
- [ ] Verify nav links (Download, Docs, Feishu, Discord) all resolve correctly
- [ ] Verify use case stories display properly in blockquote format
- [ ] Verify Contributors section renders avatar images


Made with [Cursor](https://cursor.com)