### PR TITLE
chore(actions): quote desktop release PR body heredoc

### DIFF
--- a/.github/workflows/desktop-prepare-release.yml
+++ b/.github/workflows/desktop-prepare-release.yml
@@ -77,7 +77,7 @@ jobs:
           set -euo pipefail
 
           body_path="$RUNNER_TEMP/desktop-release-pr.md"
-          cat > "$body_path" <<EOF
+          cat > "$body_path" <<'EOF'
           ## Summary
           - bump \\`apps/desktop/package.json\\` to \\`${{ steps.version.outputs.desktop_version }}\\`
           - prepare the desktop release branch for tag \\`${{ steps.version.outputs.tag_name }}\\`


### PR DESCRIPTION
## Summary
- quote the release PR body heredoc so markdown backticks are not executed by bash
- prevent the desktop prepare release workflow from failing before `gh pr create` runs