### PR TITLE
chore: rename desktop release artifacts

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -207,11 +207,11 @@ jobs:
             exit 1
           fi
 
-          # New naming: nexu-simplest-openclaw-desktop-{version}-{channel}-{arch}.{ext}
-          versioned_dmg="nexu-simplest-openclaw-desktop-${VERSION}-${CHANNEL}-arm64.dmg"
-          versioned_zip="nexu-simplest-openclaw-desktop-${VERSION}-${CHANNEL}-arm64.zip"
-          latest_dmg="nexu-simplest-openclaw-desktop-latest-${CHANNEL}-arm64.dmg"
-          latest_zip="nexu-simplest-openclaw-desktop-latest-${CHANNEL}-arm64.zip"
+          # New naming: nexu-{version}-{channel}-{arch}.{ext}
+          versioned_dmg="nexu-${VERSION}-${CHANNEL}-arm64.dmg"
+          versioned_zip="nexu-${VERSION}-${CHANNEL}-arm64.zip"
+          latest_dmg="nexu-latest-${CHANNEL}-arm64.dmg"
+          latest_zip="nexu-latest-${CHANNEL}-arm64.zip"
 
           cp "${dmg_files[0]}" "apps/desktop/channel-artifacts/${versioned_dmg}"
           cp "${zip_files[0]}" "apps/desktop/channel-artifacts/${versioned_zip}"
@@ -285,10 +285,10 @@ jobs:
           fi
 
           # electron-builder generates filenames without channel, we need to patch them
-          # Original: nexu-simplest-openclaw-desktop-0.1.3-arm64.dmg
-          # Target:   nexu-simplest-openclaw-desktop-0.1.3-nightly-arm64.dmg
-          original_dmg="nexu-simplest-openclaw-desktop-${VERSION}-arm64.dmg"
-          original_zip="nexu-simplest-openclaw-desktop-${VERSION}-arm64.zip"
+          # Original: nexu-0.1.3-arm64.dmg
+          # Target:   nexu-0.1.3-nightly-arm64.dmg
+          original_dmg="nexu-${VERSION}-arm64.dmg"
+          original_zip="nexu-${VERSION}-arm64.zip"
 
           echo "Patching latest-mac.yml:"
           echo "  ${original_dmg} → ${VERSIONED_DMG}"

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -180,11 +180,11 @@ jobs:
             exit 1
           fi
 
-          # New naming: nexu-simplest-openclaw-desktop-{version}-{channel}-{arch}.{ext}
-          versioned_dmg="nexu-simplest-openclaw-desktop-${VERSION}-${channel}-arm64.dmg"
-          versioned_zip="nexu-simplest-openclaw-desktop-${VERSION}-${channel}-arm64.zip"
-          latest_dmg="nexu-simplest-openclaw-desktop-latest-${channel}-arm64.dmg"
-          latest_zip="nexu-simplest-openclaw-desktop-latest-${channel}-arm64.zip"
+          # New naming: nexu-{version}-{channel}-{arch}.{ext}
+          versioned_dmg="nexu-${VERSION}-${channel}-arm64.dmg"
+          versioned_zip="nexu-${VERSION}-${channel}-arm64.zip"
+          latest_dmg="nexu-latest-${channel}-arm64.dmg"
+          latest_zip="nexu-latest-${channel}-arm64.zip"
 
           cp "${dmg_files[0]}" "apps/desktop/release-artifacts/${versioned_dmg}"
           cp "${zip_files[0]}" "apps/desktop/release-artifacts/${versioned_zip}"
@@ -251,8 +251,8 @@ jobs:
           fi
 
           # electron-builder generates filenames without channel, we need to patch them
-          original_dmg="nexu-simplest-openclaw-desktop-${VERSION}-arm64.dmg"
-          original_zip="nexu-simplest-openclaw-desktop-${VERSION}-arm64.zip"
+          original_dmg="nexu-${VERSION}-arm64.dmg"
+          original_zip="nexu-${VERSION}-arm64.zip"
 
           echo "Patching latest-mac.yml:"
           echo "  ${original_dmg} → ${VERSIONED_DMG}"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -109,7 +109,7 @@
       "icon": "build/icon.icns",
       "category": "public.app-category.developer-tools",
       "target": ["dmg", "zip"],
-      "artifactName": "nexu-simplest-openclaw-desktop-${version}-${arch}.${ext}",
+      "artifactName": "nexu-${version}-${arch}.${ext}",
       "hardenedRuntime": true,
       "gatekeeperAssess": false,
       "entitlements": "build/entitlements.mac.plist",


### PR DESCRIPTION
## Summary
- rename desktop build outputs from `nexu-simplest-openclaw-desktop-*` to `nexu-*`
- update stable, beta, and nightly workflow packaging logic to upload and patch manifests with the new filenames
- keep the generated `latest-mac.yml` references aligned with the new artifact names