### PR TITLE
chore: add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,94 @@
+name: Bug Report
+description: Report a bug or unexpected behavior.
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill out the sections below so we can reproduce and fix it.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug description
+      description: A clear and concise description of what the bug is.
+      placeholder: Describe the bug...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to reproduce the behavior.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened. Include error messages, logs, or screenshots if applicable.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Which part of Nexu is affected?
+      multiple: true
+      options:
+        - Desktop app (Electron shell)
+        - Controller (backend / API)
+        - Web dashboard (React UI)
+        - OpenClaw runtime
+        - Skills
+        - Shared schemas / packages
+        - Build / CI / Tooling
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Nexu version
+      description: "App version or commit SHA (find it in the desktop app's About dialog or run `git rev-parse --short HEAD`)."
+      placeholder: "e.g. 0.4.2 or abc1234"
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: "OS, Node.js version, and any other relevant environment details."
+      placeholder: |
+        - OS: macOS 15.3
+        - Node.js: 22.x
+        - pnpm: 9.x
+      render: markdown
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: "Paste any relevant log output. **Redact credentials and tokens.**"
+      render: shell
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Anything else that might help — screenshots, config snippets, related issues, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Discussions
+    url: https://github.com/nexu-io/nexu/discussions
+    about: Ask questions and discuss ideas here instead of opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,55 @@
+name: Feature Request
+description: Suggest a new feature or capability.
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea to improve Nexu? Describe it below.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: What problem does this feature solve? Why is it needed?
+      placeholder: "I'm always frustrated when..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the feature or behavior you'd like.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative solutions or workarounds you've considered.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Which part of Nexu does this relate to?
+      multiple: true
+      options:
+        - Desktop app (Electron shell)
+        - Controller (backend / API)
+        - Web dashboard (React UI)
+        - OpenClaw runtime
+        - Skills
+        - Shared schemas / packages
+        - Build / CI / Tooling
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Mockups, screenshots, links to related issues, or anything else.

--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -1,0 +1,63 @@
+name: Improvement
+description: Suggest an improvement to existing functionality (refactoring, performance, DX, etc.).
+labels: ["improvement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Suggest an improvement to something that already exists in Nexu.
+
+  - type: textarea
+    id: current
+    attributes:
+      label: Current behavior
+      description: Describe the current behavior or state of things.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed
+    attributes:
+      label: Proposed improvement
+      description: What should change and why?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      options:
+        - Performance
+        - Developer experience
+        - Code quality / Refactoring
+        - Documentation
+        - Testing
+        - Observability / Logging
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Which part of Nexu does this relate to?
+      multiple: true
+      options:
+        - Desktop app (Electron shell)
+        - Controller (backend / API)
+        - Web dashboard (React UI)
+        - OpenClaw runtime
+        - Skills
+        - Shared schemas / packages
+        - Build / CI / Tooling
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Benchmarks, code pointers, related issues, or anything else.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,40 @@
+## What
+
+<!-- One-liner: what does this PR do? -->
+
+## Why
+
+<!-- Motivation: what problem does it solve or what feature does it enable? Link related issues with "Closes #123". -->
+
+## How
+
+<!-- Implementation approach: key design decisions, trade-offs, or anything reviewers should know. -->
+
+## Affected areas
+
+<!-- Check all that apply -->
+
+- [ ] Desktop app (Electron shell)
+- [ ] Controller (backend / API)
+- [ ] Web dashboard (React UI)
+- [ ] OpenClaw runtime
+- [ ] Skills
+- [ ] Shared schemas / packages
+- [ ] Build / CI / Tooling
+
+## Checklist
+
+- [ ] `pnpm typecheck` passes
+- [ ] `pnpm lint` passes
+- [ ] `pnpm test` passes
+- [ ] `pnpm generate-types` run (if API routes/schemas changed)
+- [ ] No credentials or tokens in code or logs
+- [ ] No `any` types introduced (use `unknown` with narrowing)
+
+## Screenshots / recordings
+
+<!-- If applicable, add screenshots or recordings to help explain the change. Delete this section if not needed. -->
+
+## Notes for reviewers
+
+<!-- Anything specific reviewers should focus on, test manually, or be aware of. Delete this section if not needed. -->


### PR DESCRIPTION
## What

Add structured GitHub issue templates and a PR template to standardize contributions.

## Why

The repo had no issue or PR templates, making it easy for reports to miss key info (reproduction steps, environment, affected area) and for PRs to skip required checks. This brings the GitHub workflow in line with the repo's existing conventions in AGENTS.md.

## How

- **3 YAML-based issue form templates** (bug report, feature request, improvement) with required fields, dropdowns for affected area, and auto-applied `triage` label
- **`config.yml`** disables blank issues and links to Discussions for questions
- **PR template** with What/Why/How sections, affected area checklist, and a CI checklist mirroring the repo's hard rules (`typecheck`, `lint`, `test`, `generate-types`, no `any`, no credentials)

## Affected areas

- [x] Build / CI / Tooling

## Checklist

- [x] `pnpm typecheck` passes (no code changes)
- [x] `pnpm lint` passes (no code changes)
- [x] `pnpm test` passes (no code changes)
- [ ] ~~`pnpm generate-types` run~~ (not applicable)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced