### PR TITLE
feat: unify desktop Sentry metadata and sourcemap pipeline

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -138,6 +138,7 @@ jobs:
         run: |
           export BUILT_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
           node -e '
+            const { version } = require("./apps/desktop/package.json");
             const sentryDsnByEnvironment = {
               "nexu-test": process.env.SENTRY_DSN_TEST,
               "nexu-prod": process.env.SENTRY_DSN_PROD,
@@ -146,6 +147,7 @@ jobs:
             const config = {
               NEXU_CLOUD_URL: process.env.CLOUD_URL,
               NEXU_LINK_URL: process.env.LINK_URL === "null" ? null : process.env.LINK_URL,
+              NEXU_DESKTOP_APP_VERSION: version,
               NEXU_DESKTOP_BUILD_SOURCE: process.env.BUILD_SOURCE,
               NEXU_DESKTOP_BUILD_BRANCH: process.env.BUILD_BRANCH,
               NEXU_DESKTOP_BUILD_COMMIT: process.env.BUILD_COMMIT,
@@ -171,6 +173,7 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: pnpm --filter @nexu/desktop dist:mac
 
       - name: Prepare artifacts

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -118,10 +118,12 @@ jobs:
         run: |
           export BUILT_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
           node -e '
+            const { version } = require("./apps/desktop/package.json");
             const config = {
               NEXU_CLOUD_URL: "https://nexu.io",
               NEXU_LINK_URL: "https://link.nexu.io",
               NEXU_UPDATE_FEED_URL: `https://desktop-releases.nexu.io/${process.env.CHANNEL}`,
+              NEXU_DESKTOP_APP_VERSION: version,
               NEXU_DESKTOP_BUILD_SOURCE: "release",
               NEXU_DESKTOP_BUILD_BRANCH: "",
               NEXU_DESKTOP_BUILD_COMMIT: process.env.BUILD_COMMIT,
@@ -144,6 +146,7 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: pnpm --filter @nexu/desktop dist:mac
 
       - name: Prepare release artifacts

--- a/apps/desktop/.env.example
+++ b/apps/desktop/.env.example
@@ -3,6 +3,13 @@ VITE_API_BASE_URL=http://127.0.0.1:50800
 # Optional: desktop Sentry DSN for both the Electron main and renderer processes.
 NEXU_DESKTOP_SENTRY_DSN=
 
+# Optional: release sourcemap upload for packaged desktop builds.
+SENTRY_AUTH_TOKEN=
+# Optional explicit overrides for one-off runs.
+# NEXU_DESKTOP_SENTRY_ORG=refly-ai
+# NEXU_DESKTOP_SENTRY_PROJECT=
+# NEXU_DESKTOP_SENTRY_API_ORIGIN=https://us.sentry.io
+
 # Optional: Apple notarization for `pnpm --filter @nexu/desktop dist:mac`
 APPLE_API_ISSUER=
 APPLE_API_KEY_ID=

--- a/apps/desktop/main/index.ts
+++ b/apps/desktop/main/index.ts
@@ -12,6 +12,7 @@ import {
 } from "electron";
 import type { DesktopChromeMode, DesktopSurface } from "../shared/host";
 import { getDesktopRuntimeConfig } from "../shared/runtime-config";
+import { getDesktopSentryBuildMetadata } from "../shared/sentry-build-metadata";
 import { getDesktopAppRoot } from "../shared/workspace-paths";
 import { ensureDesktopAuthSession } from "./desktop-bootstrap";
 import { DesktopDiagnosticsReporter } from "./desktop-diagnostics";
@@ -69,10 +70,15 @@ app.commandLine.appendSwitch("disable-popup-blocking");
 const sentryDsn = runtimeConfig.sentryDsn;
 
 if (sentryDsn) {
+  const sentryBuildMetadata = getDesktopSentryBuildMetadata(
+    runtimeConfig.buildInfo,
+  );
+
   Sentry.init({
     dsn: sentryDsn,
     environment: app.isPackaged ? "production" : "development",
-    release: `@nexu/desktop@${app.getVersion()}`,
+    release: sentryBuildMetadata.release,
+    ...(sentryBuildMetadata.dist ? { dist: sentryBuildMetadata.dist } : {}),
     beforeSend(event) {
       const testTitle =
         typeof event.tags?.["nexu.test_title"] === "string"
@@ -92,6 +98,8 @@ if (sentryDsn) {
       };
     },
   });
+
+  Sentry.setContext("build", sentryBuildMetadata.buildContext);
 } else {
   crashReporter.start({
     companyName: "Nexu",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -19,6 +19,7 @@
     "package:sidecars": "node ./scripts/prepare-runtime-sidecars.mjs --release",
     "dist:mac": "node ./scripts/dist-mac.mjs",
     "dist:mac:unsigned": "node ./scripts/dist-mac.mjs --unsigned",
+    "upload:sourcemaps": "node ./scripts/upload-sourcemaps.mjs",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/desktop/preload/index.ts
+++ b/apps/desktop/preload/index.ts
@@ -22,6 +22,7 @@ const runtimeConfig = getDesktopRuntimeConfig(process.env, {
 
 const hostBridge: HostBridge = {
   bootstrap: {
+    buildInfo: runtimeConfig.buildInfo,
     sentryDsn: runtimeConfig.sentryDsn,
     isPackaged: !process.defaultApp,
   },

--- a/apps/desktop/scripts/dist-mac.mjs
+++ b/apps/desktop/scripts/dist-mac.mjs
@@ -9,6 +9,7 @@ const scriptDir = dirname(fileURLToPath(import.meta.url));
 const electronRoot = resolve(scriptDir, "..");
 const repoRoot =
   process.env.NEXU_WORKSPACE_ROOT ?? resolve(electronRoot, "../..");
+const desktopPackageJsonPath = resolve(electronRoot, "package.json");
 const require = createRequire(import.meta.url);
 const isUnsigned =
   process.argv.includes("--unsigned") ||
@@ -214,6 +215,9 @@ async function stapleNotarizedAppBundles() {
 async function ensureBuildConfig() {
   const configPath = resolve(electronRoot, "build-config.json");
   let existingConfig = {};
+  const desktopPackage = JSON.parse(
+    await readFile(desktopPackageJsonPath, "utf8"),
+  );
 
   try {
     const existing = await readFile(configPath, "utf8");
@@ -254,6 +258,14 @@ async function ensureBuildConfig() {
       merged.NEXU_CLOUD_URL ??
       "https://nexu.io",
     NEXU_LINK_URL: existingConfig.NEXU_LINK_URL ?? merged.NEXU_LINK_URL ?? null,
+    NEXU_DESKTOP_APP_VERSION:
+      existingConfig.NEXU_DESKTOP_APP_VERSION ??
+      merged.NEXU_DESKTOP_APP_VERSION ??
+      (typeof desktopPackage.version === "string"
+        ? desktopPackage.version
+        : undefined) ??
+      merged.npm_package_version ??
+      undefined,
     ...((existingConfig.NEXU_DESKTOP_SENTRY_DSN ??
     merged.NEXU_DESKTOP_SENTRY_DSN)
       ? {
@@ -369,6 +381,10 @@ async function main() {
     },
   });
   await run("pnpm", ["run", "build"], { cwd: electronRoot, env });
+  await run("node", [resolve(scriptDir, "upload-sourcemaps.mjs")], {
+    cwd: electronRoot,
+    env,
+  });
   await run(
     "node",
     [resolve(scriptDir, "prepare-runtime-sidecars.mjs"), "--release"],

--- a/apps/desktop/scripts/upload-sourcemaps.mjs
+++ b/apps/desktop/scripts/upload-sourcemaps.mjs
@@ -1,0 +1,399 @@
+import { execFileSync } from "node:child_process";
+import { readFile, readdir } from "node:fs/promises";
+import { basename, relative, resolve } from "node:path";
+
+const scriptDir = import.meta.dirname;
+const electronRoot = resolve(scriptDir, "..");
+const repoRoot = resolve(electronRoot, "../..");
+const buildConfigPath = resolve(electronRoot, "build-config.json");
+const desktopPackageJsonPath = resolve(electronRoot, "package.json");
+const DEFAULT_SENTRY_ORG = "refly-ai";
+const DEFAULT_SENTRY_PROJECT_BY_SOURCE = {
+  "local-dev": "nexu-desktop-dev",
+  "local-dist": "nexu-desktop-dev",
+  "nightly-test": "nexu-desktop-test",
+  "nightly-prod": "nexu-desktop-prod",
+  release: "nexu-desktop-prod",
+};
+
+function normalizeCommit(commit) {
+  if (typeof commit !== "string") {
+    return null;
+  }
+
+  const trimmedCommit = commit.trim();
+  return trimmedCommit.length > 0 ? trimmedCommit : null;
+}
+
+function buildSentryRelease(version) {
+  return `nexu-desktop@${version}`;
+}
+
+function buildSentryDist(version, commit) {
+  const normalizedCommit = normalizeCommit(commit);
+  if (!normalizedCommit) {
+    return undefined;
+  }
+
+  return `${version.trim().replace(/[^A-Za-z0-9_.-]+/g, "-")}-${normalizedCommit.replace(/[^A-Za-z0-9_.-]+/g, "-")}`.slice(
+    0,
+    64,
+  );
+}
+
+function getSentryApiOrigin(dsn, overrideOrigin) {
+  if (overrideOrigin) {
+    return overrideOrigin.replace(/\/+$/u, "");
+  }
+
+  if (!dsn) {
+    return null;
+  }
+
+  const host = new URL(dsn).hostname;
+  const match = host.match(/^[^.]+\.ingest\.(.+)$/u);
+  const apiHost = match ? match[1] : host.replace(/^ingest\./u, "");
+
+  return `https://${apiHost}`;
+}
+
+async function loadBuildConfig() {
+  const raw = await readFile(buildConfigPath, "utf8");
+  return JSON.parse(raw);
+}
+
+async function loadDesktopPackageVersion() {
+  const raw = await readFile(desktopPackageJsonPath, "utf8");
+  const parsed = JSON.parse(raw);
+  return typeof parsed.version === "string" ? parsed.version : null;
+}
+
+function getGitValue(args) {
+  try {
+    return execFileSync("git", args, {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+async function resolveUploadBuildMetadata() {
+  const buildConfig = await loadBuildConfig();
+  const packageVersion = await loadDesktopPackageVersion();
+  const isCi =
+    process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true";
+
+  if (!isCi) {
+    return {
+      version: packageVersion ?? buildConfig.NEXU_DESKTOP_APP_VERSION ?? null,
+      source: process.env.NEXU_DESKTOP_BUILD_SOURCE ?? "local-dev",
+      commit:
+        process.env.NEXU_DESKTOP_BUILD_COMMIT ??
+        getGitValue(["rev-parse", "HEAD"]),
+      dsn:
+        process.env.NEXU_DESKTOP_SENTRY_DSN ??
+        buildConfig.NEXU_DESKTOP_SENTRY_DSN,
+    };
+  }
+
+  return {
+    version: buildConfig.NEXU_DESKTOP_APP_VERSION ?? packageVersion,
+    source:
+      buildConfig.NEXU_DESKTOP_BUILD_SOURCE ??
+      process.env.NEXU_DESKTOP_BUILD_SOURCE ??
+      null,
+    commit:
+      buildConfig.NEXU_DESKTOP_BUILD_COMMIT ??
+      process.env.NEXU_DESKTOP_BUILD_COMMIT ??
+      null,
+    dsn:
+      buildConfig.NEXU_DESKTOP_SENTRY_DSN ??
+      process.env.NEXU_DESKTOP_SENTRY_DSN,
+  };
+}
+
+function resolveSentryProject(buildSource) {
+  const explicitProject = process.env.NEXU_DESKTOP_SENTRY_PROJECT;
+
+  if (explicitProject) {
+    return explicitProject;
+  }
+
+  return DEFAULT_SENTRY_PROJECT_BY_SOURCE[buildSource] ?? "";
+}
+
+async function collectArtifactFiles(dirPath) {
+  const entries = await readdir(dirPath, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const entryPath = resolve(dirPath, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...(await collectArtifactFiles(entryPath)));
+      continue;
+    }
+
+    if (!entry.isFile()) {
+      continue;
+    }
+
+    if (
+      entry.name.endsWith(".js") ||
+      entry.name.endsWith(".js.map") ||
+      entry.name.endsWith(".mjs") ||
+      entry.name.endsWith(".mjs.map")
+    ) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+}
+
+function getArtifactName(filePath) {
+  const relativePath = relative(electronRoot, filePath).split("\\").join("/");
+  return `app:///${relativePath}`;
+}
+
+function getContentType(filePath) {
+  if (filePath.endsWith(".map")) {
+    return "application/json";
+  }
+
+  return "application/javascript";
+}
+
+async function sentryRequest(url, authToken, options = {}) {
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${authToken}`,
+      ...(options.headers ?? {}),
+    },
+  });
+
+  if (response.ok) {
+    return response;
+  }
+
+  const body = await response.text();
+  throw new Error(
+    `[sourcemaps] ${options.method ?? "GET"} ${url} failed: ${response.status} ${response.statusText}${body ? ` - ${body}` : ""}`,
+  );
+}
+
+async function trySentryRequest(url, authToken, options = {}) {
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${authToken}`,
+      ...(options.headers ?? {}),
+    },
+  });
+
+  return response;
+}
+
+async function ensureRelease(apiOrigin, org, project, release, authToken) {
+  const response = await fetch(
+    `${apiOrigin}/api/0/organizations/${encodeURIComponent(org)}/releases/`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${authToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        version: release,
+        ...(project ? { projects: [project] } : {}),
+      }),
+    },
+  );
+
+  if (response.ok || response.status === 208 || response.status === 409) {
+    return;
+  }
+
+  const body = await response.text();
+  throw new Error(
+    `[sourcemaps] failed to create Sentry release ${release}: ${response.status} ${response.statusText}${body ? ` - ${body}` : ""}`,
+  );
+}
+
+async function listReleaseFiles(apiOrigin, org, release, authToken) {
+  const response = await sentryRequest(
+    `${apiOrigin}/api/0/organizations/${encodeURIComponent(org)}/releases/${encodeURIComponent(release)}/files/`,
+    authToken,
+  );
+
+  return response.json();
+}
+
+async function deleteReleaseFile(apiOrigin, org, release, fileId, authToken) {
+  const response = await trySentryRequest(
+    `${apiOrigin}/api/0/organizations/${encodeURIComponent(org)}/releases/${encodeURIComponent(release)}/files/${encodeURIComponent(String(fileId))}/`,
+    authToken,
+    { method: "DELETE" },
+  );
+
+  if (response.ok) {
+    return { deleted: true };
+  }
+
+  const body = await response.text();
+  if (response.status === 403) {
+    return {
+      deleted: false,
+      reason: `permission_denied:${body}`,
+    };
+  }
+
+  throw new Error(
+    `[sourcemaps] DELETE ${apiOrigin}/api/0/organizations/${encodeURIComponent(org)}/releases/${encodeURIComponent(release)}/files/${encodeURIComponent(String(fileId))}/ failed: ${response.status} ${response.statusText}${body ? ` - ${body}` : ""}`,
+  );
+}
+
+async function uploadReleaseFile(
+  apiOrigin,
+  org,
+  release,
+  dist,
+  filePath,
+  authToken,
+) {
+  const form = new FormData();
+  form.set("name", getArtifactName(filePath));
+  form.set("header", `Content-Type:${getContentType(filePath)}`);
+  if (dist) {
+    form.set("dist", dist);
+  }
+  form.set(
+    "file",
+    new Blob([await readFile(filePath)], { type: getContentType(filePath) }),
+    basename(filePath),
+  );
+
+  await sentryRequest(
+    `${apiOrigin}/api/0/organizations/${encodeURIComponent(org)}/releases/${encodeURIComponent(release)}/files/`,
+    authToken,
+    {
+      method: "POST",
+      body: form,
+    },
+  );
+}
+
+async function main() {
+  const authToken = process.env.SENTRY_AUTH_TOKEN ?? "";
+  const org = process.env.NEXU_DESKTOP_SENTRY_ORG ?? DEFAULT_SENTRY_ORG;
+
+  if (!authToken) {
+    console.log(
+      "[sourcemaps] skipping upload: set SENTRY_AUTH_TOKEN to enable desktop sourcemap upload.",
+    );
+    return;
+  }
+
+  const buildMetadata = await resolveUploadBuildMetadata();
+  const version = buildMetadata.version;
+  const dsn = buildMetadata.dsn;
+  const project = resolveSentryProject(buildMetadata.source ?? "local-dev");
+
+  if (typeof version !== "string" || version.length === 0) {
+    console.log(
+      "[sourcemaps] skipping upload: unable to resolve desktop app version from build-config.json or package.json.",
+    );
+    return;
+  }
+
+  if (typeof dsn !== "string" || dsn.length === 0) {
+    console.log(
+      "[sourcemaps] skipping upload: build-config.json is missing NEXU_DESKTOP_SENTRY_DSN.",
+    );
+    return;
+  }
+
+  if (!project) {
+    console.log(
+      "[sourcemaps] skipping upload: no Sentry project configured for this desktop build source.",
+    );
+    return;
+  }
+
+  const apiOrigin = getSentryApiOrigin(
+    dsn,
+    process.env.NEXU_DESKTOP_SENTRY_API_ORIGIN,
+  );
+
+  if (!apiOrigin) {
+    throw new Error("[sourcemaps] unable to determine Sentry API origin.");
+  }
+
+  const release = buildSentryRelease(version);
+  const dist = buildSentryDist(version, buildMetadata.commit ?? null);
+  const artifactFiles = [
+    ...(await collectArtifactFiles(resolve(electronRoot, "dist"))),
+    ...(await collectArtifactFiles(
+      resolve(electronRoot, "dist-electron", "preload"),
+    )),
+  ];
+
+  await ensureRelease(apiOrigin, org, project, release, authToken);
+
+  const existingFiles = await listReleaseFiles(
+    apiOrigin,
+    org,
+    release,
+    authToken,
+  );
+  const replaceableNames = new Set(artifactFiles.map(getArtifactName));
+  const blockedArtifactNames = new Set();
+  let skippedReplacementCount = 0;
+  let uploadedCount = 0;
+
+  for (const file of existingFiles) {
+    if (!replaceableNames.has(file.name)) {
+      continue;
+    }
+
+    const fileDist = typeof file.dist === "string" ? file.dist : undefined;
+    if ((dist ?? undefined) !== fileDist) {
+      continue;
+    }
+
+    const deletion = await deleteReleaseFile(
+      apiOrigin,
+      org,
+      release,
+      file.id,
+      authToken,
+    );
+
+    if (!deletion.deleted) {
+      blockedArtifactNames.add(file.name);
+      skippedReplacementCount += 1;
+      console.warn(
+        `[sourcemaps] keeping existing artifact ${file.name} for release=${release}${dist ? ` dist=${dist}` : ""}; delete was denied, so this file was skipped during upload.`,
+      );
+    }
+  }
+
+  for (const filePath of artifactFiles) {
+    if (blockedArtifactNames.has(getArtifactName(filePath))) {
+      continue;
+    }
+
+    await uploadReleaseFile(apiOrigin, org, release, dist, filePath, authToken);
+    uploadedCount += 1;
+  }
+
+  console.log(
+    `[sourcemaps] uploaded ${uploadedCount}/${artifactFiles.length} desktop artifacts to ${apiOrigin} for project=${project} release=${release}${dist ? ` dist=${dist}` : ""}${skippedReplacementCount > 0 ? ` (${skippedReplacementCount} kept existing)` : ""}.`,
+  );
+}
+
+await main();

--- a/apps/desktop/shared/host.ts
+++ b/apps/desktop/shared/host.ts
@@ -1,5 +1,5 @@
-import type { DesktopRuntimeConfig } from "./runtime-config";
-export type { DesktopRuntimeConfig } from "./runtime-config";
+import type { DesktopBuildInfo, DesktopRuntimeConfig } from "./runtime-config";
+export type { DesktopBuildInfo, DesktopRuntimeConfig } from "./runtime-config";
 import type { SkillhubCatalogData } from "./skillhub-types";
 export type { SkillhubCatalogData } from "./skillhub-types";
 
@@ -269,6 +269,7 @@ export type HostBridge = {
 };
 
 export type HostBootstrap = {
+  buildInfo: DesktopBuildInfo;
   sentryDsn: string | null;
   isPackaged: boolean;
 };

--- a/apps/desktop/shared/runtime-config.ts
+++ b/apps/desktop/shared/runtime-config.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { getDesktopAppRoot } from "./workspace-paths";
 
 export const DEFAULT_API_PORT = 50_800;
 export const DEFAULT_WEB_PORT = 50_810;
@@ -23,6 +24,7 @@ type BuildConfig = {
   NEXU_CLOUD_URL?: string;
   NEXU_LINK_URL?: string | null;
   NEXU_UPDATE_FEED_URL?: string;
+  NEXU_DESKTOP_APP_VERSION?: string;
   NEXU_DESKTOP_SENTRY_DSN?: string;
   NEXU_DESKTOP_BUILD_SOURCE?: string;
   NEXU_DESKTOP_BUILD_BRANCH?: string;
@@ -71,6 +73,10 @@ function loadBuildConfig(resourcesPath?: string): BuildConfig {
         record,
         "NEXU_UPDATE_FEED_URL",
       ),
+      NEXU_DESKTOP_APP_VERSION: readBuildConfigString(
+        record,
+        "NEXU_DESKTOP_APP_VERSION",
+      ),
       NEXU_DESKTOP_SENTRY_DSN: readBuildConfigString(
         record,
         "NEXU_DESKTOP_SENTRY_DSN",
@@ -95,6 +101,42 @@ function loadBuildConfig(resourcesPath?: string): BuildConfig {
   } catch {
     return {};
   }
+}
+
+function readJsonVersion(filePath: string): string | undefined {
+  if (!existsSync(filePath)) {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, "utf8")) as unknown;
+
+    if (!parsed || typeof parsed !== "object") {
+      return undefined;
+    }
+
+    const version = (parsed as { version?: unknown }).version;
+    return typeof version === "string" && version.length > 0
+      ? version
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readPackagedAppVersion(resourcesPath?: string): string | undefined {
+  if (!resourcesPath) {
+    return undefined;
+  }
+
+  return (
+    readJsonVersion(resolve(resourcesPath, "app.asar", "package.json")) ??
+    readJsonVersion(resolve(resourcesPath, "app", "package.json"))
+  );
+}
+
+function readDesktopPackageVersion(): string | undefined {
+  return readJsonVersion(resolve(getDesktopAppRoot(), "package.json"));
 }
 
 export type DesktopBuildSource =
@@ -174,6 +216,9 @@ export function getDesktopRuntimeConfig(
 ): DesktopRuntimeConfig {
   // Load build-time config (for packaged apps)
   const buildConfig = loadBuildConfig(defaults?.resourcesPath);
+  const fallbackPackageVersion =
+    readPackagedAppVersion(defaults?.resourcesPath) ??
+    readDesktopPackageVersion();
   const ports = {
     api: Number.parseInt(env.NEXU_API_PORT ?? String(DEFAULT_API_PORT), 10),
     web: Number.parseInt(env.NEXU_WEB_PORT ?? String(DEFAULT_WEB_PORT), 10),
@@ -207,7 +252,13 @@ export function getDesktopRuntimeConfig(
 
   return {
     buildInfo: {
-      version: defaults?.appVersion ?? env.npm_package_version ?? "0.0.0",
+      version:
+        defaults?.appVersion ??
+        env.NEXU_DESKTOP_APP_VERSION ??
+        buildConfig.NEXU_DESKTOP_APP_VERSION ??
+        env.npm_package_version ??
+        fallbackPackageVersion ??
+        "0.0.0",
       source: normalizeBuildSource(
         env.NEXU_DESKTOP_BUILD_SOURCE ?? buildConfig.NEXU_DESKTOP_BUILD_SOURCE,
       ),

--- a/apps/desktop/shared/sentry-build-metadata.ts
+++ b/apps/desktop/shared/sentry-build-metadata.ts
@@ -1,0 +1,53 @@
+import type { DesktopBuildInfo } from "./runtime-config";
+
+export type DesktopSentryBuildMetadata = {
+  release: string;
+  dist?: string;
+  buildContext: DesktopBuildInfo;
+};
+
+const SENTRY_DIST_MAX_LENGTH = 64;
+
+function normalizeCommit(commit: string | null): string | null {
+  if (!commit) {
+    return null;
+  }
+
+  const trimmedCommit = commit.trim();
+  return trimmedCommit.length > 0 ? trimmedCommit : null;
+}
+
+function buildSentryDist(
+  version: string,
+  commit: string | null,
+): string | undefined {
+  if (!commit) {
+    return undefined;
+  }
+
+  const normalizedVersion = version.trim().replace(/[^A-Za-z0-9_.-]+/g, "-");
+  const normalizedCommit = commit.replace(/[^A-Za-z0-9_.-]+/g, "-");
+  const dist = `${normalizedVersion}-${normalizedCommit}`.slice(
+    0,
+    SENTRY_DIST_MAX_LENGTH,
+  );
+
+  return dist.length > 0 ? dist : undefined;
+}
+
+export function getDesktopSentryBuildMetadata(
+  buildInfo: DesktopBuildInfo,
+): DesktopSentryBuildMetadata {
+  const release = `nexu-desktop@${buildInfo.version}`;
+  const commit = normalizeCommit(buildInfo.commit);
+  const dist = buildSentryDist(buildInfo.version, commit);
+
+  return {
+    release,
+    ...(dist ? { dist } : {}),
+    buildContext: {
+      ...buildInfo,
+      commit,
+    },
+  };
+}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -19,6 +19,7 @@ import type {
   RuntimeUnitSnapshot,
   RuntimeUnitState,
 } from "../shared/host";
+import { getDesktopSentryBuildMetadata } from "../shared/sentry-build-metadata";
 import { UpdateBanner } from "./components/update-banner";
 import { useAutoUpdate } from "./hooks/use-auto-update";
 import {
@@ -49,10 +50,18 @@ function initializeRendererSentry(dsn: string): void {
     return;
   }
 
+  const sentryBuildMetadata = getDesktopSentryBuildMetadata(
+    window.nexuHost.bootstrap.buildInfo,
+  );
+
   Sentry.init({
     dsn,
     environment: import.meta.env.MODE,
+    release: sentryBuildMetadata.release,
+    ...(sentryBuildMetadata.dist ? { dist: sentryBuildMetadata.dist } : {}),
   });
+
+  Sentry.setContext("build", sentryBuildMetadata.buildContext);
 
   rendererSentryInitialized = true;
 }

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
         },
         vite: {
           build: {
+            sourcemap: true,
             outDir: "dist-electron/preload",
             rollupOptions: {
               external: ["electron"],
@@ -53,6 +54,7 @@ export default defineConfig({
         },
         vite: {
           build: {
+            sourcemap: true,
             outDir: "dist-electron/preload",
             rollupOptions: {
               external: ["electron"],
@@ -87,5 +89,6 @@ export default defineConfig({
   build: {
     outDir: "dist",
     emptyOutDir: true,
+    sourcemap: true,
   },
 });

--- a/specs/change/20260319-desktop-sentry-build-metadata/spec.md
+++ b/specs/change/20260319-desktop-sentry-build-metadata/spec.md
@@ -1,0 +1,168 @@
+---
+id: 20260319-desktop-sentry-build-metadata
+name: Desktop Sentry Build Metadata
+status: implemented
+created: '2026-03-19'
+---
+
+## Overview
+
+- Add desktop build metadata to Sentry events so crash and exception issues can be tied back to the exact packaged artifact without relying on branch-specific tags.
+- Keep Sentry naming aligned with standard release management:
+  - `release`: `nexu-desktop@<version>`
+  - `dist`: `<version>-<commit>`
+- Focus the operator experience on packaged crash triage first. Local dev-only metadata such as branch and build source should remain available as event context, but should not become primary issue filters.
+- Apply the same metadata model to both Electron main and renderer pipelines so JavaScript exceptions and native crashes share the same release/dist identity in Sentry.
+
+## Research
+
+### Existing system
+
+- Electron main computes `runtimeConfig` once via `getDesktopRuntimeConfig(...)`, then initializes Sentry only when a desktop DSN is present; otherwise it keeps the local-only `crashReporter` fallback unchanged.
+- Electron renderer initializes `@sentry/electron/renderer` from preload bootstrap data, but today only receives `sentryDsn` and `isPackaged`, so it has no shared `release`/`dist` metadata.
+- `apps/desktop/shared/runtime-config.ts` already acts as the single source of truth for build metadata (`version`, `source`, `branch`, `commit`, `builtAt`) across dev env injection and packaged `build-config.json`.
+- Full runtime config is already available to the renderer through the typed `env:get-runtime-config` IPC path, and the UI already displays `buildInfo`, so no new build metadata source is needed.
+
+### Available approaches
+
+- Extend preload bootstrap to include the resolved build metadata needed for renderer Sentry initialization.
+- Initialize renderer Sentry after asynchronously fetching full runtime config over the existing `env:get-runtime-config` IPC call.
+- Add a shared desktop Sentry metadata helper that derives `release`, optional `dist`, and structured build context from `runtimeConfig.buildInfo`, then reuse it in both main and renderer.
+
+### Constraints
+
+- Preserve `getDesktopRuntimeConfig(...)` as the canonical build metadata resolver; do not duplicate environment parsing in Sentry setup code.
+- Preserve the existing DSN-absent behavior where main falls back to Electron `crashReporter` with no Sentry upload path.
+- Keep renderer access within the existing typed host bridge and IPC patterns defined in `apps/desktop/shared/host.ts`.
+- Preserve existing crash-test tagging and `beforeSend` behavior in main so desktop Sentry diagnostics continue to work.
+- `dist` must be omitted when commit metadata is unavailable instead of inventing a synthetic value.
+
+### Key references
+
+- `apps/desktop/main/index.ts:51`
+- `apps/desktop/main/index.ts:72`
+- `apps/desktop/main/index.ts:75`
+- `apps/desktop/main/index.ts:96`
+- `apps/desktop/src/main.tsx:42`
+- `apps/desktop/src/main.tsx:52`
+- `apps/desktop/preload/index.ts:19`
+- `apps/desktop/preload/index.ts:24`
+- `apps/desktop/main/ipc.ts:137`
+- `apps/desktop/shared/runtime-config.ts:107`
+- `apps/desktop/shared/runtime-config.ts:167`
+- `apps/desktop/shared/runtime-config.ts:209`
+- `apps/desktop/shared/host.ts:271`
+
+## Design
+
+### Architecture overview
+
+```text
+build-config.json / env
+        |
+        v
+getDesktopRuntimeConfig(...)
+        |
+        +--> main/index.ts --------> getDesktopSentryBuildMetadata(buildInfo)
+        |                               |-> Sentry.init({ release, dist? })
+        |                               `-> Sentry.setContext("build", ...)
+        |
+        `--> preload/index.ts -----> bootstrap.buildInfo + bootstrap.sentryDsn
+                                        |
+                                        v
+                                   src/main.tsx
+                                        |
+                                        `-> getDesktopSentryBuildMetadata(buildInfo)
+                                            -> Sentry.init({ release, dist? })
+                                            -> Sentry.setContext("build", ...)
+```
+
+### Design decisions
+
+- Keep `runtimeConfig.buildInfo` as the only source of desktop build metadata so main and renderer cannot drift.
+- Add a small shared helper that derives Sentry `release`, optional `dist`, and the structured `build` context from `DesktopBuildInfo`.
+- Rename the desktop Sentry release to `nexu-desktop@<version>` and set `dist` to a Sentry-safe `<version>-<commit>` value only when commit metadata exists.
+- Expose `buildInfo` through the existing preload bootstrap so renderer Sentry can initialize synchronously during startup instead of waiting on an async IPC round-trip.
+- Keep branch/source/commit out of Sentry tags; store them only in `Sentry.setContext("build", ...)`.
+
+### Implementation steps
+
+1. Add a shared desktop Sentry metadata helper in `apps/desktop/shared/` that normalizes commit values and returns `release`, optional `dist`, and `build` context.
+2. Update `apps/desktop/main/index.ts` to use that helper during `Sentry.init(...)` and attach the `build` context immediately after initialization.
+3. Extend the typed host bootstrap contract to include `buildInfo`, then pass it through `apps/desktop/preload/index.ts`.
+4. Update `apps/desktop/src/main.tsx` to initialize renderer Sentry from the same helper output so renderer and main share the same metadata model.
+5. Verify three cases: DSN present with commit, DSN present without commit, and DSN absent with the local crashReporter fallback intact.
+
+### Pseudocode
+
+```text
+function getDesktopSentryBuildMetadata(buildInfo):
+  release = "nexu-desktop@" + buildInfo.version
+  commit = trim(buildInfo.commit)
+
+  return {
+    release,
+    dist: commit ? version + "-" + commit : undefined,
+    buildContext: {
+      version: buildInfo.version,
+      source: buildInfo.source,
+      branch: buildInfo.branch,
+      commit: commit or null,
+      builtAt: buildInfo.builtAt,
+    },
+  }
+```
+
+### Files to create or modify
+
+- `apps/desktop/shared/sentry-build-metadata.ts` - shared helper for release, dist, and build context derivation
+- `apps/desktop/main/index.ts` - use the helper for main-process Sentry initialization and build context attachment
+- `apps/desktop/shared/host.ts` - extend preload bootstrap typing with `buildInfo`
+- `apps/desktop/preload/index.ts` - expose `buildInfo` in the bootstrap payload
+- `apps/desktop/src/main.tsx` - initialize renderer Sentry with the same release/dist/context model as main
+
+### Edge cases and error handling
+
+- Treat empty or whitespace-only commit values as missing and omit `dist`.
+- Preserve the existing DSN-absent path where main uses local-only `crashReporter` and renderer skips Sentry initialization.
+- Leave `builtAt` as raw context data; do not parse or validate timestamps during Sentry setup.
+- Keep the renderer's one-time initialization guard so startup cannot double-register Sentry.
+
+## Plan
+
+- [x] Add a shared helper that derives desktop Sentry `release`, optional `dist`, and structured build context from `DesktopBuildInfo`
+- [x] Update main-process Sentry initialization to use the shared metadata helper and attach the `build` context
+- [x] Extend the preload bootstrap contract to expose `buildInfo` to the renderer
+- [x] Update renderer Sentry initialization to use the shared metadata helper and attach the `build` context
+- [x] Run validation checks for the desktop TypeScript changes (`pnpm typecheck`, `pnpm lint`, and targeted tests if needed)
+
+## Implementation
+
+### Files created or modified
+
+- `apps/desktop/shared/sentry-build-metadata.ts` - added the shared helper that builds Sentry `release`, optional `dist`, and normalized `build` context from `DesktopBuildInfo`
+- `apps/desktop/main/index.ts` - main-process Sentry now uses the shared helper and attaches `Sentry.setContext("build", ...)`
+- `apps/desktop/src/main.tsx` - renderer Sentry now uses the same shared helper and preload bootstrap metadata for synchronous startup initialization
+- `apps/desktop/shared/host.ts` and `apps/desktop/preload/index.ts` - extended the preload bootstrap contract to expose `buildInfo`
+- `apps/desktop/shared/runtime-config.ts` - added packaged build-config support for `NEXU_DESKTOP_APP_VERSION` so preload can resolve the correct desktop version without async IPC
+- `apps/desktop/scripts/dist-mac.mjs`, `.github/workflows/desktop-build.yml`, and `.github/workflows/desktop-release.yml` - now write `NEXU_DESKTOP_APP_VERSION` into `build-config.json` for packaged builds
+- `apps/desktop/scripts/upload-sourcemaps.mjs` and `apps/desktop/vite.config.ts` - renderer/preload production builds now emit sourcemaps and upload them to Sentry releases, auto-routing by build source to hardcoded `refly-ai` desktop projects (`nexu-desktop-dev`, `nexu-desktop-test`, `nexu-desktop-prod`)
+- `tests/desktop/sentry-build-metadata.test.ts` - added unit coverage for release/dist derivation and blank-commit handling
+
+### Testing results
+
+- `pnpm typecheck` - passed
+- `pnpm lint` - passed
+- `pnpm --filter @nexu/desktop build` - passed and now emits renderer/main/preload sourcemaps
+- `pnpm exec vitest run tests/desktop/sentry-build-metadata.test.ts` - passed
+- `pnpm test` - not fully green due pre-existing environment/repo issues outside this feature: API suites expect a local `nexu_test` database, and `tests/web/home.test.tsx` still fails on the alpha video source assertion
+
+### Deviations from the design
+
+- The design originally assumed existing build metadata sources were already sufficient for synchronous renderer initialization.
+- During implementation review, packaged renderer startup was found to fall back to `0.0.0` because preload had no authoritative app version.
+- To preserve synchronous renderer Sentry initialization without introducing an async IPC dependency, packaged `build-config.json` generation was expanded to include `NEXU_DESKTOP_APP_VERSION`, and `runtimeConfig.buildInfo.version` now reads it when `appVersion` is not injected directly.
+
+## Notes
+
+<!-- Optional: Alternatives considered, open questions, etc. -->

--- a/specs/current/sentry/SENTRY.md
+++ b/specs/current/sentry/SENTRY.md
@@ -1,0 +1,323 @@
+# Sentry
+
+This document describes the current desktop Sentry pipeline as one complete system:
+
+1. the three environments
+2. the packaging pipeline, including DSN injection and sourcemap upload
+3. the runtime exception/crash reporting pipeline
+
+Scope: Electron desktop only.
+
+Key code paths:
+
+- `apps/desktop/shared/runtime-config.ts`
+- `apps/desktop/shared/sentry-build-metadata.ts`
+- `apps/desktop/main/index.ts`
+- `apps/desktop/preload/index.ts`
+- `apps/desktop/src/main.tsx`
+- `apps/desktop/scripts/dist-mac.mjs`
+- `apps/desktop/scripts/upload-sourcemaps.mjs`
+- `.github/workflows/desktop-build.yml`
+- `.github/workflows/desktop-release.yml`
+
+## 1. Three Environments
+
+Desktop Sentry uses the fixed org `refly-ai` and three fixed projects.
+
+| Environment | Build source | Sentry project | Primary use |
+| --- | --- | --- | --- |
+| Local dev | `local-dev`, `local-dist` | `nexu-desktop-dev` | local development and local packaged verification |
+| Test | `nightly-test` | `nexu-desktop-test` | nightly test desktop builds |
+| Prod | `nightly-prod`, `release` | `nexu-desktop-prod` | nightly prod builds and formal releases |
+
+This mapping is hardcoded in `apps/desktop/scripts/upload-sourcemaps.mjs`.
+
+### Environment-specific DSN sources
+
+| Environment | DSN source |
+| --- | --- |
+| Local dev | local runtime env, usually `apps/api/.env` via `NEXU_DESKTOP_SENTRY_DSN` |
+| Test | GitHub secret `SENTRY_DSN_NEXU_DESKTOP_TEST` |
+| Prod | GitHub secret `SENTRY_DSN_NEXU_DESKTOP_PROD` |
+
+### Shared release metadata rules
+
+All environments use the same metadata model from `apps/desktop/shared/sentry-build-metadata.ts`:
+
+- `release = nexu-desktop@<version>`
+- `dist = <version>-<commit>` when commit exists
+- if commit is missing, `dist` is omitted
+
+Example:
+
+- `release`: `nexu-desktop@0.1.3`
+- `dist`: `0.1.3-ce04c383286127ddb766141c7bf55b4e7b70cf18`
+
+## 2. Packaging Pipeline
+
+This section covers the build/package side of the Sentry pipeline, including both DSN injection and sourcemap upload.
+
+### 2.1 Local dev packaging flow
+
+Local verification usually follows this path:
+
+```bash
+pnpm desktop:restart
+pnpm --filter @nexu/desktop build
+pnpm --filter @nexu/desktop upload:sourcemaps
+```
+
+#### Local dev DSN injection
+
+For local runs, runtime config resolves the DSN in `apps/desktop/shared/runtime-config.ts` in this order:
+
+1. `process.env.NEXU_DESKTOP_SENTRY_DSN`
+2. `build-config.json`
+3. `null`
+
+In practice, local source of truth is usually:
+
+- `apps/api/.env`
+- variable: `NEXU_DESKTOP_SENTRY_DSN`
+
+#### Local dev build metadata resolution
+
+For local sourcemap upload, `apps/desktop/scripts/upload-sourcemaps.mjs` uses local-friendly fallbacks:
+
+- version: desktop `package.json` fallback is allowed
+- source: defaults to `local-dev` unless overridden
+- commit: falls back to `git rev-parse HEAD`
+- DSN: prefers env, then `build-config.json`
+
+This is why local upload can work even if `build-config.json` is not a fresh CI-style packaged artifact.
+
+#### Local dev sourcemap generation
+
+`apps/desktop/vite.config.ts` emits production sourcemaps for:
+
+- renderer: `apps/desktop/dist/**/*.js.map`
+- preload: `apps/desktop/dist-electron/preload/**/*.js.map`
+
+#### Local dev sourcemap upload
+
+`apps/desktop/scripts/upload-sourcemaps.mjs` then:
+
+1. resolves version / source / commit / DSN
+2. maps `local-dev` or `local-dist` to `nexu-desktop-dev`
+3. derives Sentry API origin from the DSN
+4. creates or reuses the Sentry release
+5. uploads renderer + preload JS artifacts and sourcemaps
+
+Required local secret material:
+
+- `SENTRY_AUTH_TOKEN`
+
+Local project/org mapping is hardcoded, so they do not need to be configured.
+
+### 2.2 Test packaging flow
+
+Nightly test builds are handled in `.github/workflows/desktop-build.yml`.
+
+#### Test DSN injection
+
+The workflow reads:
+
+- `SENTRY_DSN_NEXU_DESKTOP_TEST`
+
+Then writes a CI build manifest at `apps/desktop/build-config.json` containing:
+
+- `NEXU_DESKTOP_APP_VERSION`
+- `NEXU_DESKTOP_BUILD_SOURCE=nightly-test`
+- `NEXU_DESKTOP_BUILD_BRANCH`
+- `NEXU_DESKTOP_BUILD_COMMIT`
+- `NEXU_DESKTOP_BUILD_TIME`
+- `NEXU_DESKTOP_SENTRY_DSN`
+
+That file is later bundled and read at runtime by `apps/desktop/shared/runtime-config.ts`.
+
+#### Test sourcemap upload
+
+The same workflow passes:
+
+- `SENTRY_AUTH_TOKEN`
+
+Then `pnpm --filter @nexu/desktop dist:mac` runs `apps/desktop/scripts/dist-mac.mjs`, which calls `apps/desktop/scripts/upload-sourcemaps.mjs` after the desktop build step.
+
+The uploader maps `nightly-test` to:
+
+- org: `refly-ai`
+- project: `nexu-desktop-test`
+
+### 2.3 Prod packaging flow
+
+There are two prod-style packaging paths.
+
+#### Nightly prod builds
+
+Handled in `.github/workflows/desktop-build.yml` with:
+
+- `SENTRY_DSN_NEXU_DESKTOP_PROD`
+- `NEXU_DESKTOP_BUILD_SOURCE=nightly-prod`
+
+Uploader target:
+
+- org: `refly-ai`
+- project: `nexu-desktop-prod`
+
+#### Formal releases
+
+Handled in `.github/workflows/desktop-release.yml`.
+
+The workflow reads:
+
+- `SENTRY_DSN_NEXU_DESKTOP_PROD`
+- `SENTRY_AUTH_TOKEN`
+
+Then writes `apps/desktop/build-config.json` with:
+
+- `NEXU_DESKTOP_APP_VERSION`
+- `NEXU_DESKTOP_BUILD_SOURCE=release`
+- `NEXU_DESKTOP_BUILD_COMMIT`
+- `NEXU_DESKTOP_BUILD_TIME`
+- `NEXU_DESKTOP_SENTRY_DSN`
+
+Then `dist:mac` runs the sourcemap upload step automatically.
+
+Uploader target:
+
+- org: `refly-ai`
+- project: `nexu-desktop-prod`
+
+### 2.4 Packaging secrets
+
+Current GitHub secrets involved in the packaging pipeline:
+
+| Secret | Where used | Purpose |
+| --- | --- | --- |
+| `SENTRY_DSN_NEXU_DESKTOP_TEST` | `.github/workflows/desktop-build.yml` | inject desktop test DSN into packaged test builds |
+| `SENTRY_DSN_NEXU_DESKTOP_PROD` | `.github/workflows/desktop-build.yml`, `.github/workflows/desktop-release.yml` | inject desktop prod DSN into packaged prod/release builds |
+| `SENTRY_AUTH_TOKEN` | `.github/workflows/desktop-build.yml`, `.github/workflows/desktop-release.yml` | authenticate sourcemap upload |
+
+Current local secret requirement:
+
+- `SENTRY_AUTH_TOKEN`
+
+### 2.5 Packaging caveats
+
+If a release file with the same artifact name already exists for the same `release` + `dist`, the uploader tries to delete it before re-uploading.
+
+If delete is denied by Sentry:
+
+- the old file is kept
+- that one file is skipped
+- the rest of the files still upload
+- the summary reports `uploaded X/Y ... (N kept existing)`
+
+## 3. Exception Reporting Pipeline
+
+This section covers runtime event delivery after the app is built and launched.
+
+### 3.1 Main process exception/crash path
+
+In `apps/desktop/main/index.ts`:
+
+1. Electron starts
+2. desktop runtime config is resolved
+3. `runtimeConfig.sentryDsn` is checked
+4. if DSN exists:
+   - initialize `@sentry/electron/main`
+   - set `environment`
+   - set `release`
+   - set optional `dist`
+   - attach build context via `Sentry.setContext("build", ...)`
+5. if DSN does not exist:
+   - fall back to local-only Electron `crashReporter`
+   - do not upload native crashes to Sentry
+
+This path covers:
+
+- main-process JavaScript exceptions
+- native crash handling routed through the Electron/Sentry main integration
+
+### 3.2 Renderer exception path
+
+In `apps/desktop/preload/index.ts` and `apps/desktop/src/main.tsx`:
+
+1. preload exposes bootstrap data:
+   - `sentryDsn`
+   - `buildInfo`
+2. renderer starts
+3. if `sentryDsn` exists:
+   - initialize `@sentry/electron/renderer`
+   - set `release`
+   - set optional `dist`
+   - attach build context via `Sentry.setContext("build", ...)`
+
+This path covers:
+
+- renderer JavaScript exceptions
+
+This is the path that depends most directly on uploaded sourcemaps for readable stack traces.
+
+### 3.3 Exception reporting by environment
+
+#### Local dev
+
+- project: `nexu-desktop-dev`
+- environment values typically appear as development-like runtime values
+- renderer exceptions should land in the dev project
+- if sourcemaps were uploaded first, renderer stack traces should resolve beyond bundled filenames
+
+#### Test
+
+- project: `nexu-desktop-test`
+- packaged nightly test builds should report into test using the baked DSN
+- sourcemaps uploaded during CI should match the exact packaged build metadata
+
+#### Prod
+
+- project: `nexu-desktop-prod`
+- nightly prod and formal releases both report into prod using the baked prod DSN
+- sourcemaps uploaded during CI/release packaging should match the exact release artifact
+
+### 3.4 Runtime failure types
+
+Current desktop failure surfaces include:
+
+- renderer JavaScript exception
+- renderer process crash
+- main process crash
+
+Behavior summary:
+
+- renderer JavaScript exception -> `@sentry/electron/renderer`
+- renderer crash / native crash path -> Electron crash pipeline + `@sentry/electron/main`
+- main process crash -> `@sentry/electron/main`
+
+If DSN is absent:
+
+- JavaScript exceptions are not sent to Sentry
+- native crashes stay on the local-only crashReporter fallback path
+
+### 3.5 What must match for readable renderer stacks
+
+For sourcemaps to apply correctly to renderer issues, all of these must align:
+
+- project must be correct for the environment
+- `release` must match exactly
+- `dist` must match exactly when present
+- sourcemaps must be uploaded before the error occurs
+
+If any of these drift, Sentry may still receive the event but show bundle-oriented frames like `app:///dist/assets/index-*.js`.
+
+## Quick Reference
+
+- org: `refly-ai`
+- projects:
+  - `nexu-desktop-dev`
+  - `nexu-desktop-test`
+  - `nexu-desktop-prod`
+- GitHub secrets:
+  - `SENTRY_AUTH_TOKEN`
+  - `SENTRY_DSN_NEXU_DESKTOP_TEST`
+  - `SENTRY_DSN_NEXU_DESKTOP_PROD`

--- a/tests/desktop/sentry-build-metadata.test.ts
+++ b/tests/desktop/sentry-build-metadata.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { getDesktopSentryBuildMetadata } from "#desktop/shared/sentry-build-metadata";
+
+describe("desktop sentry build metadata", () => {
+  it("builds release and dist when commit metadata exists", () => {
+    const result = getDesktopSentryBuildMetadata({
+      version: "1.2.3",
+      source: "local-dist",
+      branch: "main",
+      commit: "abc123",
+      builtAt: "2026-03-19T00:00:00Z",
+    });
+
+    expect(result).toEqual({
+      release: "nexu-desktop@1.2.3",
+      dist: "1.2.3-abc123",
+      buildContext: {
+        version: "1.2.3",
+        source: "local-dist",
+        branch: "main",
+        commit: "abc123",
+        builtAt: "2026-03-19T00:00:00Z",
+      },
+    });
+  });
+
+  it("omits dist when commit metadata is missing or blank", () => {
+    const result = getDesktopSentryBuildMetadata({
+      version: "1.2.3",
+      source: "nightly-test",
+      branch: null,
+      commit: "   ",
+      builtAt: null,
+    });
+
+    expect(result).toEqual({
+      release: "nexu-desktop@1.2.3",
+      buildContext: {
+        version: "1.2.3",
+        source: "nightly-test",
+        branch: null,
+        commit: null,
+        builtAt: null,
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR keeps desktop Sentry metadata in sync with the packaged build context and uploads the generated sourcemaps so renderer issues can be tied back to the exact release/dist.

## Changes

- Added a shared helper that derives the release/dist and build context from runtime build info and passes that metadata into renderer startup
- Persisted the packaged app version through build-config/workflows and runtime config so the metadata stays accurate even when preload cannot inject `appVersion`
- Emit desktop sourcemaps, upload them via a new script (guarded by `SENTRY_AUTH_TOKEN`), and document the desktop Sentry pipeline and tests