### PR TITLE
docs: add beta free-usage banner and clean up README description

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,13 @@
 
 ---
 
+> 🎉 **Beta Perk**: During the beta period, top-tier models like Claude Opus 4.6, GPT 5.4, and more are **completely free with unlimited usage**. [Download and try now →](https://nexu.io)
+
+---
+
 ## 📋 Overview
 
-**nexu** (next to you) is an open-source desktop client (Electron) that connects **OpenClaw 🦞** agents to Feishu, Slack, Discord, and other IM channels.
+**nexu** (next to you) is an open-source desktop client that connects **OpenClaw 🦞** agents to Feishu, Slack, Discord, and other IM channels.
 
 It offers graphical setup, built-in Feishu Skills, multi-model support, and BYOK.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -27,9 +27,13 @@
 
 ---
 
+> 🎉 **内测福利**：内测期间，Claude Opus 4.6、GPT 5.4 等顶级模型 **全部免费、无限量使用**。[立即下载体验 →](https://nexu.io)
+
+---
+
 ## 📋 概述
 
-**nexu**（next to you）是将 **OpenClaw 🦞** Agent 接入飞书、Slack、Discord 等 IM 的开源桌面客户端（Electron）。
+**nexu**（next to you）是将 **OpenClaw 🦞** Agent 接入飞书、Slack、Discord 等 IM 的开源桌面客户端。
 
 提供图形化配置、内置飞书 Skills、多模型支持与 BYOK。
 


### PR DESCRIPTION
## Summary

- Add a prominent blockquote banner above the Overview section in both READMEs, highlighting that Claude Opus 4.6, GPT 5.4, and other top-tier models are **free and unlimited** during the beta period
- Remove "(Electron)" from the project description for cleaner, less technical messaging

## Test plan

- [ ] Verify banner renders correctly on GitHub (both EN and ZH READMEs)
- [ ] Confirm the download link in the banner points to nexu.io

Made with [Cursor](https://cursor.com)