### PR TITLE
docs: launchd process architecture design for Desktop

### DIFF
--- a/specs/designs/launchd-process-architecture/en.md
+++ b/specs/designs/launchd-process-architecture/en.md
@@ -94,6 +94,8 @@ When supervisor is detected, OpenClaw will:
 | **Controller** | `com.nexu.controller` | API Server, config management, state storage | Yes (auto-restart on crash) |
 | **OpenClaw** | `com.nexu.openclaw` | Bot Runtime, channel connections | Yes (auto-restart on crash) |
 
+> **Isolation from Native OpenClaw**: Nexu Desktop uses the `com.nexu.*` namespace for launchd labels, completely independent from OpenClaw's native `openclaw install` which uses `io.openclaw.*`. State directories are also separate (`~/.nexu/` vs `~/.openclaw/`). Users can run Nexu Desktop and a standalone OpenClaw instance simultaneously without conflicts.
+
 ### 2.3 Key Design Decisions
 
 #### Decision 1: Controller and OpenClaw as Independent LaunchAgents

--- a/specs/designs/launchd-process-architecture/zh.md
+++ b/specs/designs/launchd-process-architecture/zh.md
@@ -94,6 +94,8 @@ const SYSTEMD_SUPERVISOR_HINT_ENV_VARS = [
 | **Controller** | `com.nexu.controller` | API Server, 配置管理, 状态存储 | Yes (崩溃自动重启) |
 | **OpenClaw** | `com.nexu.openclaw` | Bot Runtime, Channel 连接 | Yes (崩溃自动重启) |
 
+> **与原生 OpenClaw 隔离**: Nexu Desktop 使用 `com.nexu.*` 命名空间作为 launchd label，与 OpenClaw 原生 `openclaw install` 使用的 `io.openclaw.*` 完全独立。状态目录也分离（`~/.nexu/` vs `~/.openclaw/`）。用户可以同时运行 Nexu Desktop 和独立的 OpenClaw 实例，互不冲突。
+
 ### 2.3 关键设计决策
 
 #### 决策 1: Controller 和 OpenClaw 作为独立 LaunchAgent


### PR DESCRIPTION
## Summary

Design document for migrating Nexu Desktop to launchd-based process management on macOS.

### Key architectural decisions

- **Controller and OpenClaw as independent LaunchAgents**: System-level process management, crash recovery without Electron involvement
- **Desktop as GUI shell + service orchestrator**: No longer parent process, manages services via `launchctl`
- **Web UI embedded in Electron main process**: HTTP server runs in main process, eliminates Web Sidecar
- **Unified logging**: All logs in `NEXU_LOG_DIR` (production: `~/Library/Logs/Nexu/`, dev: `.tmp/logs/`)
- **Development and production unified**: Both environments use launchd, no separate code paths

### Benefits

- Solves "double restart" issue with OpenClaw
- Eliminates orphan process problems
- Desktop crash doesn't kill services
- Supports background service mode (close GUI, keep bots running)
- Reduces process count (removes Web Sidecar)

### Implementation checklist included

See `specs/designs/launchd-process-architecture.md` for full details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added English and Chinese design docs describing a new macOS process architecture: separate GUI, controller, and runtime agents; launchd-managed lifecycle with restart coordination; unified logging conventions; sample plist/service configurations; embedded HTTP server behavior (static assets, SPA fallback, API proxying); bootstrap/startup and shutdown flows; developer scripts, checklist, risks, and common launchctl workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->