### PR TITLE
fix(controller): use valid WebSocket close codes

### DIFF
--- a/apps/controller/src/runtime/openclaw-ws-client.ts
+++ b/apps/controller/src/runtime/openclaw-ws-client.ts
@@ -342,7 +342,7 @@ export class OpenClawWsClient {
       const nonce = payload?.nonce;
       if (!nonce) {
         logger.error({}, "openclaw_ws_missing_nonce");
-        this.ws?.close(1008, "missing nonce");
+        this.ws?.close(4008, "missing nonce");
         return;
       }
       this.sendConnectRequest(nonce);
@@ -459,7 +459,7 @@ export class OpenClawWsClient {
     const timer = setTimeout(() => {
       this.pending.delete(id);
       logger.error({}, "openclaw_ws_connect_timeout");
-      this.ws?.close(1008, "connect timeout");
+      this.ws?.close(4008, "connect timeout");
     }, 10_000);
 
     this.pending.set(id, {
@@ -490,7 +490,7 @@ export class OpenClawWsClient {
       },
       reject: (err) => {
         logger.error({ error: err.message }, "openclaw_ws_connect_failed");
-        this.ws?.close(1008, "connect failed");
+        this.ws?.close(4008, "connect failed");
       },
       timer,
     });


### PR DESCRIPTION
## Summary
- Replace reserved WebSocket close code 1008 with private code 4008
- Fix crash when controller encounters OpenClaw authentication errors

## Problem
When the controller fails to authenticate with the OpenClaw gateway (e.g., "device signature invalid"), it attempts to close the WebSocket with code 1008 (Policy Violation). However, code 1008 is reserved for server use only. Node.js 22's native WebSocket implementation throws `DOMException [InvalidAccessError]: invalid code` when a client attempts to use it, causing the entire controller process to crash and enter a restart loop.

## Solution
Use close code 4008 instead, which is in the valid private-use range (4000-4999) per RFC 6455.

## Test plan
- [ ] Build and package desktop app
- [ ] Verify controller no longer crashes when OpenClaw returns authentication errors
- [ ] Verify normal WebSocket connection/disconnection still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket connection error handling for failed connection scenarios, including missing credentials and timeout conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->