### PR TITLE
chore: prepare desktop 0.1.4-beta.1 release

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexu/desktop",
-  "version": "0.1.3",
+  "version": "0.1.4-beta.1",
   "private": true,
   "type": "module",
   "main": "dist-electron/main/bootstrap.js",


### PR DESCRIPTION
## Summary
- bump the desktop package version to `0.1.4-beta.1`
- prepare the beta release tag path so `desktop-release` publishes to the beta channel