### PR TITLE
feat: surface desktop build metadata

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -34,6 +34,10 @@ on:
         required: false
         type: string
         default: ""
+      build_source:
+        description: "Build source label embedded in desktop metadata"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -108,10 +112,14 @@ jobs:
           CLOUD_URL: ${{ inputs.cloud_url }}
           LINK_URL: ${{ inputs.link_url }}
           UPDATE_FEED_URL: ${{ inputs.update_feed_url }}
+          BUILD_SOURCE: ${{ inputs.build_source }}
+          BUILD_BRANCH: ${{ github.ref_name }}
+          BUILD_COMMIT: ${{ github.sha }}
           SENTRY_DSN_TEST: ${{ secrets.SENTRY_DSN_NEXU_DESKTOP_TEST }}
           SENTRY_DSN_PROD: ${{ secrets.SENTRY_DSN_NEXU_DESKTOP_PROD }}
           TARGET_ENVIRONMENT: ${{ inputs.environment }}
         run: |
+          export BUILT_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
           node -e '
             const sentryDsnByEnvironment = {
               test: process.env.SENTRY_DSN_TEST,
@@ -121,6 +129,10 @@ jobs:
             const config = {
               NEXU_CLOUD_URL: process.env.CLOUD_URL,
               NEXU_LINK_URL: process.env.LINK_URL === "null" ? null : process.env.LINK_URL,
+              NEXU_DESKTOP_BUILD_SOURCE: process.env.BUILD_SOURCE,
+              NEXU_DESKTOP_BUILD_BRANCH: process.env.BUILD_BRANCH,
+              NEXU_DESKTOP_BUILD_COMMIT: process.env.BUILD_COMMIT,
+              NEXU_DESKTOP_BUILD_TIME: process.env.BUILT_AT,
             };
             if (process.env.UPDATE_FEED_URL) {
               config.NEXU_UPDATE_FEED_URL = process.env.UPDATE_FEED_URL;

--- a/.github/workflows/desktop-nightly-test.yml
+++ b/.github/workflows/desktop-nightly-test.yml
@@ -21,6 +21,7 @@ jobs:
       cloud_url: "https://nexu.powerformer.net"
       link_url: "https://nexu-link.powerformer.net"
       update_feed_url: "https://desktop-releases.nexu.io/test"
+      build_source: "nightly-test"
       release_tag: desktop-nightly-test
       release_name: "Nexu Desktop Nightly (Test)"
       artifact_suffix: "-test"

--- a/.github/workflows/desktop-nightly.yml
+++ b/.github/workflows/desktop-nightly.yml
@@ -21,6 +21,7 @@ jobs:
       cloud_url: "https://nexu.io"
       link_url: "https://link.nexu.io"
       update_feed_url: "https://desktop-releases.nexu.io/nightly"
+      build_source: "nightly-prod"
       release_tag: desktop-nightly
       release_name: "Nexu Desktop Nightly"
       artifact_suffix: ""

--- a/apps/desktop/dev.sh
+++ b/apps/desktop/dev.sh
@@ -104,10 +104,14 @@ build_runtime() {
 }
 
 start_session() {
+  local build_branch build_commit built_at
+  build_branch="$(git -C "$ROOT_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || printf '%s' 'unknown')"
+  build_commit="$(git -C "$ROOT_DIR" rev-parse HEAD 2>/dev/null || printf '%s' 'unknown')"
+  built_at="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
   run_logged pnpm --dir "$ROOT_DIR" exec electron --version
   log "starting tmux session '$SESSION_NAME'"
   tmux new-session -d -s "$SESSION_NAME" \
-    "cd \"$ROOT_DIR\" && export NEXU_WORKSPACE_ROOT=\"$ROOT_DIR\" NEXU_DESKTOP_APP_ROOT=\"$ELECTRON_DIR\" NEXU_DESKTOP_RUNTIME_ROOT=\"$NEXU_DESKTOP_RUNTIME_ROOT\"; pnpm exec electron apps/desktop; sleep 2; while pgrep -f \"$ELECTRON_MAIN_MATCH\" >/dev/null; do sleep 1; done"
+    "cd \"$ROOT_DIR\" && export NEXU_WORKSPACE_ROOT=\"$ROOT_DIR\" NEXU_DESKTOP_APP_ROOT=\"$ELECTRON_DIR\" NEXU_DESKTOP_RUNTIME_ROOT=\"$NEXU_DESKTOP_RUNTIME_ROOT\" NEXU_DESKTOP_BUILD_SOURCE=\"local-dev\" NEXU_DESKTOP_BUILD_BRANCH=\"$build_branch\" NEXU_DESKTOP_BUILD_COMMIT=\"$build_commit\" NEXU_DESKTOP_BUILD_TIME=\"$built_at\"; pnpm exec electron apps/desktop; sleep 2; while pgrep -f \"$ELECTRON_MAIN_MATCH\" >/dev/null; do sleep 1; done"
 }
 
 start() {

--- a/apps/desktop/main/index.ts
+++ b/apps/desktop/main/index.ts
@@ -39,6 +39,7 @@ const electronRoot = app.isPackaged
   ? process.resourcesPath
   : getDesktopAppRoot();
 const runtimeConfig = getDesktopRuntimeConfig(process.env, {
+  appVersion: app.getVersion(),
   resourcesPath: electronRoot,
 });
 const orchestrator = new RuntimeOrchestrator(

--- a/apps/desktop/main/ipc.ts
+++ b/apps/desktop/main/ipc.ts
@@ -123,6 +123,7 @@ export function registerIpcHandlers(
 
         case "env:get-api-base-url": {
           const apiBaseUrl = getDesktopRuntimeConfig(process.env, {
+            appVersion: app.getVersion(),
             resourcesPath: app.isPackaged ? process.resourcesPath : undefined,
           }).urls.apiBase;
 
@@ -135,6 +136,7 @@ export function registerIpcHandlers(
 
         case "env:get-runtime-config": {
           return getDesktopRuntimeConfig(process.env, {
+            appVersion: app.getVersion(),
             resourcesPath: app.isPackaged ? process.resourcesPath : undefined,
           });
         }

--- a/apps/desktop/scripts/dist-mac.mjs
+++ b/apps/desktop/scripts/dist-mac.mjs
@@ -1,6 +1,7 @@
 import { execFileSync, spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -8,6 +9,7 @@ const scriptDir = dirname(fileURLToPath(import.meta.url));
 const electronRoot = resolve(scriptDir, "..");
 const repoRoot =
   process.env.NEXU_WORKSPACE_ROOT ?? resolve(electronRoot, "../..");
+const require = createRequire(import.meta.url);
 const isUnsigned =
   process.argv.includes("--unsigned") ||
   process.env.NEXU_DESKTOP_MAC_UNSIGNED === "1" ||
@@ -59,6 +61,18 @@ function parseEnvFile(content) {
   return values;
 }
 
+function getGitValue(args) {
+  try {
+    return execFileSync("git", args, {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
 async function loadDesktopEnv() {
   const envPath = resolve(electronRoot, ".env");
 
@@ -99,13 +113,16 @@ function shellEscape(value) {
 }
 
 async function runElectronBuilder(args, options = {}) {
+  const electronBuilderCli = require.resolve("electron-builder/cli.js", {
+    paths: [electronRoot, repoRoot],
+  });
   const targetOpenFiles = process.env.NEXU_DESKTOP_MAX_OPEN_FILES ?? "8192";
   const command = [
     `target=${shellEscape(targetOpenFiles)}`,
     'hard_limit=$(ulimit -Hn 2>/dev/null || printf %s "$target")',
     'if [ "$hard_limit" != "unlimited" ] && [ "$hard_limit" -lt "$target" ]; then target="$hard_limit"; fi',
     'ulimit -n "$target" 2>/dev/null || true',
-    `exec pnpm exec electron-builder ${args.map(shellEscape).join(" ")}`,
+    `exec ${shellEscape(process.execPath)} ${shellEscape(electronBuilderCli)} ${args.map(shellEscape).join(" ")}`,
   ].join("; ");
 
   await run("bash", ["-lc", command], options);
@@ -196,20 +213,19 @@ async function stapleNotarizedAppBundles() {
 
 async function ensureBuildConfig() {
   const configPath = resolve(electronRoot, "build-config.json");
+  let existingConfig = {};
 
   try {
     const existing = await readFile(configPath, "utf8");
+    existingConfig = JSON.parse(existing);
     console.log(
-      "[dist:mac] using pre-generated build-config.json:",
+      "[dist:mac] loaded existing build-config.json:",
       existing.trim(),
     );
-    return;
   } catch {
-    // Generate from env when no pre-generated config is present.
+    // build-config.json is optional for local dist builds.
   }
 
-  // Generate build-config.json from environment variables / .env file
-  // so that secrets (cloud/link URLs) are never committed to the repo.
   const envPath = resolve(electronRoot, ".env");
   let fileEnv = {};
   try {
@@ -218,16 +234,62 @@ async function ensureBuildConfig() {
     // .env is optional
   }
   const merged = { ...fileEnv, ...process.env };
+  const gitBranch = getGitValue(["rev-parse", "--abbrev-ref", "HEAD"]);
+  const gitCommit = getGitValue(["rev-parse", "HEAD"]);
+
+  const defaultMetadata = {
+    NEXU_DESKTOP_BUILD_SOURCE: merged.NEXU_DESKTOP_BUILD_SOURCE ?? "local-dist",
+    NEXU_DESKTOP_BUILD_BRANCH:
+      merged.NEXU_DESKTOP_BUILD_BRANCH ?? (gitBranch || undefined),
+    NEXU_DESKTOP_BUILD_COMMIT:
+      merged.NEXU_DESKTOP_BUILD_COMMIT ?? (gitCommit || undefined),
+    NEXU_DESKTOP_BUILD_TIME:
+      merged.NEXU_DESKTOP_BUILD_TIME ?? new Date().toISOString(),
+  };
 
   const config = {
-    NEXU_CLOUD_URL: merged.NEXU_CLOUD_URL ?? "https://nexu.io",
-    NEXU_LINK_URL: merged.NEXU_LINK_URL ?? null,
-    ...(merged.NEXU_DESKTOP_SENTRY_DSN
-      ? { NEXU_DESKTOP_SENTRY_DSN: merged.NEXU_DESKTOP_SENTRY_DSN }
+    ...existingConfig,
+    NEXU_CLOUD_URL:
+      existingConfig.NEXU_CLOUD_URL ??
+      merged.NEXU_CLOUD_URL ??
+      "https://nexu.io",
+    NEXU_LINK_URL: existingConfig.NEXU_LINK_URL ?? merged.NEXU_LINK_URL ?? null,
+    ...((existingConfig.NEXU_DESKTOP_SENTRY_DSN ??
+    merged.NEXU_DESKTOP_SENTRY_DSN)
+      ? {
+          NEXU_DESKTOP_SENTRY_DSN:
+            existingConfig.NEXU_DESKTOP_SENTRY_DSN ??
+            merged.NEXU_DESKTOP_SENTRY_DSN,
+        }
       : {}),
-    ...(merged.NEXU_UPDATE_FEED_URL
-      ? { NEXU_UPDATE_FEED_URL: merged.NEXU_UPDATE_FEED_URL }
+    ...((existingConfig.NEXU_UPDATE_FEED_URL ?? merged.NEXU_UPDATE_FEED_URL)
+      ? {
+          NEXU_UPDATE_FEED_URL:
+            existingConfig.NEXU_UPDATE_FEED_URL ?? merged.NEXU_UPDATE_FEED_URL,
+        }
       : {}),
+    NEXU_DESKTOP_BUILD_SOURCE:
+      existingConfig.NEXU_DESKTOP_BUILD_SOURCE ??
+      defaultMetadata.NEXU_DESKTOP_BUILD_SOURCE,
+    ...((existingConfig.NEXU_DESKTOP_BUILD_BRANCH ??
+    defaultMetadata.NEXU_DESKTOP_BUILD_BRANCH)
+      ? {
+          NEXU_DESKTOP_BUILD_BRANCH:
+            existingConfig.NEXU_DESKTOP_BUILD_BRANCH ??
+            defaultMetadata.NEXU_DESKTOP_BUILD_BRANCH,
+        }
+      : {}),
+    ...((existingConfig.NEXU_DESKTOP_BUILD_COMMIT ??
+    defaultMetadata.NEXU_DESKTOP_BUILD_COMMIT)
+      ? {
+          NEXU_DESKTOP_BUILD_COMMIT:
+            existingConfig.NEXU_DESKTOP_BUILD_COMMIT ??
+            defaultMetadata.NEXU_DESKTOP_BUILD_COMMIT,
+        }
+      : {}),
+    NEXU_DESKTOP_BUILD_TIME:
+      existingConfig.NEXU_DESKTOP_BUILD_TIME ??
+      defaultMetadata.NEXU_DESKTOP_BUILD_TIME,
   };
 
   await writeFile(configPath, JSON.stringify(config, null, 2));
@@ -235,6 +297,23 @@ async function ensureBuildConfig() {
     "[dist:mac] generated build-config.json from env:",
     JSON.stringify(config),
   );
+}
+
+async function getElectronVersion() {
+  const electronPackageJsonPath = require.resolve("electron/package.json", {
+    paths: [electronRoot, repoRoot],
+  });
+  const electronPackageJson = JSON.parse(
+    await readFile(electronPackageJsonPath, "utf8"),
+  );
+
+  if (typeof electronPackageJson.version !== "string") {
+    throw new Error(
+      `Unable to determine Electron version from ${electronPackageJsonPath}.`,
+    );
+  }
+
+  return electronPackageJson.version;
 }
 
 async function main() {
@@ -305,6 +384,7 @@ async function main() {
   // Use git short SHA as CFBundleVersion (shown in parentheses in About dialog).
   // Falls back to "dev" for local builds outside a git repo.
   let buildVersion = "dev";
+  const electronVersion = await getElectronVersion();
   try {
     buildVersion = execFileSync("git", ["rev-parse", "--short=7", "HEAD"], {
       encoding: "utf8",
@@ -318,6 +398,7 @@ async function main() {
       "--mac",
       "--publish",
       "never",
+      `--config.electronVersion=${electronVersion}`,
       `--config.buildVersion=${buildVersion}`,
       ...(isUnsigned
         ? ["--config.mac.identity=null", "--config.mac.hardenedRuntime=false"]

--- a/apps/desktop/shared/runtime-config.ts
+++ b/apps/desktop/shared/runtime-config.ts
@@ -19,20 +19,113 @@ export const DEFAULT_NEXU_LINK_URL: string | null = null;
  * Read build-time configuration from bundled config file.
  * This allows CI to inject environment-specific values at build time.
  */
-function loadBuildConfig(resourcesPath?: string): Record<string, string> {
+type BuildConfig = {
+  NEXU_CLOUD_URL?: string;
+  NEXU_LINK_URL?: string | null;
+  NEXU_UPDATE_FEED_URL?: string;
+  NEXU_DESKTOP_SENTRY_DSN?: string;
+  NEXU_DESKTOP_BUILD_SOURCE?: string;
+  NEXU_DESKTOP_BUILD_BRANCH?: string;
+  NEXU_DESKTOP_BUILD_COMMIT?: string;
+  NEXU_DESKTOP_BUILD_TIME?: string;
+};
+
+function readBuildConfigString(
+  input: Record<string, unknown>,
+  key: keyof BuildConfig,
+): string | undefined {
+  const value = input[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function readBuildConfigNullableString(
+  input: Record<string, unknown>,
+  key: keyof BuildConfig,
+): string | null | undefined {
+  const value = input[key];
+  if (value === null) {
+    return null;
+  }
+
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function loadBuildConfig(resourcesPath?: string): BuildConfig {
   if (!resourcesPath) return {};
 
   const configPath = resolve(resourcesPath, "build-config.json");
   if (!existsSync(configPath)) return {};
 
   try {
-    return JSON.parse(readFileSync(configPath, "utf8"));
+    const parsed = JSON.parse(readFileSync(configPath, "utf8")) as unknown;
+
+    if (!parsed || typeof parsed !== "object") {
+      return {};
+    }
+
+    const record = parsed as Record<string, unknown>;
+    return {
+      NEXU_CLOUD_URL: readBuildConfigString(record, "NEXU_CLOUD_URL"),
+      NEXU_LINK_URL: readBuildConfigNullableString(record, "NEXU_LINK_URL"),
+      NEXU_UPDATE_FEED_URL: readBuildConfigString(
+        record,
+        "NEXU_UPDATE_FEED_URL",
+      ),
+      NEXU_DESKTOP_SENTRY_DSN: readBuildConfigString(
+        record,
+        "NEXU_DESKTOP_SENTRY_DSN",
+      ),
+      NEXU_DESKTOP_BUILD_SOURCE: readBuildConfigString(
+        record,
+        "NEXU_DESKTOP_BUILD_SOURCE",
+      ),
+      NEXU_DESKTOP_BUILD_BRANCH: readBuildConfigString(
+        record,
+        "NEXU_DESKTOP_BUILD_BRANCH",
+      ),
+      NEXU_DESKTOP_BUILD_COMMIT: readBuildConfigString(
+        record,
+        "NEXU_DESKTOP_BUILD_COMMIT",
+      ),
+      NEXU_DESKTOP_BUILD_TIME: readBuildConfigString(
+        record,
+        "NEXU_DESKTOP_BUILD_TIME",
+      ),
+    };
   } catch {
     return {};
   }
 }
 
+export type DesktopBuildSource =
+  | "local-dev"
+  | "local-dist"
+  | "nightly-test"
+  | "nightly-prod"
+  | "unknown";
+
+export type DesktopBuildInfo = {
+  version: string;
+  source: DesktopBuildSource;
+  branch: string | null;
+  commit: string | null;
+  builtAt: string | null;
+};
+
+function normalizeBuildSource(value: string | undefined): DesktopBuildSource {
+  switch (value) {
+    case "local-dev":
+    case "local-dist":
+    case "nightly-test":
+    case "nightly-prod":
+      return value;
+    default:
+      return "unknown";
+  }
+}
+
 export type DesktopRuntimeConfig = {
+  buildInfo: DesktopBuildInfo;
   ports: {
     api: number;
     web: number;
@@ -74,6 +167,7 @@ export type DesktopRuntimeConfig = {
 export function getDesktopRuntimeConfig(
   env: Record<string, string | undefined>,
   defaults?: {
+    appVersion?: string;
     openclawBinPath?: string;
     resourcesPath?: string;
   },
@@ -112,6 +206,24 @@ export function getDesktopRuntimeConfig(
   };
 
   return {
+    buildInfo: {
+      version: defaults?.appVersion ?? env.npm_package_version ?? "0.0.0",
+      source: normalizeBuildSource(
+        env.NEXU_DESKTOP_BUILD_SOURCE ?? buildConfig.NEXU_DESKTOP_BUILD_SOURCE,
+      ),
+      branch:
+        env.NEXU_DESKTOP_BUILD_BRANCH ??
+        buildConfig.NEXU_DESKTOP_BUILD_BRANCH ??
+        null,
+      commit:
+        env.NEXU_DESKTOP_BUILD_COMMIT ??
+        buildConfig.NEXU_DESKTOP_BUILD_COMMIT ??
+        null,
+      builtAt:
+        env.NEXU_DESKTOP_BUILD_TIME ??
+        buildConfig.NEXU_DESKTOP_BUILD_TIME ??
+        null,
+    },
     ports,
     urls,
     tokens: {

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -79,6 +79,44 @@ function maskSentryDsn(dsn: string | null | undefined): string {
   return `${protocol}${maskedKey}@${hostAndPath}`;
 }
 
+function formatBuildTimestamp(value: string | null | undefined): string {
+  if (!value) {
+    return "(unknown)";
+  }
+
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) {
+    return value;
+  }
+
+  const date = new Date(timestamp);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  const seconds = String(date.getSeconds()).padStart(2, "0");
+  const timezoneOffsetMinutes = -date.getTimezoneOffset();
+  const offsetSign = timezoneOffsetMinutes >= 0 ? "+" : "-";
+  const offsetHours = String(
+    Math.floor(Math.abs(timezoneOffsetMinutes) / 60),
+  ).padStart(2, "0");
+  const offsetMinutes = String(Math.abs(timezoneOffsetMinutes) % 60).padStart(
+    2,
+    "0",
+  );
+
+  return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}${offsetSign}${offsetHours}:${offsetMinutes}`;
+}
+
+function formatBuildCommit(value: string | null | undefined): string {
+  if (!value) {
+    return "(unknown)";
+  }
+
+  return value.slice(0, 7);
+}
+
 if (amplitudeApiKey) {
   amplitude.initAll(amplitudeApiKey, {
     analytics: { autocapture: true },
@@ -1067,8 +1105,30 @@ function DesktopShell() {
 
         {runtimeConfig ? (
           <div className="desktop-sidebar-config">
-            <span className="desktop-shell-eyebrow">Build Config</span>
+            <span className="desktop-shell-eyebrow">Build Info</span>
             <dl className="desktop-config-list">
+              <div>
+                <dt>Source</dt>
+                <dd>{runtimeConfig.buildInfo.source}</dd>
+              </div>
+              <div>
+                <dt>Version</dt>
+                <dd>{runtimeConfig.buildInfo.version}</dd>
+              </div>
+              <div>
+                <dt>Branch</dt>
+                <dd>{runtimeConfig.buildInfo.branch ?? "(unknown)"}</dd>
+              </div>
+              <div>
+                <dt>Commit</dt>
+                <dd title={runtimeConfig.buildInfo.commit ?? undefined}>
+                  {formatBuildCommit(runtimeConfig.buildInfo.commit)}
+                </dd>
+              </div>
+              <div>
+                <dt>Built At</dt>
+                <dd>{formatBuildTimestamp(runtimeConfig.buildInfo.builtAt)}</dd>
+              </div>
               <div>
                 <dt>Cloud</dt>
                 <dd>{runtimeConfig.urls.nexuCloud}</dd>

--- a/apps/desktop/src/runtime-page.css
+++ b/apps/desktop/src/runtime-page.css
@@ -27,7 +27,7 @@ body,
 
 .desktop-sidebar {
   display: flex;
-  width: 240px;
+  width: 272px;
   flex-direction: column;
   gap: 24px;
   padding: 48px 18px 20px;

--- a/biome.json
+++ b/biome.json
@@ -46,8 +46,10 @@
   ],
   "files": {
     "ignore": [
-      ".claude",
-      "specs/cowork",
+      ".claude/**",
+      ".cursor/**",
+      ".opencode/**",
+      "specs/**",
       "apps/web/lib/api",
       "apps/api/migrations/meta/*.json",
       "*.gen.ts",

--- a/openclaw-runtime/package-lock.json
+++ b/openclaw-runtime/package-lock.json
@@ -854,14 +854,6 @@
         "scripts/actions/documentation"
       ]
     },
-    "node_modules/@buape/carbon/node_modules/opusscript": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.0.8.tgz",
-      "integrity": "sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@buape/carbon/node_modules/prism-media": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.5.tgz",
@@ -970,14 +962,6 @@
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
-    },
-    "node_modules/@discordjs/voice/node_modules/opusscript": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.0.8.tgz",
-      "integrity": "sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/@discordjs/voice/node_modules/prism-media": {
       "version": "1.3.5",
@@ -1143,7 +1127,6 @@
       "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.6.tgz",
       "integrity": "sha512-MyMWyLnjqo+KRJYSH7oWNbsOn5onuIvfXYPcc0WOGxU0eHUV7oAYUoQTl2BMdu7ml+ea/bu11UM+EshbeHwtIA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1709,7 +1692,6 @@
       "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
       "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.1.1"
       }
@@ -1718,8 +1700,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@larksuiteoapi/node-sdk": {
       "version": "1.59.0",
@@ -2172,6 +2153,7 @@
       "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.96.tgz",
       "integrity": "sha512-6NNmNxvoJKeucVjxaaRUt3La2i5jShgiAbaY3G/72s1Vp3U06XPrAIxkAjBxpDcamEn/t+WJ4OOlGmvILo4/Ew==",
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "e2e/*"
       ],
@@ -2445,7 +2427,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -2463,7 +2444,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -2480,7 +2460,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -2497,7 +2476,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -2514,7 +2492,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -2531,7 +2508,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -2549,7 +2525,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -2566,7 +2541,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -2584,7 +2558,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -2601,7 +2574,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -2618,7 +2590,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -2635,7 +2606,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -2652,7 +2622,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -2662,7 +2631,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/app/-/app-16.1.2.tgz",
       "integrity": "sha512-8j7sEpUYVj18dxvh0KWj6W/l6uAiVRBl1JBDVRqH1VHKAO/G5eRVl4yEoYACjakWers1DjUkcCHyJNQK47JqyQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-app": "^8.1.2",
         "@octokit/auth-unauthenticated": "^7.0.3",
@@ -2681,7 +2649,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-8.2.0.tgz",
       "integrity": "sha512-vVjdtQQwomrZ4V46B9LaCsxsySxGoHsyw6IYBov/TqJVROrlYdyNgw5q6tQbB7KZt53v1l1W53RiqTvpzL907g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-oauth-app": "^9.0.3",
         "@octokit/auth-oauth-user": "^6.0.2",
@@ -2701,7 +2668,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-9.0.3.tgz",
       "integrity": "sha512-+yoFQquaF8OxJSxTb7rnytBIC2ZLbLqA/yb71I4ZXT9+Slw4TziV9j/kyGhUFRRTF2+7WlnIWsePZCWHs+OGjg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-oauth-device": "^8.0.3",
         "@octokit/auth-oauth-user": "^6.0.2",
@@ -2718,7 +2684,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-8.0.3.tgz",
       "integrity": "sha512-zh2W0mKKMh/VWZhSqlaCzY7qFyrgd9oTWmTmHaXnHNeQRCZr/CXy2jCgHo4e4dJVTiuxP5dLa0YM5p5QVhJHbw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/oauth-methods": "^6.0.2",
         "@octokit/request": "^10.0.6",
@@ -2734,7 +2699,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-6.0.2.tgz",
       "integrity": "sha512-qLoPPc6E6GJoz3XeDG/pnDhJpTkODTGG4kY0/Py154i/I003O9NazkrwJwRuzgCalhzyIeWQ+6MDvkUmKXjg/A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-oauth-device": "^8.0.3",
         "@octokit/oauth-methods": "^6.0.2",
@@ -2751,7 +2715,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
       "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 20"
       }
@@ -2761,7 +2724,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-7.0.3.tgz",
       "integrity": "sha512-8Jb1mtUdmBHL7lGmop9mU9ArMRUTRhg8vp0T1VtZ4yd9vEm3zcLwmjQkhNEduKawOOORie61xhtYIhTDN+ZQ3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/request-error": "^7.0.2",
         "@octokit/types": "^16.0.0"
@@ -2794,7 +2756,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
       "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/types": "^16.0.0",
         "universal-user-agent": "^7.0.2"
@@ -2808,7 +2769,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
       "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/request": "^10.0.6",
         "@octokit/types": "^16.0.0",
@@ -2823,7 +2783,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-8.0.3.tgz",
       "integrity": "sha512-jnAjvTsPepyUaMu9e69hYBuozEPgYqP4Z3UnpmvoIzHDpf8EXDGvTY1l1jK0RsZ194oRd+k6Hm13oRU8EoDFwg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-oauth-app": "^9.0.2",
         "@octokit/auth-oauth-user": "^6.0.1",
@@ -2843,7 +2802,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-8.0.0.tgz",
       "integrity": "sha512-7QoLPRh/ssEA/HuHBHdVdSgF8xNLz/Bc5m9fZkArJE5bb6NmVkDm3anKxXPmN1zh6b5WKZPRr3697xKT/yM3qQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 20"
       }
@@ -2853,7 +2811,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-6.0.2.tgz",
       "integrity": "sha512-HiNOO3MqLxlt5Da5bZbLV8Zarnphi4y9XehrbaFMkcoJ+FL7sMxH/UlUsCVxpddVu4qvNDrBdaTVE2o4ITK8ng==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/oauth-authorization-url": "^8.0.0",
         "@octokit/request": "^10.0.6",
@@ -2868,22 +2825,19 @@
       "version": "27.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
       "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@octokit/openapi-webhooks-types": {
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-webhooks-types/-/openapi-webhooks-types-12.1.0.tgz",
       "integrity": "sha512-WiuzhOsiOvb7W3Pvmhf8d2C6qaLHXrWiLBP4nJ/4kydu+wpagV5Fkz9RfQwV2afYzv3PB+3xYgp4mAdNGjDprA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@octokit/plugin-paginate-graphql": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-graphql/-/plugin-paginate-graphql-6.0.0.tgz",
       "integrity": "sha512-crfpnIoFiBtRkvPqOyLOsw12XsveYuY2ieP6uYDosoUegBJpSVxGwut9sxUgFFcll3VTOTqpUf8yGd8x1OmAkQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 20"
       },
@@ -2896,7 +2850,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
       "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/types": "^16.0.0"
       },
@@ -2912,7 +2865,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
       "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/types": "^16.0.0"
       },
@@ -2928,7 +2880,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-8.1.0.tgz",
       "integrity": "sha512-O1FZgXeiGb2sowEr/hYTr6YunGdSAFWnr2fyW39Ah85H8O33ELASQxcvOFF5LE6Tjekcyu2ms4qAzJVhSaJxTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/request-error": "^7.0.2",
         "@octokit/types": "^16.0.0",
@@ -2946,7 +2897,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-11.0.3.tgz",
       "integrity": "sha512-34eE0RkFCKycLl2D2kq7W+LovheM/ex3AwZCYN8udpi6bxsyjZidb2McXs69hZhLmJlDqTSP8cH+jSRpiaijBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/types": "^16.0.0",
         "bottleneck": "^2.15.3"
@@ -2963,7 +2913,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.8.tgz",
       "integrity": "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/endpoint": "^11.0.3",
         "@octokit/request-error": "^7.0.2",
@@ -2981,7 +2930,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
       "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/types": "^16.0.0"
       },
@@ -2994,7 +2942,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
       "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/openapi-types": "^27.0.0"
       }
@@ -3004,7 +2951,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-14.2.0.tgz",
       "integrity": "sha512-da6KbdNCV5sr1/txD896V+6W0iamFWrvVl8cHkBSPT+YlvmT3DwXa4jxZnQc+gnuTEqSWbBeoSZYTayXH9wXcw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/openapi-webhooks-types": "12.1.0",
         "@octokit/request-error": "^7.0.0",
@@ -3019,7 +2965,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-6.0.0.tgz",
       "integrity": "sha512-MFlzzoDJVw/GcbfzVC1RLR36QqkTLUf79vLVO3D+xn7r0QgxnFoLZgtrzxiQErAjFUOdH6fas2KeQJ1yr/qaXQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 20"
       }
@@ -3110,7 +3055,6 @@
       "integrity": "sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -3137,7 +3081,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -3154,7 +3097,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -3171,7 +3113,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -3188,7 +3129,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -3205,7 +3145,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -3222,7 +3161,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -3239,7 +3177,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -3256,7 +3193,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -4288,7 +4224,6 @@
       "resolved": "https://registry.npmjs.org/@tinyhttp/content-disposition/-/content-disposition-2.2.4.tgz",
       "integrity": "sha512-5Kc5CM2Ysn3vTTArBs2vESUt0AQiWZA86yc1TI3B+lxXmtEq133C1nxXNOgnzhrivdPZIh3zLj5gDnZjoLL5GA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.17.0"
       },
@@ -4340,15 +4275,13 @@
       "version": "8.10.161",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.161.tgz",
       "integrity": "sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
       "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -4369,7 +4302,6 @@
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -4391,7 +4323,6 @@
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
       "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -4403,8 +4334,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/jsonwebtoken": {
       "version": "9.0.10",
@@ -4447,15 +4377,13 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
       "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/retry": {
       "version": "0.12.0",
@@ -4468,7 +4396,6 @@
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
       "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -4478,7 +4405,6 @@
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
       "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/http-errors": "*",
         "@types/node": "*"
@@ -4642,7 +4568,6 @@
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.1.tgz",
       "integrity": "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -4712,7 +4637,6 @@
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
       "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "retry": "0.13.1"
       }
@@ -4785,8 +4709,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
       "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
@@ -4949,8 +4872,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/chmodrp/-/chmodrp-1.0.2.tgz",
       "integrity": "sha512-TdngOlFV1FLTzU0o1w8MB6/BFywhtLC0SzRTGJU7T9lmdjlCWeMRt1iVo0Ki+ldwNk0BqNiKoc8xpLZEQ8mY1w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/chokidar": {
       "version": "5.0.0",
@@ -4987,7 +4909,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4997,7 +4918,6 @@
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
       "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "restore-cursor": "^5.0.0"
       },
@@ -5147,7 +5067,6 @@
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
       "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       },
@@ -5218,7 +5137,6 @@
       "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-8.0.0.tgz",
       "integrity": "sha512-YbUP88RDwCvoQkZhRtGURYm9RIpWdtvZuhT87fKNoLjk8kIFIFeARpKfuZQGdwfH99GZpUmqSfcDrK62X7lTgg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.3",
         "fs-extra": "^11.3.3",
@@ -5272,7 +5190,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
       "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -5448,7 +5365,6 @@
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -5655,7 +5571,6 @@
       "resolved": "https://registry.npmjs.org/env-var/-/env-var-7.5.0.tgz",
       "integrity": "sha512-mKZOzLRN0ETzau2W2QXefbFjo5EF4yWq28OyKb9ICdeNhHJlOE/pHHnz4hdYJ9cNZXcJHo5xN4OT4pzuSHSNvA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -5879,8 +5794,7 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -5993,7 +5907,6 @@
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-3.0.0.tgz",
       "integrity": "sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -6006,7 +5919,6 @@
       "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-6.0.0.tgz",
       "integrity": "sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "filename-reserved-regex": "^3.0.0"
       },
@@ -6158,7 +6070,6 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
       "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -6368,6 +6279,7 @@
       "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.41.1.tgz",
       "integrity": "sha512-wcHAQ1e7svL3fJMpDchcQVcWUmywhuepOOjHUHmMmWAwUJEIyK5ea5sbSjZd+Gy1aMpZeP8VYJa+4tP+j1YptQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@grammyjs/types": "3.25.0",
         "abort-controller": "^3.0.0",
@@ -6465,17 +6377,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/hono": {
-      "version": "4.12.8",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
-      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=16.9.0"
       }
     },
     "node_modules/hookified": {
@@ -6640,8 +6541,7 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/ip-address": {
       "version": "10.1.0",
@@ -6666,7 +6566,6 @@
       "resolved": "https://registry.npmjs.org/ipull/-/ipull-3.9.5.tgz",
       "integrity": "sha512-5w/yZB5lXmTfsvNawmvkCjYo4SJNuKQz/av8TC1UiOyfOHyaM+DReqbpU2XpWYfmY+NIUbRRH8PUAWsxaS+IfA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tinyhttp/content-disposition": "^2.2.0",
         "async-retry": "^1.3.3",
@@ -6706,15 +6605,13 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lifecycle-utils/-/lifecycle-utils-2.1.0.tgz",
       "integrity": "sha512-AnrXnE2/OF9PHCyFg0RSqsnQTzV991XaZA/buhFDoc58xU7rhSCDgCz/09Lqpsn4MpoPHt7TRAXV1kWZypFVsA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ipull/node_modules/parse-ms": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-3.0.0.tgz",
       "integrity": "sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6727,7 +6624,6 @@
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-8.0.0.tgz",
       "integrity": "sha512-ASJqOugUF1bbzI35STMBUpZqdfYKlJugy6JBziGi2EE+AL5JPJGSzvpeVXojxrr0ViUYoToUjb5kjSEGf7Y83Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "parse-ms": "^3.0.0"
       },
@@ -6743,7 +6639,6 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
       "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^6.2.1",
         "is-fullwidth-code-point": "^5.0.0"
@@ -6766,7 +6661,6 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
       "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "get-east-asian-width": "^1.3.1"
       },
@@ -6782,7 +6676,6 @@
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
       "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6813,7 +6706,6 @@
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
       "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -6832,7 +6724,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
       "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
       "license": "BlueOak-1.0.0",
-      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -6893,8 +6784,7 @@
       "version": "3.5.7",
       "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.7.tgz",
       "integrity": "sha512-7ei3MdAI5+fJPVnKlW77TKNKwQ5ppSzWvhPuSuINT/GYW9ZOC1eRKOuhV9yHG5aEsUPj9BBx5JIekkmoLHxZOw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -6913,7 +6803,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -6981,6 +6870,7 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -7056,8 +6946,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lifecycle-utils/-/lifecycle-utils-3.1.1.tgz",
       "integrity": "sha512-gNd3OvhFNjHykJE3uGntz7UuPzWlK9phrIdXxU9Adis0+ExkwnZibfxCJWiWWZ+a6VbKiZrb+9D9hCQWd4vjTg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/linkedom": {
       "version": "0.18.12",
@@ -7096,8 +6985,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.identity": {
       "version": "3.0.0",
@@ -7164,7 +7052,6 @@
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
       "integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-unicode-supported": "^2.0.0",
         "yoctocolors": "^2.1.1"
@@ -7187,7 +7074,6 @@
       "resolved": "https://registry.npmjs.org/lowdb/-/lowdb-7.0.1.tgz",
       "integrity": "sha512-neJAj8GwF0e8EpycYIDFqEPcx9Qz4GUho20jWFR7YiFeXzF1YMLdxB36PypcTSPMA+4+LvgyMacYhlr18Zlymw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "steno": "^4.0.2"
       },
@@ -7302,7 +7188,6 @@
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
       "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -7330,7 +7215,6 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -7415,7 +7299,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.js"
       },
@@ -7446,7 +7329,6 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.6.0.tgz",
       "integrity": "sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18 || ^20 || >= 21"
       }
@@ -7455,8 +7337,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/node-api-headers/-/node-api-headers-1.8.0.tgz",
       "integrity": "sha512-jfnmiKWjRAGbdD1yQS28bknFM1tbHC1oucyuMPjmkEs+kpiu76aRs40WlTmBmyEgzDM76ge1DQ7XJ3R5deiVjQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -7628,7 +7509,6 @@
       "resolved": "https://registry.npmjs.org/octokit/-/octokit-5.0.5.tgz",
       "integrity": "sha512-4+/OFSqOjoyULo7eN7EA97DE0Xydj/PW5aIckxqQIoFjFwqXKuFCvXUJObyJfBF9Khu4RL/jlDRI9FPaMGfPnw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/app": "^16.1.2",
         "@octokit/core": "^7.0.6",
@@ -7681,7 +7561,6 @@
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
       "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mimic-function": "^5.0.0"
       },
@@ -7820,7 +7699,6 @@
       "resolved": "https://registry.npmjs.org/ora/-/ora-9.3.0.tgz",
       "integrity": "sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chalk": "^5.6.2",
         "cli-cursor": "^5.0.0",
@@ -7843,7 +7721,6 @@
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
       "integrity": "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.20"
       },
@@ -7965,7 +7842,6 @@
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
       "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -8132,7 +8008,6 @@
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.1.tgz",
       "integrity": "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.13.1 || >=16.0.0"
       },
@@ -8145,7 +8020,6 @@
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
       "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "parse-ms": "^4.0.0"
       },
@@ -8367,7 +8241,6 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "peer": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -8444,7 +8317,6 @@
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
       "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "onetime": "^7.0.0",
         "signal-exit": "^4.1.0"
@@ -8461,7 +8333,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -8692,6 +8563,7 @@
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -8834,7 +8706,6 @@
       "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.33.0.tgz",
       "integrity": "sha512-D4V/tGC2sjsoNhoMybKyGoE+v8A60hRawKQ1iFRA1zwuDgGZCBJ4ByOzZ5J8joBbi4Oam0qiPH+GhzmSBwbJng==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
@@ -8855,15 +8726,13 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/sleep-promise/-/sleep-promise-9.1.0.tgz",
       "integrity": "sha512-UHYzVpz9Xn8b+jikYSD6bqvf754xL2uBUzDFwiU6NcdZeifPr6UfgU43xpkPu67VMS88+TI2PSI7Eohgqf2fKA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/slice-ansi": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
       "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^6.2.3",
         "is-fullwidth-code-point": "^5.1.0"
@@ -9048,7 +8917,6 @@
       "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.1.tgz",
       "integrity": "sha512-reExS1kSGoElkextOcPkel4NE99S0BWxjUHQeDFnR8S993JxpPX7KU4MNmO19NXhlJp+8dmdCbKQVNgLJh2teA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -9061,7 +8929,6 @@
       "resolved": "https://registry.npmjs.org/stdout-update/-/stdout-update-4.0.1.tgz",
       "integrity": "sha512-wiS21Jthlvl1to+oorePvcyrIkiG/6M3D3VTmDUlJm7Cy6SbFhKkAvX+YBuHLxck/tO3mrdpC/cNesigQc3+UQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-escapes": "^6.2.0",
         "ansi-styles": "^6.2.1",
@@ -9076,15 +8943,13 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/stdout-update/node_modules/string-width": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "emoji-regex": "^10.3.0",
         "get-east-asian-width": "^1.0.0",
@@ -9102,7 +8967,6 @@
       "resolved": "https://registry.npmjs.org/steno/-/steno-4.0.2.tgz",
       "integrity": "sha512-yhPIQXjrlt1xv7dyPQg2P17URmXbuM5pdGkpiMB3RenprfiBlvK415Lctfe0eshk90oA7/tNq7WEiMK8RSP39A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -9130,7 +8994,6 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
       "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "get-east-asian-width": "^1.5.0",
         "strip-ansi": "^7.1.2"
@@ -9229,7 +9092,6 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9279,7 +9141,6 @@
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
       "integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
       "license": "BlueOak-1.0.0",
-      "peer": true,
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -9326,7 +9187,6 @@
       "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.0.tgz",
       "integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9454,22 +9314,19 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-2.2.2.tgz",
       "integrity": "sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/universal-user-agent": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
       "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -9487,8 +9344,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
       "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -9501,7 +9357,6 @@
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
       "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
@@ -9545,7 +9400,6 @@
       "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
       "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "isexe": "^4.0.0"
       },
@@ -9873,6 +9727,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/openclaw-runtime/package.json
+++ b/openclaw-runtime/package.json
@@ -5,8 +5,9 @@
   "packageManager": "npm@11",
   "scripts": {
     "clean": "node ./clean-node-modules.mjs",
-    "install:full": "npm install",
-    "install:pruned": "npm install && node ./prune-runtime.mjs"
+    "install:full": "npm install --no-package-lock",
+    "install:pruned": "npm install --no-package-lock && node ./prune-runtime.mjs",
+    "refresh-lock": "npm install && node ./prune-runtime.mjs"
   },
   "dependencies": {
     "@larksuiteoapi/node-sdk": "^1.59.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test": "vitest run",
     "generate-types": "pnpm --filter @nexu/api generate-openapi && pnpm --filter @nexu/web generate-sdk",
     "openclaw-runtime:install": "npm --prefix ./openclaw-runtime run install:pruned",
+    "openclaw-runtime:refresh-lock": "npm --prefix ./openclaw-runtime run refresh-lock",
     "openclaw-runtime:reinstall": "npm --prefix ./openclaw-runtime run clean && npm --prefix ./openclaw-runtime run install:pruned",
     "preinstall": "npm --prefix ./openclaw-runtime run clean",
     "postinstall": "npm --prefix ./openclaw-runtime run install:pruned",


### PR DESCRIPTION
## Summary

This PR teaches the desktop build pipeline to record where each build came from (source, branch, commit, and timestamp) and exposes that data inside the runtime so users can see which build they are running.

## Changes

- add a `build_source` workflow input and export build metadata env vars for both CI builds and local dev sessions
- enrich the runtime config with structured build info (source, branch, commit, timestamp, app version) and display it in the sidebar
- rewrite `dist-mac.mjs` to generate/persist the metadata file, capture Electron version info, and keep runtime defaults in sync
- refresh the `openclaw-runtime` lockfile and add helper scripts for reinstalling/refreshing without committing packages