### PR TITLE
feat: Add desktop diagnostics export flow

### DIFF
--- a/apps/desktop/main/diagnostics-export.ts
+++ b/apps/desktop/main/diagnostics-export.ts
@@ -1,0 +1,397 @@
+import { access, readFile, stat, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { deflateRawSync } from "node:zlib";
+import { app, dialog } from "electron";
+import type { DesktopRuntimeConfig } from "../shared/runtime-config";
+import { getDesktopDiagnosticsFilePath } from "./desktop-diagnostics";
+import type { RuntimeOrchestrator } from "./runtime/daemon-supervisor";
+
+export type DiagnosticsExportResult = {
+  status: "success" | "cancelled" | "failed";
+  outputPath?: string;
+  warnings?: string[];
+  errorMessage?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Minimal ZIP writer (deflate compression via Node built-in zlib)
+// ---------------------------------------------------------------------------
+
+const CRC32_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let i = 0; i < 256; i++) {
+    let c = i;
+    for (let j = 0; j < 8; j++) {
+      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    }
+    table[i] = c;
+  }
+  return table;
+})();
+
+function crc32(buf: Buffer): number {
+  let crc = 0xffffffff;
+  for (let i = 0; i < buf.length; i++) {
+    crc = (crc >>> 8) ^ CRC32_TABLE[(crc ^ buf[i]) & 0xff];
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function writeUint16LE(buf: Buffer, offset: number, value: number): void {
+  buf.writeUInt16LE(value, offset);
+}
+
+function writeUint32LE(buf: Buffer, offset: number, value: number): void {
+  buf.writeUInt32LE(value >>> 0, offset);
+}
+
+type ZipFileEntry = {
+  name: string;
+  data: Buffer;
+  modTime?: Date;
+};
+
+function toDosDateTime(date: Date): { dosTime: number; dosDate: number } {
+  const dosTime =
+    ((date.getHours() & 0x1f) << 11) |
+    ((date.getMinutes() & 0x3f) << 5) |
+    ((date.getSeconds() >> 1) & 0x1f);
+  const dosDate =
+    (((date.getFullYear() - 1980) & 0x7f) << 9) |
+    (((date.getMonth() + 1) & 0x0f) << 5) |
+    (date.getDate() & 0x1f);
+  return { dosTime, dosDate };
+}
+
+async function writeZip(
+  entries: ZipFileEntry[],
+  outputPath: string,
+): Promise<void> {
+  const chunks: Buffer[] = [];
+  const centralDirEntries: Buffer[] = [];
+  let offset = 0;
+
+  for (const entry of entries) {
+    const nameBytes = Buffer.from(entry.name, "utf8");
+    const dataLen = entry.data.length;
+    const crc = crc32(entry.data);
+
+    // Local file header (30 bytes + name)
+    const compressed = deflateRawSync(entry.data, { level: 6 });
+    const compressedLen = compressed.length;
+    const localHeader = Buffer.alloc(30 + nameBytes.length);
+    const { dosTime, dosDate } = toDosDateTime(entry.modTime ?? new Date());
+    writeUint32LE(localHeader, 0, 0x04034b50); // signature
+    writeUint16LE(localHeader, 4, 20); // version needed
+    writeUint16LE(localHeader, 6, 0); // flags
+    writeUint16LE(localHeader, 8, 8); // compression: deflate
+    writeUint16LE(localHeader, 10, dosTime); // mod time
+    writeUint16LE(localHeader, 12, dosDate); // mod date
+    writeUint32LE(localHeader, 14, crc);
+    writeUint32LE(localHeader, 18, compressedLen); // compressed size
+    writeUint32LE(localHeader, 22, dataLen); // uncompressed size
+    writeUint16LE(localHeader, 26, nameBytes.length);
+    writeUint16LE(localHeader, 28, 0); // extra length
+    nameBytes.copy(localHeader, 30);
+
+    // Central directory record (46 bytes + name)
+    const centralRecord = Buffer.alloc(46 + nameBytes.length);
+    writeUint32LE(centralRecord, 0, 0x02014b50); // signature
+    writeUint16LE(centralRecord, 4, 20); // version made by
+    writeUint16LE(centralRecord, 6, 20); // version needed
+    writeUint16LE(centralRecord, 8, 0); // flags
+    writeUint16LE(centralRecord, 10, 8); // compression: deflate
+    writeUint16LE(centralRecord, 12, dosTime); // mod time
+    writeUint16LE(centralRecord, 14, dosDate); // mod date
+    writeUint32LE(centralRecord, 16, crc);
+    writeUint32LE(centralRecord, 20, compressedLen); // compressed size
+    writeUint32LE(centralRecord, 24, dataLen); // uncompressed size
+    writeUint16LE(centralRecord, 28, nameBytes.length);
+    writeUint16LE(centralRecord, 30, 0); // extra length
+    writeUint16LE(centralRecord, 32, 0); // comment length
+    writeUint16LE(centralRecord, 34, 0); // disk number start
+    writeUint16LE(centralRecord, 36, 0); // internal attrs
+    writeUint32LE(centralRecord, 38, 0); // external attrs
+    writeUint32LE(centralRecord, 42, offset); // local header offset
+    nameBytes.copy(centralRecord, 46);
+
+    chunks.push(localHeader, compressed);
+    centralDirEntries.push(centralRecord);
+
+    offset += localHeader.length + compressedLen;
+  }
+
+  const centralDirBuffer = Buffer.concat(centralDirEntries);
+  const centralDirSize = centralDirBuffer.length;
+  const centralDirOffset = offset;
+
+  // End of central directory record (22 bytes)
+  const eocd = Buffer.alloc(22);
+  writeUint32LE(eocd, 0, 0x06054b50); // signature
+  writeUint16LE(eocd, 4, 0); // disk number
+  writeUint16LE(eocd, 6, 0); // central dir start disk
+  writeUint16LE(eocd, 8, entries.length); // entries on disk
+  writeUint16LE(eocd, 10, entries.length); // total entries
+  writeUint32LE(eocd, 12, centralDirSize);
+  writeUint32LE(eocd, 16, centralDirOffset);
+  writeUint16LE(eocd, 20, 0); // comment length
+
+  const zipData = Buffer.concat([...chunks, centralDirBuffer, eocd]);
+  await writeFile(outputPath, zipData);
+}
+
+// ---------------------------------------------------------------------------
+// Redaction
+// ---------------------------------------------------------------------------
+
+const SENSITIVE_KEY_RE = /token|password|secret|key|dsn/i;
+
+// Scrub token/password/secret values embedded in URL query params or fragments
+// e.g. "http://127.0.0.1:18789/#token=gw-secret-token" → ".../#token=[REDACTED]"
+const SENSITIVE_URL_PARAM_RE = /([?&#])(token|password|secret)(=[^&#\s]*)/gi;
+
+function scrubUrlTokens(str: string): string {
+  return str.replace(SENSITIVE_URL_PARAM_RE, "$1$2=[REDACTED]");
+}
+
+function redactJsonValue(value: unknown, key?: string): unknown {
+  if (typeof value === "string") {
+    if (key && SENSITIVE_KEY_RE.test(key)) {
+      return "[REDACTED]";
+    }
+    return scrubUrlTokens(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => redactJsonValue(item));
+  }
+  if (value !== null && typeof value === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      result[k] = redactJsonValue(v, k);
+    }
+    return result;
+  }
+  return value;
+}
+
+function scrubTextBuffer(raw: Buffer): Buffer {
+  const text = raw.toString("utf8");
+  return Buffer.from(scrubUrlTokens(text), "utf8");
+}
+
+function redactJsonBuffer(raw: Buffer): Buffer {
+  try {
+    const parsed: unknown = JSON.parse(raw.toString("utf8"));
+    const redacted = redactJsonValue(parsed) as object;
+    return Buffer.from(`${JSON.stringify(redacted, null, 2)}\n`, "utf8");
+  } catch {
+    // Not valid JSON — return as-is
+    return raw;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Artifact collection
+// ---------------------------------------------------------------------------
+
+async function tryReadFile(
+  filePath: string,
+): Promise<{ data: Buffer; mtime: Date } | null> {
+  try {
+    await access(filePath);
+    const [data, fileStat] = await Promise.all([
+      readFile(filePath),
+      stat(filePath),
+    ]);
+    return { data, mtime: fileStat.mtime };
+  } catch {
+    return null;
+  }
+}
+
+function getTimestampSlug(): string {
+  const now = new Date();
+  const pad = (n: number, w = 2) => String(n).padStart(w, "0");
+  const date = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}`;
+  const time = `${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
+  const offsetMin = -now.getTimezoneOffset();
+  const sign = offsetMin >= 0 ? "+" : "-";
+  const absMin = Math.abs(offsetMin);
+  const tz = `${sign}${pad(Math.floor(absMin / 60))}${pad(absMin % 60)}`;
+  return `${date}T${time}${tz}`;
+}
+
+async function collectArtifacts(
+  orchestrator: RuntimeOrchestrator,
+  runtimeConfig: DesktopRuntimeConfig,
+): Promise<{ entries: ZipFileEntry[]; warnings: string[] }> {
+  const entries: ZipFileEntry[] = [];
+  const included: string[] = [];
+  const missing: string[] = [];
+  const warnings: string[] = [];
+
+  async function addFile(
+    zipPath: string,
+    filePath: string,
+    {
+      redact = false,
+      scrubLog = false,
+    }: { redact?: boolean; scrubLog?: boolean } = {},
+  ): Promise<void> {
+    const result = await tryReadFile(filePath);
+    if (result === null) {
+      missing.push(zipPath);
+      return;
+    }
+    let { data } = result;
+    if (redact) data = redactJsonBuffer(data);
+    if (scrubLog) data = scrubTextBuffer(data);
+    entries.push({ name: zipPath, data, modTime: result.mtime });
+    included.push(zipPath);
+  }
+
+  // Desktop diagnostics snapshot
+  await addFile(
+    "diagnostics/desktop-diagnostics.json",
+    getDesktopDiagnosticsFilePath(),
+    {
+      redact: true,
+    },
+  );
+
+  // Main process logs
+  const logsDir = app.getPath("logs");
+  await addFile("logs/cold-start.log", resolve(logsDir, "cold-start.log"), {
+    scrubLog: true,
+  });
+  await addFile("logs/desktop-main.log", resolve(logsDir, "desktop-main.log"), {
+    scrubLog: true,
+  });
+
+  // Runtime unit logs (skip embedded units — they have no subprocess log file)
+  const runtimeState = orchestrator.getRuntimeState();
+  for (const unit of runtimeState.units) {
+    if (unit.logFilePath && unit.launchStrategy !== "embedded") {
+      await addFile(`logs/runtime-units/${unit.id}.log`, unit.logFilePath, {
+        scrubLog: true,
+      });
+    }
+  }
+
+  // OpenClaw config (derived from userData path, same logic as manifests.ts)
+  const openclawConfigPath = resolve(
+    app.getPath("userData"),
+    "runtime/openclaw/config/openclaw.json",
+  );
+  await addFile("config/openclaw.json", openclawConfigPath, { redact: true });
+
+  // Environment summary (safe metadata only)
+  const envSummary = buildEnvironmentSummary(runtimeConfig);
+  const now = new Date();
+  entries.push({
+    name: "summary/environment-summary.json",
+    data: Buffer.from(`${JSON.stringify(envSummary, null, 2)}\n`, "utf8"),
+    modTime: now,
+  });
+  included.push("summary/environment-summary.json");
+
+  // Manifest
+  const manifest = {
+    exportedAt: now.toISOString(),
+    appVersion: app.getVersion(),
+    included,
+    missing,
+    warnings,
+    redactionNote:
+      "JSON files have had fields matching token/password/secret/key/dsn patterns redacted. " +
+      "Log and JSON string values have had URL-embedded tokens (e.g. #token=, ?token=) scrubbed.",
+  };
+  entries.push({
+    name: "summary/manifest.json",
+    data: Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`, "utf8"),
+    modTime: now,
+  });
+
+  if (missing.length > 0) {
+    warnings.push(`${missing.length} file(s) were not found and were skipped.`);
+  }
+
+  return { entries, warnings };
+}
+
+function buildEnvironmentSummary(runtimeConfig: DesktopRuntimeConfig): object {
+  return {
+    buildInfo: runtimeConfig.buildInfo,
+    platform: process.platform,
+    arch: process.arch,
+    nodeVersion: process.versions.node,
+    electronVersion: process.versions.electron,
+    isPackaged: app.isPackaged,
+    appVersion: app.getVersion(),
+    logPath: app.getPath("logs"),
+    userDataPath: app.getPath("userData"),
+    // Omit tokens, passwords, DSN — those are redacted from other artifacts
+    ports: runtimeConfig.ports,
+    urls: {
+      controllerBase: runtimeConfig.urls.controllerBase,
+      web: runtimeConfig.urls.web,
+      openclawBase: runtimeConfig.urls.openclawBase,
+      nexuCloud: runtimeConfig.urls.nexuCloud,
+      nexuLink: runtimeConfig.urls.nexuLink,
+    },
+    nexuHome: runtimeConfig.paths.nexuHome,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main export entry point
+// ---------------------------------------------------------------------------
+
+export async function exportDiagnostics({
+  orchestrator,
+  runtimeConfig,
+  source: _source,
+}: {
+  orchestrator: RuntimeOrchestrator;
+  runtimeConfig: DesktopRuntimeConfig;
+  source: "diagnostics-page" | "help-menu";
+}): Promise<DiagnosticsExportResult> {
+  const defaultFilename = `nexu-diagnostics-${getTimestampSlug()}.zip`;
+
+  let filePath: string | undefined;
+  try {
+    const result = await dialog.showSaveDialog({
+      title: "Export Diagnostics",
+      defaultPath: defaultFilename,
+      filters: [{ name: "ZIP Archive", extensions: ["zip"] }],
+    });
+
+    if (result.canceled || !result.filePath) {
+      return { status: "cancelled" };
+    }
+
+    filePath = result.filePath;
+  } catch (error) {
+    return {
+      status: "failed",
+      errorMessage:
+        error instanceof Error ? error.message : "Save dialog failed.",
+    };
+  }
+
+  try {
+    const { entries, warnings } = await collectArtifacts(
+      orchestrator,
+      runtimeConfig,
+    );
+
+    await writeZip(entries, filePath);
+
+    return { status: "success", outputPath: filePath, warnings };
+  } catch (error) {
+    return {
+      status: "failed",
+      errorMessage: error instanceof Error ? error.message : "Export failed.",
+    };
+  }
+}

--- a/apps/desktop/main/index.ts
+++ b/apps/desktop/main/index.ts
@@ -16,6 +16,7 @@ import { getDesktopSentryBuildMetadata } from "../shared/sentry-build-metadata";
 import { getDesktopAppRoot } from "../shared/workspace-paths";
 import { ensureDesktopAuthSession } from "./desktop-bootstrap";
 import { DesktopDiagnosticsReporter } from "./desktop-diagnostics";
+import { exportDiagnostics } from "./diagnostics-export";
 import {
   registerIpcHandlers,
   setComponentUpdater,
@@ -230,6 +231,22 @@ function installApplicationMenu(): void {
     ],
   };
 
+  const helpMenu: MenuItemConstructorOptions = {
+    role: "help",
+    submenu: [
+      {
+        label: "Export Diagnostics…",
+        click: () => {
+          void exportDiagnostics({
+            orchestrator,
+            runtimeConfig,
+            source: "help-menu",
+          }).catch(() => undefined);
+        },
+      },
+    ],
+  };
+
   const template: MenuItemConstructorOptions[] = [
     ...(process.platform === "darwin"
       ? ([{ role: "appMenu" }] satisfies MenuItemConstructorOptions[])
@@ -239,6 +256,7 @@ function installApplicationMenu(): void {
     { role: "viewMenu" },
     developMenu,
     { role: "windowMenu" },
+    helpMenu,
   ];
 
   Menu.setApplicationMenu(Menu.buildFromTemplate(template));

--- a/apps/desktop/main/ipc.ts
+++ b/apps/desktop/main/ipc.ts
@@ -10,6 +10,7 @@ import {
   getDesktopRuntimeConfig,
 } from "../shared/runtime-config";
 import { ensureDesktopAuthSession } from "./desktop-bootstrap";
+import { exportDiagnostics } from "./diagnostics-export";
 import type { RuntimeOrchestrator } from "./runtime/daemon-supervisor";
 import type { ComponentUpdater } from "./updater/component-updater";
 import type { UpdateManager } from "./updater/update-manager";
@@ -138,6 +139,16 @@ export function registerIpcHandlers(
             clearNativeCrashAnnotations();
           }, 5000);
           return undefined;
+        }
+
+        case "diagnostics:export": {
+          const typedPayload =
+            payload as HostInvokePayloadMap["diagnostics:export"];
+          return exportDiagnostics({
+            orchestrator,
+            runtimeConfig,
+            source: typedPayload.source,
+          });
         }
 
         case "env:get-controller-base-url": {

--- a/apps/desktop/shared/host.ts
+++ b/apps/desktop/shared/host.ts
@@ -6,6 +6,7 @@ export const hostInvokeChannels = [
   "diagnostics:get-info",
   "diagnostics:crash-main",
   "diagnostics:crash-renderer",
+  "diagnostics:export",
   "env:get-controller-base-url",
   "env:get-runtime-config",
   "runtime:get-state",
@@ -42,11 +43,19 @@ export type RuntimeEventQueryResult = {
   nextCursor: number;
 };
 
+export type DiagnosticsExportResult = {
+  status: "success" | "cancelled" | "failed";
+  outputPath?: string;
+  warnings?: string[];
+  errorMessage?: string;
+};
+
 export type HostInvokePayloadMap = {
   "app:get-info": undefined;
   "diagnostics:get-info": undefined;
   "diagnostics:crash-main": undefined;
   "diagnostics:crash-renderer": undefined;
+  "diagnostics:export": { source: "diagnostics-page" | "help-menu" };
   "env:get-controller-base-url": undefined;
   "env:get-runtime-config": undefined;
   "runtime:get-state": undefined;
@@ -83,6 +92,7 @@ export type HostInvokeResultMap = {
   "diagnostics:get-info": DiagnosticsInfo;
   "diagnostics:crash-main": undefined;
   "diagnostics:crash-renderer": undefined;
+  "diagnostics:export": DiagnosticsExportResult;
   "env:get-controller-base-url": {
     controllerBaseUrl: string;
   };

--- a/apps/desktop/src/lib/host-api.ts
+++ b/apps/desktop/src/lib/host-api.ts
@@ -1,6 +1,7 @@
 import type {
   AppInfo,
   DesktopRuntimeConfig,
+  DiagnosticsExportResult,
   DiagnosticsInfo,
   HostDesktopCommand,
   RuntimeEvent,
@@ -25,6 +26,12 @@ export async function getAppInfo(): Promise<AppInfo> {
 
 export async function getDiagnosticsInfo(): Promise<DiagnosticsInfo> {
   return getHostBridge().invoke("diagnostics:get-info", undefined);
+}
+
+export async function exportDiagnostics(
+  source: "diagnostics-page" | "help-menu" = "diagnostics-page",
+): Promise<DiagnosticsExportResult> {
+  return getHostBridge().invoke("diagnostics:export", { source });
 }
 
 export async function triggerMainProcessCrash(): Promise<void> {

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -10,6 +10,7 @@ import type {
   DesktopChromeMode,
   DesktopRuntimeConfig,
   DesktopSurface,
+  DiagnosticsExportResult,
   DiagnosticsInfo,
   RuntimeEvent,
   RuntimeLogEntry,
@@ -24,6 +25,7 @@ import { UpdateBanner } from "./components/update-banner";
 import { useAutoUpdate } from "./hooks/use-auto-update";
 import {
   checkComponentUpdates,
+  exportDiagnostics,
   getAppInfo,
   getDiagnosticsInfo,
   getRuntimeConfig,
@@ -787,7 +789,8 @@ function EmbeddedControlPlane() {
 type DiagnosticsActionId =
   | "renderer-exception"
   | "renderer-crash"
-  | "main-crash";
+  | "main-crash"
+  | "export";
 
 function DiagnosticsActionCard({
   description,
@@ -828,6 +831,8 @@ function DiagnosticsPage({
   const [lastAction, setLastAction] = useState<string>(
     "Ready for diagnostics.",
   );
+  const [exportResult, setExportResult] =
+    useState<DiagnosticsExportResult | null>(null);
 
   useEffect(() => {
     void Promise.all([getAppInfo(), getDiagnosticsInfo()])
@@ -891,6 +896,21 @@ function DiagnosticsPage({
 
     void runAction("main-crash", async () => {
       await triggerMainProcessCrash();
+    });
+  }, [runAction]);
+
+  const triggerExport = useCallback(() => {
+    setExportResult(null);
+    void runAction("export", async () => {
+      const result = await exportDiagnostics("diagnostics-page");
+      setExportResult(result);
+      if (result.status === "success") {
+        setLastAction(
+          `Diagnostics exported at ${new Date().toLocaleTimeString()}.`,
+        );
+      } else if (result.status === "failed") {
+        setLastAction(`Export failed at ${new Date().toLocaleTimeString()}.`);
+      }
     });
   }, [runAction]);
 
@@ -976,7 +996,22 @@ function DiagnosticsPage({
           label="Test Main Crash"
           onClick={triggerMainCrash}
         />
+        <DiagnosticsActionCard
+          description="Packages logs, diagnostics snapshot, and OpenClaw config into a ZIP file for sharing with the team. Sensitive fields are redacted before export."
+          disabled={busyAction !== null}
+          label={busyAction === "export" ? "Exporting…" : "Export Diagnostics"}
+          onClick={triggerExport}
+        />
       </section>
+
+      {exportResult?.status === "success" ? (
+        <p className="runtime-note diagnostics-note">
+          Exported to: {exportResult.outputPath}
+          {exportResult.warnings && exportResult.warnings.length > 0
+            ? ` (${exportResult.warnings.join("; ")})`
+            : null}
+        </p>
+      ) : null}
 
       <section className="diagnostics-status-card">
         <div>

--- a/specs/change/20260319-nexu-desktop-diagnostics-export/spec.md
+++ b/specs/change/20260319-nexu-desktop-diagnostics-export/spec.md
@@ -1,0 +1,273 @@
+---
+id: 20260319-nexu-desktop-diagnostics-export
+name: Nexu Desktop Diagnostics Export
+status: implemented
+created: '2026-03-19'
+---
+
+## Overview
+
+### Problem Statement
+
+- Nexu Desktop currently lacks a one-click way to export troubleshooting data.
+- This makes issue investigation harder during development/testing and after release when users need to send diagnostic information back to the team.
+
+### Goals
+
+- Add a one-click export flow in Nexu Desktop for issue diagnosis.
+- Make it easy for users to export diagnostics and share them with the team for troubleshooting.
+
+### Scope
+
+**In scope:**
+- Export Nexu Desktop build information.
+- Export machine environment information.
+- Export `openclaw.json` configuration.
+- Export logs.
+
+## Research
+
+### Existing System
+
+- Desktop user actions cross the Electron boundary through a typed host bridge: renderer wrappers call `window.nexuHost.invoke(...)`, preload validates the channel, and Electron main handles the request in a central IPC switch. Key files: `apps/desktop/src/lib/host-api.ts:23`, `apps/desktop/preload/index.ts:23`, `apps/desktop/shared/host.ts:6`, `apps/desktop/main/ipc.ts:75`.
+- Desktop already persists diagnostics data to `desktop-diagnostics.json` in the Electron logs directory. The snapshot includes cold-start state, renderer/webview failures, runtime state, and recent runtime events, and it is written with a temp-file-then-rename pattern. Key files: `apps/desktop/main/desktop-diagnostics.ts:66`, `apps/desktop/main/desktop-diagnostics.ts:255`, `apps/desktop/main/desktop-diagnostics.ts:277`.
+- Desktop also writes persistent log files for the shell and runtime units. Main-process logs use `cold-start.log` and `desktop-main.log`; runtime-unit logs live under `logs/runtime-units/*.log` with rotation handled by the runtime logger. Key files: `apps/desktop/main/index.ts:179`, `apps/desktop/main/runtime/manifests.ts:227`, `apps/desktop/main/runtime/runtime-logger.ts:99`, `apps/desktop/main/runtime/runtime-logger.ts:332`.
+- The renderer already exposes two adjacent user-facing surfaces: a runtime control page with per-unit log reveal actions, and a diagnostics page that shows app/build metadata and crash-testing actions. Key files: `apps/desktop/src/main.tsx:381`, `apps/desktop/src/main.tsx:528`, `apps/desktop/src/main.tsx:807`, `apps/desktop/src/main.tsx:1087`.
+- Build metadata is generated at packaging time into `build-config.json`, loaded into desktop runtime config, and displayed in the shell UI. Key files: `apps/desktop/scripts/dist-mac.mjs:214`, `apps/desktop/shared/runtime-config.ts:50`, `apps/desktop/shared/runtime-config.ts:153`, `apps/desktop/src/main.tsx:1115`.
+- Controller-owned local state includes Nexu config and compiled OpenClaw config paths, and the desktop runtime manifest passes an `OPENCLAW_CONFIG_PATH` into the controller-managed runtime. Key files: `apps/controller/src/app/env.ts:45`, `apps/controller/src/app/env.ts:53`, `apps/controller/src/services/openclaw-sync-service.ts:21`, `apps/controller/src/runtime/openclaw-config-writer.ts:9`, `apps/desktop/main/runtime/manifests.ts:315`.
+- Repo tooling already has a diagnostics collection pattern in CI: it knows the expected diagnostics/log file locations for dev and packaged modes and copies those artifacts into a capture directory. Key files: `scripts/desktop-ci-check.mjs:44`, `scripts/desktop-ci-check.mjs:65`, `scripts/desktop-ci-check.mjs:79`, `scripts/desktop-ci-check.mjs:823`.
+
+### Available Approaches
+
+- **Snapshot-led export**: Package the existing `desktop-diagnostics.json` together with the persistent log files and the generated OpenClaw config path already used by desktop/controller runtime management. Relevant code: `apps/desktop/main/desktop-diagnostics.ts:255`, `apps/desktop/main/index.ts:179`, `apps/desktop/main/runtime/manifests.ts:327`.
+- **On-demand assembled export**: Add a new host IPC action that gathers build info, environment/path metadata, config files, and selected logs directly in Electron main when the user clicks export. Relevant code path: `apps/desktop/shared/host.ts:6`, `apps/desktop/main/ipc.ts:75`, `apps/desktop/src/lib/host-api.ts:23`.
+- **Capture-directory export**: Reuse the same artifact grouping used by `scripts/desktop-ci-check.mjs` to copy known diagnostics and log paths into an export folder, then hand that folder or an archive to the user. Relevant code: `scripts/desktop-ci-check.mjs:44`, `scripts/desktop-ci-check.mjs:79`, `scripts/desktop-ci-check.mjs:157`, `scripts/desktop-ci-check.mjs:823`.
+- **Diagnostics-surface entry point**: Attach export to the existing desktop Diagnostics page, which already presents troubleshooting metadata and user-triggered diagnostics actions. Relevant UI: `apps/desktop/src/main.tsx:807`, `apps/desktop/src/main.tsx:951`, `apps/desktop/src/main.tsx:1183`.
+- **Runtime-surface entry point**: Attach export to the runtime control plane, which already exposes per-unit logs, live runtime state, and runtime actions. Relevant UI: `apps/desktop/src/main.tsx:347`, `apps/desktop/src/main.tsx:528`, `apps/desktop/src/main.tsx:727`.
+
+### Constraints & Dependencies
+
+- Desktop filesystem access currently lives in Electron main behind the typed host bridge. Any renderer-triggered export has to be introduced as a new host channel and handled in main. Key files: `apps/desktop/shared/host.ts:6`, `apps/desktop/preload/index.ts:17`, `apps/desktop/main/ipc.ts:57`.
+- There is no existing desktop save/export dialog flow in Electron main. Current file-oriented UX reveals existing log files in Finder rather than prompting for a destination. Key files: `apps/desktop/main/ipc.ts:168`, `apps/desktop/src/main.tsx:381`.
+- Runtime event history is bounded in memory, and the persisted diagnostics snapshot only includes a limited recent slice. Full-history export cannot rely only on `runtime:query-events`. Key files: `apps/desktop/main/runtime/daemon-supervisor.ts:23`, `apps/desktop/main/runtime/daemon-supervisor.ts:203`, `apps/desktop/main/desktop-diagnostics.ts:256`.
+- Runtime config contains sensitive values, including the gateway token and desktop auth password, so any exported environment/config metadata will need explicit filtering or redaction. Key files: `apps/desktop/shared/runtime-config.ts:138`, `apps/desktop/shared/runtime-config.ts:223`.
+- Packaged desktop code must not rely on shell tools from the user's PATH. Existing archive/extract helpers in desktop code sometimes shell out to `tar`, which is a constraint for any packaged export/archive implementation. Key files: `apps/desktop/main/runtime/manifests.ts:200`, `apps/desktop/main/updater/component-updater.ts:124`, `apps/desktop/main/skillhub/catalog-manager.ts:155`.
+- Desktop dev and packaged modes use different log roots, and existing diagnostics tooling already treats them as separate path sets. Key files: `scripts/desktop-ci-check.mjs:45`, `scripts/desktop-ci-check.mjs:86`.
+
+### Key References
+
+- `apps/desktop/shared/host.ts:6` - Typed host IPC contract and runtime event/query types.
+- `apps/desktop/main/ipc.ts:75` - Central Electron main handler for host actions.
+- `apps/desktop/main/desktop-diagnostics.ts:66` - Diagnostics snapshot file location and reporter.
+- `apps/desktop/main/index.ts:179` - Desktop main log file locations and log writers.
+- `apps/desktop/main/runtime/daemon-supervisor.ts:203` - Cursored runtime event query over bounded in-memory history.
+- `apps/desktop/main/runtime/manifests.ts:227` - Runtime-unit log paths and controller/OpenClaw environment wiring.
+- `apps/desktop/main/runtime/runtime-logger.ts:332` - Persistent structured runtime log serialization.
+- `apps/desktop/shared/runtime-config.ts:153` - Build info, URLs, tokens, and desktop path config.
+- `apps/controller/src/app/env.ts:45` - Controller local config and OpenClaw file path defaults.
+- `scripts/desktop-ci-check.mjs:44` - Existing diagnostics artifact grouping for dev and packaged modes.
+
+## Design
+
+### Architecture
+
+V1 keeps the export flow intentionally small and centered in Electron main.
+
+```text
+Diagnostics Page button / Help menu item
+  -> typed host action or direct main-process command
+  -> exportDiagnostics()
+  -> collect existing artifacts
+  -> redact sensitive values
+  -> write staging directory
+  -> create ZIP
+  -> save to user-selected path
+```
+
+- Renderer stays thin and only triggers export + shows success/error state.
+- Electron main owns filesystem access, save dialog, artifact collection, redaction, and ZIP creation.
+- Export reuses existing persisted diagnostics files instead of rebuilding runtime state on demand.
+- V1 adds two entry points:
+  - Diagnostics page: developer-oriented troubleshooting surface.
+  - Native app menu `Help -> Export Diagnostics...`: user-friendly support entry.
+
+### Implementation Steps
+
+1. **Add export contract**
+   - Add a new typed host action for diagnostics export.
+   - Return structured results for success, cancel, warnings, and failures.
+2. **Build main-process export flow**
+   - Show a native save dialog for the destination ZIP path.
+   - Collect the known diagnostics artifacts from desktop log/config locations.
+   - Create generated summary files for build/environment metadata.
+3. **Apply default redaction**
+   - Redact known secret fields from JSON/config data.
+   - Apply a lightweight text redaction pass to log/config text.
+4. **Package the export**
+   - Copy redacted artifacts into a temporary export directory.
+   - Create a ZIP archive from that staged directory.
+   - Clean up temp files after completion.
+5. **Expose both entry points**
+   - Add an export action to the Diagnostics page.
+   - Add `Help -> Export Diagnostics...` in the native menu.
+6. **Document warnings and follow-ups**
+   - Include a manifest/summary file in the bundle with included/missing files.
+   - Capture V2 improvement ideas in Notes instead of overbuilding V1.
+
+### Pseudocode: Export Flow
+
+```text
+exportDiagnostics(triggerSource):
+  targetPath = promptUserForSaveLocation()
+  if user cancelled:
+    return { status: "cancelled" }
+
+  artifacts = collectArtifactsFromKnownPaths()
+  summaries = buildSafeEnvironmentSummary()
+
+  stagedFiles = []
+  for each artifact in artifacts + summaries:
+    if artifact exists:
+      content = readArtifact()
+      redactedContent = redactSensitiveValues(content)
+      writeToStagingDirectory(redactedContent)
+      recordIncluded(artifact)
+    else:
+      recordMissing(artifact)
+
+  writeManifest(included, missing, warnings)
+  zipStagingDirectoryTo(targetPath)
+  cleanupTemporaryFiles()
+  return { status: "success", targetPath, warnings }
+```
+
+### Files to Modify
+
+- `apps/desktop/shared/host.ts` - Add the typed diagnostics export channel and result types.
+- `apps/desktop/src/lib/host-api.ts` - Add a renderer helper that invokes diagnostics export.
+- `apps/desktop/main/ipc.ts` - Handle the new export request in Electron main.
+- `apps/desktop/src/main.tsx` - Add the Diagnostics page export action and status messaging.
+- `apps/desktop/main/index.ts` - Add the native `Help -> Export Diagnostics...` menu entry.
+
+### Files to Create
+
+- `apps/desktop/main/diagnostics-export.ts` - V1 export orchestrator for save dialog, collection, redaction, staging, and ZIP creation.
+
+### Export Contents
+
+ZIP directory layout after unzip:
+
+```
+nexu-diagnostics-<timestamp>/
+├── diagnostics/
+│   └── desktop-diagnostics.json      # Persisted desktop diagnostics snapshot (JSON-redacted)
+├── logs/
+│   ├── cold-start.log                # Main-process cold-start log (URL-token scrubbed)
+│   ├── desktop-main.log              # Main-process runtime log (URL-token scrubbed)
+│   └── runtime-units/
+│       ├── controller.log            # Controller sidecar log (URL-token scrubbed)
+│       ├── openclaw.log              # OpenClaw process log (URL-token scrubbed)
+│       └── web.log                   # Web server log (URL-token scrubbed)
+├── config/
+│   └── openclaw.json                 # OpenClaw config (JSON-redacted)
+└── summary/
+    ├── environment-summary.json      # Build info, platform, mode, safe paths, ports, URLs
+    └── manifest.json                 # Included/missing files, warnings, redaction notes
+```
+
+Notes:
+- All files are deflate-compressed (method 8) with real file modification timestamps.
+- Embedded runtime units (e.g. `control-plane`) have no subprocess log and are excluded from `logs/runtime-units/`.
+- Files listed under `logs/runtime-units/` depend on which units are present at export time; each unit that has a log file and is not embedded is included.
+- Any file not found at export time is omitted from the ZIP and listed in `manifest.json` under `missing`.
+
+### Interfaces / API
+
+- **Renderer -> Main**
+  - Channel: `diagnostics:export`
+  - Request:
+
+```text
+{
+  source: "diagnostics-page"
+}
+```
+
+  - Response:
+
+```text
+{
+  status: "success" | "cancelled" | "failed",
+  outputPath?: string,
+  warnings?: string[],
+  errorMessage?: string
+}
+```
+
+- **Main menu -> Export service**
+  - Directly call the same export function with `source: "help-menu"`.
+
+### Edge Cases
+
+- **Save cancelled** - Return `cancelled`; do not show a failure banner.
+- **Missing files** - Still export the ZIP and list missing items in `manifest.json`.
+- **Config not created yet** - Skip `openclaw.json` and record a warning.
+- **Invalid JSON** - Fall back to raw text redaction when parsing fails.
+- **Write/permission failure** - Return a clear actionable error.
+- **Large logs** - V1 exports current log files as-is; note future size controls in Notes.
+- **Sensitive data** - Default redaction covers known config secrets and common `token/password/secret` patterns.
+
+### Scope Boundaries
+
+- **In scope for V1**
+  - Dev + packaged desktop support.
+  - ZIP export through native save dialog.
+  - Default redaction.
+  - Diagnostics page entry.
+  - Help menu entry.
+- **Out of scope for V1**
+  - Optional unredacted export mode.
+  - Multiple export formats.
+  - Fine-grained file selection UI.
+  - Advanced log truncation or size budgeting.
+  - Uploading diagnostics directly to a remote service.
+
+## Plan
+
+- [x] Add `diagnostics:export` channel and `DiagnosticsExportResult` type to `shared/host.ts`
+- [x] Add `exportDiagnostics()` renderer helper in `src/lib/host-api.ts`
+- [x] Create `main/diagnostics-export.ts` — ZIP writer, redaction, artifact collection, and export orchestrator
+- [x] Handle `diagnostics:export` in `main/ipc.ts`
+- [x] Add export action card and success message to `DiagnosticsPage` in `src/main.tsx`
+- [x] Add `Help -> Export Diagnostics…` menu entry in `main/index.ts`
+
+## Notes
+
+### Implementation
+
+- **`apps/desktop/shared/host.ts`** — Added `"diagnostics:export"` to `hostInvokeChannels`, `HostInvokePayloadMap`, and `HostInvokeResultMap`; added `DiagnosticsExportResult` type.
+- **`apps/desktop/src/lib/host-api.ts`** — Added `exportDiagnostics()` renderer helper.
+- **`apps/desktop/main/diagnostics-export.ts`** (new) — Self-contained module with: minimal ZIP writer (deflate via Node built-in `zlib.deflateRawSync`, real DOS mod timestamps from file `stat`), recursive JSON redaction keyed on `token|password|secret|key|dsn` pattern plus URL fragment/param token scrubbing on all string values, plain-text URL token scrubbing for log files, artifact collection from known paths (embedded units skipped), environment summary builder (strips all tokens/passwords), and the main `exportDiagnostics()` entry point.
+- **`apps/desktop/main/ipc.ts`** — Added `diagnostics:export` case that delegates to the new orchestrator.
+- **`apps/desktop/src/main.tsx`** — Added `"export"` to `DiagnosticsActionId`, `exportResult` state, `triggerExport` callback, an "Export Diagnostics" action card, and a success path display.
+- **`apps/desktop/main/index.ts`** — Added a `Help` menu with `Export Diagnostics…` item that calls `exportDiagnostics()` with `source: "help-menu"`.
+- ZIP uses deflate (method 8, level 6) via Node's built-in `zlib` — ~70-80% size reduction on text-heavy logs, no external deps. ZIP was chosen over tar.gz for native macOS double-click support.
+- ZIP entries carry real file modification timestamps (DOS datetime from `fs.stat` mtime); generated in-memory entries (manifest, environment summary) use export time.
+- Runtime unit log paths are taken from `orchestrator.getRuntimeState()` rather than being hardcoded. Units with `launchStrategy === "embedded"` are skipped — they run in-process and never write to their declared `logFilePath`.
+- OpenClaw config path is derived from `app.getPath("userData")/runtime/openclaw/config/openclaw.json`, mirroring the manifests.ts convention.
+- Redaction covers two layers: (1) JSON key-name matching (`token|password|secret|key|dsn` → `"[REDACTED]"`), (2) URL-embedded param/fragment values (`?token=…`, `#token=…`, etc. → `=[REDACTED]`) applied to all string values in JSON and to all log text.
+
+### Verification
+
+- `pnpm --filter @nexu/desktop typecheck` — passes cleanly.
+- `pnpm lint` — passes cleanly after format fix.
+- Manual testing requires a running desktop runtime (`pnpm desktop:start`); exercise from the Diagnostics page export button and from `Help -> Export Diagnostics…`.
+- Known V1 limitations: large log files are exported as-is (no truncation).
+
+- V1 intentionally favors a small export flow over a deeper layered architecture.
+- Prefer a single export orchestrator file first; split collector/redactor/archive helpers later only if V1 grows.
+- Improvement ideas for V2:
+  - Better log size limits and truncation markers.
+  - More robust structured redaction rules and audit counts.
+  - Additional entry points inside the end-user product UI.
+  - Optional direct upload/share workflow for support cases.


### PR DESCRIPTION
## Summary

This PR adds a diagnostics export workflow to Nexu Desktop so testers and support engineers can package logs, diagnostics snapshots, and OpenClaw config into a redacted ZIP via the diagnostics page or Help menu.

## Changes

- implement the diagnostics export orchestrator with redaction, automatic manifest, and ZIP creation
- expose the export action through the renderer host API plus the Diagnostics page UI and Help menu shortcut
- document the feature in specs/change/20260319-nexu-desktop-diagnostics-export/spec.md