### PR TITLE
fix: avoid secrets context parse error in desktop reusable workflow

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -347,7 +347,7 @@ jobs:
           npx wrangler r2 object put "nexu-desktop-releases/${r2_prefix}/desktop-sha256.txt" --file "apps/desktop/channel-artifacts/desktop-sha256.txt" --remote
 
       - name: Purge Cloudflare CDN cache for latest artifacts
-        if: inputs.update_feed_url != '' && secrets.CLOUDFLARE_ZONE_ID != ''
+        if: inputs.update_feed_url != '' && env.CLOUDFLARE_ZONE_ID != ''
         env:
           CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary
- switch the reusable desktop purge step to gate on an env-backed Cloudflare zone id
- avoid workflow-call parse failures caused by referencing secrets directly in the step if expression
- keep the CDN purge optional when the zone id secret is not configured
