### PR TITLE
fix(controller): seed config writer cache from disk on cold start

### DIFF
--- a/apps/controller/src/runtime/openclaw-config-writer.ts
+++ b/apps/controller/src/runtime/openclaw-config-writer.ts
@@ -1,4 +1,4 @@
-import { mkdir, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { OpenClawConfig } from "@nexu/shared";
 import type { ControllerEnv } from "../app/env.js";
@@ -13,6 +13,20 @@ export class OpenClawConfigWriter {
   async write(config: OpenClawConfig): Promise<void> {
     await mkdir(path.dirname(this.env.openclawConfigPath), { recursive: true });
     const content = `${JSON.stringify(config, null, 2)}\n`;
+
+    // On cold start, seed the cache from the existing file on disk so the
+    // first write() after a process restart doesn't trigger an unnecessary
+    // OpenClaw reload when the config hasn't actually changed.
+    if (this.lastWrittenContent === null) {
+      try {
+        this.lastWrittenContent = await readFile(
+          this.env.openclawConfigPath,
+          "utf8",
+        );
+      } catch {
+        // File doesn't exist yet — leave cache empty.
+      }
+    }
 
     // Skip writing if the content hasn't changed since the last write.
     // This prevents OpenClaw's file watcher from triggering unnecessary

--- a/apps/controller/tests/openclaw-config-writer.test.ts
+++ b/apps/controller/tests/openclaw-config-writer.test.ts
@@ -109,7 +109,7 @@ describe("OpenClawConfigWriter", () => {
     expect(finalStat.mtimeMs).toBe(firstStat.mtimeMs);
   });
 
-  it("separate writer instances do not share state", async () => {
+  it("new writer instance seeds cache from existing file on cold start", async () => {
     const config = makeConfig();
 
     const writer1 = new OpenClawConfigWriter(env);
@@ -118,11 +118,38 @@ describe("OpenClawConfigWriter", () => {
 
     await new Promise((r) => setTimeout(r, 50));
 
-    // A new writer instance has no memory of previous writes
+    // A new writer instance reads the existing file to seed its cache,
+    // so it skips the write when content matches (cold-start optimization).
     const writer2 = new OpenClawConfigWriter(env);
     await writer2.write(config);
     const secondStat = await stat(env.openclawConfigPath);
 
-    expect(secondStat.mtimeMs).not.toBe(firstStat.mtimeMs);
+    expect(secondStat.mtimeMs).toBe(firstStat.mtimeMs);
+  });
+
+  it("new writer instance writes when content differs from existing file", async () => {
+    const configA = makeConfig({ commands: { native: "auto" } });
+    const configB = makeConfig({ commands: { native: "off" } });
+
+    const writer1 = new OpenClawConfigWriter(env);
+    await writer1.write(configA);
+
+    // A new writer reads the existing file, sees different content, and writes.
+    const writer2 = new OpenClawConfigWriter(env);
+    await writer2.write(configB);
+    const written = await readFile(env.openclawConfigPath, "utf8");
+
+    expect(JSON.parse(written)).toEqual(configB);
+  });
+
+  it("cold start with no existing file writes normally", async () => {
+    // No file exists yet — writer should write without error.
+    const writer = new OpenClawConfigWriter(env);
+    const config = makeConfig();
+
+    await writer.write(config);
+
+    const written = await readFile(env.openclawConfigPath, "utf8");
+    expect(JSON.parse(written)).toEqual(config);
   });
 });


### PR DESCRIPTION
## Summary

- Follows up on #347 — on process restart, `lastWrittenContent` is `null`, so the first `write()` always writes to disk even if the file already has identical content
- Fix: read the existing config file to seed the in-memory cache on the first `write()` call
- This eliminates the unnecessary OpenClaw reload that happened on every controller cold start

## Test plan

- [x] New test: new writer instance seeds cache from existing file (skips write)
- [x] New test: new writer instance writes when content differs from existing file
- [x] New test: cold start with no existing file writes normally
- [x] Existing tests still pass (8/8)
- [ ] Manual: restart controller and verify no unnecessary OpenClaw reload in logs (`openclaw_config_write_skipped_unchanged` should appear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)