### PR TITLE
chore: update Discord invite link & remove download shortcut from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,9 @@
 
 <p align="center">
   <a href="https://nexu.io" target="_blank" rel="noopener"><strong>🌐 Website</strong></a> &nbsp;·&nbsp;
-  <a href="https://github.com/nexu-io/nexu/releases/latest" target="_blank" rel="noopener"><strong>⬇️ Download</strong></a> &nbsp;·&nbsp;
   <a href="https://docs.nexu.io" target="_blank" rel="noopener"><strong>📖 Docs</strong></a> &nbsp;·&nbsp;
   <a href="https://applink.feishu.cn/client/chat/chatter/add_by_link?link_token=8b7k7b5b-ac27-4748-9165-78606dc16913" target="_blank" rel="noopener"><strong>💬 Feishu</strong></a> &nbsp;·&nbsp;
-  <a href="https://discord.gg/nexu" target="_blank" rel="noopener"><strong>🎮 Discord</strong></a> &nbsp;·&nbsp;
+  <a href="https://discord.gg/Q6AxCUuMNU" target="_blank" rel="noopener"><strong>🎮 Discord</strong></a> &nbsp;·&nbsp;
   <a href="https://x.com/Nexu06" target="_blank" rel="noopener"><strong>𝕏 Twitter</strong></a>
 </p>
 
@@ -205,7 +204,7 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 | Feishu Group | Discord |
 |:---:|:---:|
 | <img src="site/media/feishu-qr.png" width="200" /> | <img src="site/media/discord-qr.png" width="200" /> |
-| [Join Feishu Group](https://applink.feishu.cn/client/chat/chatter/add_by_link?link_token=8b7k7b5b-ac27-4748-9165-78606dc16913) | [Join Discord](https://discord.gg/nexu) |
+| [Join Feishu Group](https://applink.feishu.cn/client/chat/chatter/add_by_link?link_token=8b7k7b5b-ac27-4748-9165-78606dc16913) | [Join Discord](https://discord.gg/Q6AxCUuMNU) |
 
 - [GitHub Discussions](https://github.com/nexu-io/nexu/discussions)
 - [GitHub Issues](https://github.com/nexu-io/nexu/issues)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -15,10 +15,9 @@
 
 <p align="center">
   <a href="https://nexu.io" target="_blank" rel="noopener"><strong>🌐 官网</strong></a> &nbsp;·&nbsp;
-  <a href="https://github.com/nexu-io/nexu/releases/latest" target="_blank" rel="noopener"><strong>⬇️ 下载</strong></a> &nbsp;·&nbsp;
   <a href="https://docs.nexu.io" target="_blank" rel="noopener"><strong>📖 文档</strong></a> &nbsp;·&nbsp;
   <a href="https://applink.feishu.cn/client/chat/chatter/add_by_link?link_token=8b7k7b5b-ac27-4748-9165-78606dc16913" target="_blank" rel="noopener"><strong>💬 飞书</strong></a> &nbsp;·&nbsp;
-  <a href="https://discord.gg/nexu" target="_blank" rel="noopener"><strong>🎮 Discord</strong></a> &nbsp;·&nbsp;
+  <a href="https://discord.gg/Q6AxCUuMNU" target="_blank" rel="noopener"><strong>🎮 Discord</strong></a> &nbsp;·&nbsp;
   <a href="https://x.com/Nexu06" target="_blank" rel="noopener"><strong>𝕏 Twitter</strong></a>
 </p>
 
@@ -205,7 +204,7 @@ pnpm test
 | 飞书群 | Discord |
 |:---:|:---:|
 | <img src="site/media/feishu-qr.png" width="200" /> | <img src="site/media/discord-qr.png" width="200" /> |
-| [加入飞书群](https://applink.feishu.cn/client/chat/chatter/add_by_link?link_token=8b7k7b5b-ac27-4748-9165-78606dc16913) | [加入 Discord](https://discord.gg/nexu) |
+| [加入飞书群](https://applink.feishu.cn/client/chat/chatter/add_by_link?link_token=8b7k7b5b-ac27-4748-9165-78606dc16913) | [加入 Discord](https://discord.gg/Q6AxCUuMNU) |
 
 - [GitHub Discussions](https://github.com/nexu-io/nexu/discussions)
 - [GitHub Issues](https://github.com/nexu-io/nexu/issues)

--- a/apps/web/src/pages/invite.tsx
+++ b/apps/web/src/pages/invite.tsx
@@ -238,7 +238,7 @@ export function InvitePage() {
                 {/* Discord */}
                 <div className="mt-10 pt-8 border-t border-border">
                   <a
-                    href="https://discord.gg/nexu"
+                    href="https://discord.gg/Q6AxCUuMNU"
                     target="_blank"
                     rel="noopener noreferrer"
                     className="flex items-center gap-4 p-4 rounded-xl border border-border bg-surface-1 hover:border-border-hover transition-all group"

--- a/docs/en/guide/contact.md
+++ b/docs/en/guide/contact.md
@@ -12,7 +12,7 @@ We'd love to hear from you! Reach out through any of the following channels.
 
 Join our Discord server to chat with the team and other users:
 
-👉 [Join nexu Discord](https://discord.gg/Ynv8dFMRRN)
+👉 [Join nexu Discord](https://discord.gg/Q6AxCUuMNU)
 
 ### X (Twitter)
 

--- a/docs/zh/guide/contact.md
+++ b/docs/zh/guide/contact.md
@@ -12,7 +12,7 @@
 
 加入我们的 Discord 服务器，与团队和其他用户交流：
 
-👉 [加入 nexu Discord](https://discord.gg/Ynv8dFMRRN)
+👉 [加入 nexu Discord](https://discord.gg/Q6AxCUuMNU)
 
 ### X (Twitter)
 


### PR DESCRIPTION
## Summary

- Update Discord invite link to `https://discord.gg/Q6AxCUuMNU` across all files
- Remove ⬇️ Download shortcut from README header navigation (both EN and ZH)

### Files changed

- `README.md` / `README.zh-CN.md` — header nav + community section
- `docs/en/guide/contact.md` / `docs/zh/guide/contact.md` — docs contact page
- `apps/web/src/pages/invite.tsx` — web invite page

## Test plan

- [ ] Verify new Discord link works: https://discord.gg/Q6AxCUuMNU
- [ ] Confirm README header no longer shows Download link
- [ ] Check docs site contact page renders updated link

Made with [Cursor](https://cursor.com)