### PR TITLE
fix: enrich desktop diagnostics export

### DIFF
--- a/apps/desktop/main/diagnostics-export.ts
+++ b/apps/desktop/main/diagnostics-export.ts
@@ -1,5 +1,8 @@
-import { access, readFile, stat, writeFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import { execFileSync } from "node:child_process";
+import type { Dirent } from "node:fs";
+import { access, readFile, readdir, stat, writeFile } from "node:fs/promises";
+import { homedir, hostname } from "node:os";
+import { basename, resolve } from "node:path";
 import { deflateRawSync } from "node:zlib";
 import { app, dialog } from "electron";
 import type { DesktopRuntimeConfig } from "../shared/runtime-config";
@@ -49,6 +52,13 @@ type ZipFileEntry = {
   name: string;
   data: Buffer;
   modTime?: Date;
+};
+
+type CollectedFileMetadata = {
+  sourcePath: string;
+  archivePath: string;
+  sizeBytes: number;
+  modifiedAt: string;
 };
 
 function toDosDateTime(date: Date): { dosTime: number; dosDate: number } {
@@ -209,6 +219,64 @@ async function tryReadFile(
   }
 }
 
+async function listFilesInDirectory(directoryPath: string): Promise<string[]> {
+  try {
+    const entries = await readdir(directoryPath, { withFileTypes: true });
+    return entries
+      .filter((entry) => entry.isFile())
+      .map((entry) => resolve(directoryPath, entry.name));
+  } catch {
+    return [];
+  }
+}
+
+async function listFilesRecursive(directoryPath: string): Promise<string[]> {
+  const output: string[] = [];
+
+  async function walk(currentPath: string): Promise<void> {
+    let entries: Dirent[];
+    try {
+      entries = await readdir(currentPath, {
+        withFileTypes: true,
+        encoding: "utf8",
+      });
+    } catch {
+      return;
+    }
+
+    await Promise.all(
+      entries.map(async (entry) => {
+        const nextPath = resolve(currentPath, entry.name);
+        if (entry.isDirectory()) {
+          await walk(nextPath);
+          return;
+        }
+        if (entry.isFile()) {
+          output.push(nextPath);
+        }
+      }),
+    );
+  }
+
+  await walk(directoryPath);
+  return output;
+}
+
+function readMacOsProductVersion(): string | null {
+  if (process.platform !== "darwin") {
+    return null;
+  }
+
+  try {
+    const output = execFileSync("sw_vers", ["-productVersion"], {
+      encoding: "utf8",
+    }).trim();
+    return output.length > 0 ? output : null;
+  } catch {
+    return null;
+  }
+}
+
 function getTimestampSlug(): string {
   const now = new Date();
   const pad = (n: number, w = 2) => String(n).padStart(w, "0");
@@ -224,11 +292,20 @@ function getTimestampSlug(): string {
 async function collectArtifacts(
   orchestrator: RuntimeOrchestrator,
   runtimeConfig: DesktopRuntimeConfig,
+  archiveRoot: string,
 ): Promise<{ entries: ZipFileEntry[]; warnings: string[] }> {
   const entries: ZipFileEntry[] = [];
   const included: string[] = [];
   const missing: string[] = [];
   const warnings: string[] = [];
+
+  const additionalArtifacts = {
+    startupHealth: null as CollectedFileMetadata | null,
+    openclawLogs: [] as CollectedFileMetadata[],
+    sentryFiles: [] as CollectedFileMetadata[],
+    crashReports: [] as CollectedFileMetadata[],
+    sentrySkippedNonJson: [] as string[],
+  };
 
   async function addFile(
     zipPath: string,
@@ -237,17 +314,27 @@ async function collectArtifacts(
       redact = false,
       scrubLog = false,
     }: { redact?: boolean; scrubLog?: boolean } = {},
-  ): Promise<void> {
+  ): Promise<CollectedFileMetadata | null> {
     const result = await tryReadFile(filePath);
     if (result === null) {
       missing.push(zipPath);
-      return;
+      return null;
     }
     let { data } = result;
     if (redact) data = redactJsonBuffer(data);
     if (scrubLog) data = scrubTextBuffer(data);
-    entries.push({ name: zipPath, data, modTime: result.mtime });
+    entries.push({
+      name: `${archiveRoot}/${zipPath}`,
+      data,
+      modTime: result.mtime,
+    });
     included.push(zipPath);
+    return {
+      sourcePath: filePath,
+      archivePath: zipPath,
+      sizeBytes: data.length,
+      modifiedAt: result.mtime.toISOString(),
+    };
   }
 
   // Desktop diagnostics snapshot
@@ -260,7 +347,7 @@ async function collectArtifacts(
   );
 
   // Main process logs
-  const logsDir = app.getPath("logs");
+  const logsDir = resolve(app.getPath("userData"), "logs");
   await addFile("logs/cold-start.log", resolve(logsDir, "cold-start.log"), {
     scrubLog: true,
   });
@@ -285,15 +372,131 @@ async function collectArtifacts(
   );
   await addFile("config/openclaw.json", openclawConfigPath, { redact: true });
 
+  // Startup health state (updater rollback diagnostics)
+  additionalArtifacts.startupHealth = await addFile(
+    "diagnostics/startup-health.json",
+    resolve(app.getPath("userData"), "startup-health.json"),
+    {
+      redact: true,
+    },
+  );
+
+  // OpenClaw runtime logs from /tmp/openclaw
+  const openclawLogsDir = "/tmp/openclaw";
+  const openclawLogFiles = (await listFilesInDirectory(openclawLogsDir))
+    .filter((filePath) => /^openclaw-.*\.log$/i.test(basename(filePath)))
+    .sort();
+
+  for (const openclawLogPath of openclawLogFiles) {
+    const metadata = await addFile(
+      `logs/openclaw/${basename(openclawLogPath)}`,
+      openclawLogPath,
+      {
+        scrubLog: true,
+      },
+    );
+    if (metadata) {
+      additionalArtifacts.openclawLogs.push(metadata);
+    }
+  }
+
+  // Sentry local data under userData/sentry (JSON files only)
+  const sentryDir = resolve(app.getPath("userData"), "sentry");
+  const sentryFiles = (await listFilesRecursive(sentryDir)).sort();
+
+  for (const sentryFilePath of sentryFiles) {
+    const fileName = sentryFilePath.slice(sentryDir.length + 1);
+    const isJsonLike = /\.(json|jsonl)$/i.test(fileName);
+
+    if (!isJsonLike) {
+      additionalArtifacts.sentrySkippedNonJson.push(fileName);
+      continue;
+    }
+
+    const metadata = await addFile(
+      `diagnostics/sentry/${fileName}`,
+      sentryFilePath,
+      {
+        redact: true,
+      },
+    );
+    if (metadata) {
+      additionalArtifacts.sentryFiles.push(metadata);
+    }
+  }
+
+  // Crash reports (last 7 days, file name contains "exu")
+  const crashReportsDir = resolve(homedir(), "Library/Logs/DiagnosticReports");
+  const crashCandidateFiles = (
+    await listFilesInDirectory(crashReportsDir)
+  ).sort();
+  const crashCutoffMs = Date.now() - 7 * 24 * 60 * 60 * 1000;
+
+  for (const crashFilePath of crashCandidateFiles) {
+    const reportName = basename(crashFilePath);
+    if (!reportName.toLowerCase().includes("exu")) {
+      continue;
+    }
+
+    const crashStat = await stat(crashFilePath).catch(() => null);
+    if (crashStat === null || crashStat.mtimeMs < crashCutoffMs) {
+      continue;
+    }
+
+    const crashFile = await tryReadFile(crashFilePath);
+    if (crashFile === null) {
+      continue;
+    }
+
+    const crashJson = {
+      sourcePath: crashFilePath,
+      fileName: reportName,
+      modifiedAt: crashStat.mtime.toISOString(),
+      sizeBytes: crashStat.size,
+      content: scrubTextBuffer(crashFile.data).toString("utf8"),
+    };
+
+    const archivePath = `diagnostics/crashes/${reportName}.json`;
+    entries.push({
+      name: `${archiveRoot}/${archivePath}`,
+      data: Buffer.from(`${JSON.stringify(crashJson, null, 2)}\n`, "utf8"),
+      modTime: crashStat.mtime,
+    });
+    included.push(archivePath);
+    additionalArtifacts.crashReports.push({
+      sourcePath: crashFilePath,
+      archivePath,
+      sizeBytes: crashStat.size,
+      modifiedAt: crashStat.mtime.toISOString(),
+    });
+  }
+
   // Environment summary (safe metadata only)
   const envSummary = buildEnvironmentSummary(runtimeConfig);
   const now = new Date();
   entries.push({
-    name: "summary/environment-summary.json",
+    name: `${archiveRoot}/summary/environment-summary.json`,
     data: Buffer.from(`${JSON.stringify(envSummary, null, 2)}\n`, "utf8"),
     modTime: now,
   });
   included.push("summary/environment-summary.json");
+
+  const extraArtifactsSummary = {
+    startupHealth: additionalArtifacts.startupHealth,
+    openclawLogs: additionalArtifacts.openclawLogs,
+    sentryFiles: additionalArtifacts.sentryFiles,
+    sentrySkippedNonJson: additionalArtifacts.sentrySkippedNonJson,
+    crashReports: additionalArtifacts.crashReports,
+  };
+  entries.push({
+    name: `${archiveRoot}/summary/additional-artifacts.json`,
+    data: Buffer.from(
+      `${JSON.stringify(extraArtifactsSummary, null, 2)}\n`,
+      "utf8",
+    ),
+    modTime: now,
+  });
+  included.push("summary/additional-artifacts.json");
 
   // Manifest
   const manifest = {
@@ -307,7 +510,7 @@ async function collectArtifacts(
       "Log and JSON string values have had URL-embedded tokens (e.g. #token=, ?token=) scrubbed.",
   };
   entries.push({
-    name: "summary/manifest.json",
+    name: `${archiveRoot}/summary/manifest.json`,
     data: Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`, "utf8"),
     modTime: now,
   });
@@ -324,6 +527,8 @@ function buildEnvironmentSummary(runtimeConfig: DesktopRuntimeConfig): object {
     buildInfo: runtimeConfig.buildInfo,
     platform: process.platform,
     arch: process.arch,
+    hostName: hostname(),
+    osVersion: readMacOsProductVersion(),
     nodeVersion: process.versions.node,
     electronVersion: process.versions.electron,
     isPackaged: app.isPackaged,
@@ -357,6 +562,7 @@ export async function exportDiagnostics({
   source: "diagnostics-page" | "help-menu";
 }): Promise<DiagnosticsExportResult> {
   const defaultFilename = `nexu-diagnostics-${getTimestampSlug()}.zip`;
+  const defaultArchiveRoot = defaultFilename.replace(/\.zip$/i, "");
 
   let filePath: string | undefined;
   try {
@@ -380,9 +586,15 @@ export async function exportDiagnostics({
   }
 
   try {
+    const archiveRoot =
+      filePath
+        .split(/[\\/]/)
+        .pop()
+        ?.replace(/\.zip$/i, "") || defaultArchiveRoot;
     const { entries, warnings } = await collectArtifacts(
       orchestrator,
       runtimeConfig,
+      archiveRoot,
     );
 
     await writeZip(entries, filePath);

--- a/specs/current/diagnostics/diagnostics.en.md
+++ b/specs/current/diagnostics/diagnostics.en.md
@@ -1,0 +1,176 @@
+# Desktop `Export Diagnostics` Execution Guide
+
+Export the diagnostics bundle via the menu `Help -> Export Diagnostics…`.
+
+## Execution Method
+
+### 1) Confirm the desktop app is running
+
+```bash
+pnpm desktop:status
+```
+
+Expect to see tmux session `nexu-desktop` in running state.
+
+If not running, start the desktop app first:
+
+```bash
+pnpm desktop:start
+```
+
+### 2) Trigger the menu and save via AppleScript (Agent Execution Spec)
+
+Goal: Export a zip via `Help -> Export Diagnostics…` to `<nexu-repo-root>/.tmp/diagnostics`.
+
+Do not treat the AppleScript as a "fixed script to run all at once." Instead, execute it as a state machine: **locate process -> focus -> click menu -> wait for save panel -> enter path and save -> verify output**.
+
+#### Root Causes of Failure (must understand first)
+
+- `keystroke` / `key code` are sent to the current foreground window, not bound to process `p`.
+- `set frontmost of p to true` done only once is not enough — focus can be stolen by user actions or system dialogs during execution.
+- The save sheet may appear with jitter; a fixed `delay` may cause premature input, resulting in missed keystrokes or input sent to the wrong window.
+
+#### Agent Execution Principles
+
+1. Re-confirm the target process is frontmost before every critical action (at minimum: before clicking the menu, before sending keystrokes).
+2. Only send `Cmd+Shift+G` and the return key sequence after detecting that `sheet 1 of window 1 of p` exists.
+3. All UI actions should allow limited retries (recommended 2–3 times); failures must be reported explicitly, never silently swallowed.
+4. Do not rely on "command exit code success"; always verify output by checking file timestamps to confirm a new zip was actually produced.
+
+#### Key Code Snippets (for composition — do not hardcode into a single long script)
+
+Get PID:
+
+```bash
+PID=$(ps -ax -o pid,command | rg "Electron apps/desktop$" | awk '{print $1}' | head -n 1)
+```
+
+Focus target process:
+
+```applescript
+tell application "System Events"
+  set p to first process whose unix id is (targetPid as integer)
+  set frontmost of p to true
+end tell
+```
+
+Click menu item:
+
+```applescript
+click menu item "Export Diagnostics…" of menu 1 of menu bar item "Help" of menu bar 1 of p
+```
+
+Wait for save sheet:
+
+```applescript
+repeat 40 times
+  tell application "System Events"
+    if exists sheet 1 of window 1 of p then exit repeat
+  end tell
+  delay 0.1
+end repeat
+```
+
+Enter directory and confirm save:
+
+```applescript
+keystroke "G" using {command down, shift down}
+keystroke "<nexu-repo-root>/.tmp/diagnostics"
+key code 36
+key code 36
+```
+
+## Verification Commands
+
+Immediately confirm the file exists after export — check the file timestamp:
+
+```bash
+ls -lt <nexu-repo-root>/.tmp/diagnostics/nexu-diagnostics-*.zip
+```
+
+Also recommended to check the export bundle size and large file distribution:
+
+```bash
+ZIP=<nexu-repo-root>/.tmp/diagnostics/nexu-diagnostics-<timestamp>.zip
+TMP=<nexu-repo-root>/.tmp/diagnostics-check
+rm -rf "$TMP" && mkdir -p "$TMP"
+unzip -q "$ZIP" -d "$TMP"
+du -ah "$TMP"/nexu-diagnostics-* | sort -hr | head -n 20
+```
+
+## Export Bundle Directory Structure (confirmed)
+
+After extraction, there should be a single top-level directory — files will not be scattered into the current directory:
+
+```text
+nexu-diagnostics-<timestamp>/
+├── diagnostics/
+│   ├── desktop-diagnostics.json
+│   ├── startup-health.json
+│   ├── sentry/
+│   │   └── *.json
+│   └── crashes/
+│       └── *.json
+├── logs/
+│   ├── cold-start.log
+│   ├── desktop-main.log
+│   ├── openclaw/
+│   │   └── openclaw-*.log
+│   └── runtime-units/
+│       ├── controller.log
+│       ├── openclaw.log
+│       └── web.log
+├── config/
+│   └── openclaw.json
+└── summary/
+    ├── environment-summary.json
+    ├── additional-artifacts.json
+    └── manifest.json
+```
+
+Recommended: use the following command to inspect the ZIP internal paths directly (more reliable than Finder):
+
+```bash
+unzip -l <nexu-repo-root>/.tmp/diagnostics/nexu-diagnostics-<timestamp>.zip
+```
+
+## New Information Notes (for troubleshooting completeness)
+
+- `diagnostics/startup-health.json`
+  - Upgrade/rollback health status (failure count, version, last check time).
+- `diagnostics/sentry/**/*.json`
+  - Local Sentry session/queue/context snapshots (JSON recursively collected, with unified redaction).
+- `diagnostics/crashes/*.json`
+  - Crash reports from the last 7 days in `DiagnosticReports` with filenames containing `exu`, converted to JSON (includes a `content` text field).
+- `logs/openclaw/openclaw-*.log`
+  - Native OpenClaw logs from `/tmp/openclaw`, supplementing troubleshooting info beyond runtime-units.
+- `summary/additional-artifacts.json`
+  - Index of newly collected files (source path, archive path, size, modification time) for quickly determining "did we collect everything?"
+
+## Environment Differences (local dev vs packaged build)
+
+- Both runtime modes collect via Electron `userData`-relative paths (avoiding hardcoded legacy paths).
+- Local `pnpm desktop:restart`: `userData` is at `<repo>/.tmp/desktop/electron`.
+- Packaged build: `userData` is at `~/Library/Application Support/@nexu/desktop` (or overridden by `NEXU_DESKTOP_USER_DATA_ROOT`).
+
+## Redaction Check (recommended)
+
+After export, quickly scan for suspected plaintext credentials:
+
+```bash
+rg --pcre2 -n -i "gw-secret-token|xox[baprs]-|bearer\s+[a-z0-9._-]{8,}|token\"\s*:\s*\"(?!\[REDACTED\])|password\"\s*:\s*\"(?!\[REDACTED\])|secret\"\s*:\s*\"(?!\[REDACTED\])|dsn\"\s*:\s*\"(?!\[REDACTED\])" \
+  <unzipped-diagnostics-root>
+```
+
+## Common Issues
+
+1. **Error: `osascript is not allowed assistive access (-1719)`**
+   - Grant accessibility permission to the current terminal app: `System Settings -> Privacy & Security -> Accessibility`.
+
+2. **"Path changed but didn't save"**
+   - This means only the directory navigation completed, but the final Save was not triggered.
+   - Fix: Add one or two extra `return` key presses after the path entry return, and include a short delay in the script.
+
+3. **Switching to another app during execution causes intermittent export failures**
+   - Root cause: `keystroke` is sent to the current foreground window — if focus drifts, keystrokes hit the wrong target.
+   - Fix: Re-set `frontmost` before every critical action, explicitly wait for the `sheet` to appear; after export, use `ls -lt` to forcibly verify whether a new zip was generated.

--- a/specs/current/diagnostics/diagnostics.md
+++ b/specs/current/diagnostics/diagnostics.md
@@ -1,0 +1,176 @@
+# Desktop `Export Diagnostics` 执行经验
+
+通过菜单 `Help -> Export Diagnostics…` 导出诊断包。
+
+## 执行方式
+
+### 1) 先确认桌面端已运行
+
+```bash
+pnpm desktop:status
+```
+
+期望看到 tmux session `nexu-desktop` 处于 running。
+
+如果未运行，请先启动桌面端。
+
+```bash
+pnpm desktop:start
+```
+
+### 2) 用 AppleScript 触发菜单并保存（Agent 执行规范）
+
+目标：通过 `Help -> Export Diagnostics…` 导出 zip 到 `<nexu-repo-root>/.tmp/diagnostics`。
+
+不要把 AppleScript 当成“固定脚本一次跑完”，而是按状态机执行：**定位进程 -> 聚焦 -> 点击菜单 -> 等待保存面板 -> 输入路径并保存 -> 校验产物**。
+
+#### 失败根因（必须先理解）
+
+- `keystroke` / `key code` 是发给当前前台窗口，不是绑定到 `p`。
+- `set frontmost of p to true` 只做一次不够，执行过程中焦点可能被用户操作或系统弹窗抢走。
+- 保存 sheet 出现有抖动，固定 `delay` 可能提前输入，导致按键落空或发错窗口。
+
+#### Agent 执行原则
+
+1. 每个关键动作前都重新确认目标进程前置（至少：点菜单前、发按键前）。
+2. 只在检测到 `sheet 1 of window 1 of p` 存在后再发送 `Cmd+Shift+G` 与回车序列。
+3. 所有 UI 动作允许有限重试（建议 2-3 次），失败要显式报错，不静默吞掉。
+4. 不依赖“命令退出码成功”；必须用文件时间戳校验是否真的产出新 zip。
+
+#### 关键代码片段（用于组合，不要固化成单一长脚本）
+
+获取 PID：
+
+```bash
+PID=$(ps -ax -o pid,command | rg "Electron apps/desktop$" | awk '{print $1}' | head -n 1)
+```
+
+聚焦目标进程：
+
+```applescript
+tell application "System Events"
+  set p to first process whose unix id is (targetPid as integer)
+  set frontmost of p to true
+end tell
+```
+
+点击菜单项：
+
+```applescript
+click menu item "Export Diagnostics…" of menu 1 of menu bar item "Help" of menu bar 1 of p
+```
+
+等待保存 sheet：
+
+```applescript
+repeat 40 times
+  tell application "System Events"
+    if exists sheet 1 of window 1 of p then exit repeat
+  end tell
+  delay 0.1
+end repeat
+```
+
+输入目录并确认保存：
+
+```applescript
+keystroke "G" using {command down, shift down}
+keystroke "<nexu-repo-root>/.tmp/diagnostics"
+key code 36
+key code 36
+```
+
+## 校验命令
+
+导出后立刻确认文件存在，记得确认文件时间戳。
+
+```bash
+ls -lt <nexu-repo-root>/.tmp/diagnostics/nexu-diagnostics-*.zip
+```
+
+建议同时检查导出包体积与大文件分布：
+
+```bash
+ZIP=<nexu-repo-root>/.tmp/diagnostics/nexu-diagnostics-<timestamp>.zip
+TMP=<nexu-repo-root>/.tmp/diagnostics-check
+rm -rf "$TMP" && mkdir -p "$TMP"
+unzip -q "$ZIP" -d "$TMP"
+du -ah "$TMP"/nexu-diagnostics-* | sort -hr | head -n 20
+```
+
+## 导出包目录结构（已确认）
+
+解压后应有单一顶层目录，不会把文件散落到当前目录：
+
+```text
+nexu-diagnostics-<timestamp>/
+├── diagnostics/
+│   ├── desktop-diagnostics.json
+│   ├── startup-health.json
+│   ├── sentry/
+│   │   └── *.json
+│   └── crashes/
+│       └── *.json
+├── logs/
+│   ├── cold-start.log
+│   ├── desktop-main.log
+│   ├── openclaw/
+│   │   └── openclaw-*.log
+│   └── runtime-units/
+│       ├── controller.log
+│       ├── openclaw.log
+│       └── web.log
+├── config/
+│   └── openclaw.json
+└── summary/
+    ├── environment-summary.json
+    ├── additional-artifacts.json
+    └── manifest.json
+```
+
+建议用下面命令直接看 ZIP 内部路径（比依赖 Finder 展示更可靠）：
+
+```bash
+unzip -l <nexu-repo-root>/.tmp/diagnostics/nexu-diagnostics-<timestamp>.zip
+```
+
+## 新增信息说明（用于排障完整性）
+
+- `diagnostics/startup-health.json`
+  - 升级/回滚健康状态（失败计数、版本、最后检查时间）。
+- `diagnostics/sentry/**/*.json`
+  - 本地 Sentry 会话/队列/上下文快照（JSON 递归采集，做统一脱敏）。
+- `diagnostics/crashes/*.json`
+  - 最近 7 天 `DiagnosticReports` 中文件名包含 `exu` 的崩溃报告，转成 JSON（包含 `content` 文本字段）。
+- `logs/openclaw/openclaw-*.log`
+  - `/tmp/openclaw` 下 OpenClaw 原生日志，补足 runtime-units 之外的排障信息。
+- `summary/additional-artifacts.json`
+  - 新增采集文件索引（源路径、归档路径、大小、修改时间），用于快速判断“收齐了没有”。
+
+## 环境差异说明（本地启动 vs 打包版本）
+
+- 两种运行方式统一通过 Electron `userData` 相关路径采集（避免绑定旧路径）。
+- 本地 `pnpm desktop:restart`：`userData` 在 repo 下 `.tmp/desktop/electron`。
+- 打包版本：`userData` 在 `~/Library/Application Support/@nexu/desktop`（或 `NEXU_DESKTOP_USER_DATA_ROOT` 覆盖路径）。
+
+## 脱敏检查（建议）
+
+导出后可快速扫描是否存在疑似明文凭据：
+
+```bash
+rg --pcre2 -n -i "gw-secret-token|xox[baprs]-|bearer\s+[a-z0-9._-]{8,}|token\"\s*:\s*\"(?!\[REDACTED\])|password\"\s*:\s*\"(?!\[REDACTED\])|secret\"\s*:\s*\"(?!\[REDACTED\])|dsn\"\s*:\s*\"(?!\[REDACTED\])" \
+  <unzipped-diagnostics-root>
+```
+
+## 常见问题
+
+1. 报错 `osascript 不允许辅助访问 (-1719)`
+   - 给当前终端应用开启：`系统设置 -> 隐私与安全性 -> 辅助功能`。
+
+2. “路径改了，但没保存”
+   - 说明只完成了目录跳转，没触发最终 Save。
+   - 解决：在路径回车后再补一次或两次 `return`，并在脚本中留短延时。
+
+3. 执行时切到其他软件，导出偶发失败
+   - 根因：`keystroke` 发送到当前前台窗口，焦点漂移后会打到错误目标。
+   - 解决：每个关键动作前重新 `frontmost`，并显式等待 `sheet` 出现；导出后用 `ls -lt` 强制校验新 zip 是否生成。

--- a/specs/current/environment.md
+++ b/specs/current/environment.md
@@ -1,0 +1,43 @@
+# Environment Startup Guide
+
+This repo currently uses two desktop local environments with different startup flows.
+
+## 1) local-dev (controller-first development runtime)
+
+Use this when iterating quickly in development.
+
+- Restart/start command (from repo root):
+
+```bash
+pnpm desktop:restart
+```
+
+- Equivalent flow:
+  - `pnpm desktop:start` -> `./apps/desktop/dev.sh start`
+  - `pnpm desktop:restart` -> `./apps/desktop/dev.sh restart`
+
+- Characteristics:
+  - Uses tmux session `nexu-desktop`.
+  - Rebuilds runtime artifacts and launches the desktop dev stack.
+  - Intended for active coding/debugging.
+
+## 2) local-dist (packaged app verification runtime)
+
+Use this when verifying behavior in a packaged desktop app.
+
+- Build unsigned local package (from repo root):
+
+```bash
+pnpm desktop:dist:mac:unsigned
+```
+
+- Launch packaged app after build:
+
+```bash
+open "apps/desktop/release/mac-arm64/Nexu.app"
+```
+
+- Characteristics:
+  - Generates artifacts under `apps/desktop/release` by default (`.app`, `.dmg`, `.zip`).
+  - Does not use `dev.sh`/tmux lifecycle.
+  - Intended for local packaged-app checks (closer to release behavior).


### PR DESCRIPTION
## Summary

This PR enriches the desktop diagnostics export with more context (logs, crash reports, metadata) and documents the export workflow plus environment setup.

## Changes

- gather startup health, OpenClaw runtime logs, Sentry data, recent crash reports, and manifest metadata inside the diagnostics bundle while tracking archive roots and host/os info
- update the export pipeline to compute archive roots dynamically and include additional-artifacts.json
- add docs describing how to run the diagnostics export and environment startup details