### PR TITLE
fix(web): update channel setup guide doc URLs to docs.nexu.io

### DIFF
--- a/apps/web/src/components/channel-connect-modal.tsx
+++ b/apps/web/src/components/channel-connect-modal.tsx
@@ -72,7 +72,7 @@ function getChannelConfigs(t: (key: string) => string): Record<
           style={{ objectFit: "contain" }}
         />
       ),
-      docUrl: "https://docs.nexu.ai/channels/feishu",
+      docUrl: "https://docs.nexu.io/guide/channels/feishu",
       fields: [
         {
           id: "appId",
@@ -91,7 +91,7 @@ function getChannelConfigs(t: (key: string) => string): Record<
     slack: {
       name: "Slack",
       icon: <SlackIcon />,
-      docUrl: "https://docs.nexu.ai/channels/slack",
+      docUrl: "https://docs.nexu.io/guide/channels/slack",
       fields: [
         {
           id: "botToken",
@@ -110,7 +110,7 @@ function getChannelConfigs(t: (key: string) => string): Record<
     discord: {
       name: "Discord",
       icon: <DiscordIcon />,
-      docUrl: "https://docs.nexu.ai/channels/discord",
+      docUrl: "https://docs.nexu.io/guide/channels/discord",
       fields: [
         {
           id: "botToken",


### PR DESCRIPTION
## Summary
- Update channel connect modal doc URLs from `docs.nexu.ai` to `docs.nexu.io/guide/channels/...` for Feishu, Slack, and Discord

## Test plan
- [ ] Verify each "View setup guide" link in channel connect modal opens the correct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)