### PR TITLE
fix: restore desktop drag bar and page top spacing

### DIFF
--- a/apps/desktop/src/runtime-page.css
+++ b/apps/desktop/src/runtime-page.css
@@ -193,9 +193,9 @@ body,
 .window-drag-bar {
   position: fixed;
   top: 0;
-  left: 112px; /* Leave space for traffic lights + sidebar toggle */
-  width: 240px;
-  height: 30px;
+  left: 100px; /* Leave space for traffic lights + sidebar toggle */
+  right: 0;
+  height: 38px;
   z-index: 9999;
   -webkit-app-region: drag;
 }

--- a/apps/web/src/pages/home.tsx
+++ b/apps/web/src/pages/home.tsx
@@ -185,6 +185,12 @@ function getChannelStatusMeta(
 export function HomePage() {
   const { t } = useTranslation();
   const { stars } = useGitHubStars();
+  const isDesktopClient = useMemo(
+    () =>
+      typeof navigator !== "undefined" &&
+      navigator.userAgent.includes("Electron"),
+    [],
+  );
   const [modalChannel, setModalChannel] = useState<
     "feishu" | "slack" | "discord" | null
   >(null);
@@ -592,7 +598,10 @@ export function HomePage() {
      ══════════════════════════════════════════════════════════════════════ */
   return (
     <div className="h-full overflow-y-auto">
-      <div className="max-w-4xl mx-auto px-4 sm:px-6 py-6 sm:py-8 space-y-6">
+      <div
+        className="max-w-4xl mx-auto px-4 sm:px-6 pb-6 sm:pb-8 space-y-6"
+        style={{ paddingTop: isDesktopClient ? "2rem" : "1.5rem" }}
+      >
         {/* ═══ TOP: Hero — Bot running (horizontal layout) ═══ */}
         <div className="flex items-center gap-4">
           <div

--- a/apps/web/src/pages/models.tsx
+++ b/apps/web/src/pages/models.tsx
@@ -769,6 +769,12 @@ function _CurrentModelSelector({
 export function ModelsPage() {
   const { t } = useTranslation();
   const { stars } = useGitHubStars();
+  const isDesktopClient = useMemo(
+    () =>
+      typeof navigator !== "undefined" &&
+      navigator.userAgent.includes("Electron"),
+    [],
+  );
   const [searchParams, setSearchParams] = useSearchParams();
   const isSetupMode = searchParams.get("setup") === "1";
   const tabParam = searchParams.get("tab");
@@ -951,7 +957,10 @@ export function ModelsPage() {
 
   return (
     <div className="h-full overflow-y-auto">
-      <div className="max-w-4xl mx-auto px-4 sm:px-6 pt-2 pb-6 sm:pb-8">
+      <div
+        className="max-w-4xl mx-auto px-4 sm:px-6 pb-6 sm:pb-8"
+        style={{ paddingTop: isDesktopClient ? "2rem" : "0.5rem" }}
+      >
         <div className="flex items-center justify-between mb-6">
           <div>
             <h2 className="heading-page">{t("models.pageTitle")}</h2>

--- a/apps/web/src/pages/skills.tsx
+++ b/apps/web/src/pages/skills.tsx
@@ -171,6 +171,12 @@ function SkillCard({
 export function SkillsPage() {
   const { t } = useTranslation();
   const { stars } = useGitHubStars();
+  const isDesktopClient = useMemo(
+    () =>
+      typeof navigator !== "undefined" &&
+      navigator.userAgent.includes("Electron"),
+    [],
+  );
   const { locale } = useLocale();
   const { data, isLoading, isError } = useCommunitySkills();
   const refreshMutation = useRefreshCatalog();
@@ -380,7 +386,10 @@ export function SkillsPage() {
 
   return (
     <div className="h-full overflow-y-auto">
-      <div className="max-w-4xl mx-auto px-4 sm:px-6 pt-2 pb-6 sm:pb-8">
+      <div
+        className="max-w-4xl mx-auto px-4 sm:px-6 pb-6 sm:pb-8"
+        style={{ paddingTop: isDesktopClient ? "2rem" : "0.5rem" }}
+      >
         {/* Header */}
         <div className="flex items-center justify-between mb-10">
           <div>


### PR DESCRIPTION
## Summary
- restore the desktop window drag region to the previous full-width top bar
- add desktop-only top spacing to home, skills, and settings so their headers align better with the left sidebar

## Testing
- pnpm typecheck
- pnpm lint