### PR TITLE
feat(ci): add Feishu notification workflow for new GitHub issues

### DIFF
--- a/.github/workflows/feishu-issue-notify.yml
+++ b/.github/workflows/feishu-issue-notify.yml
@@ -1,0 +1,60 @@
+name: Feishu Issue Notification
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  notify:
+    name: Notify Feishu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Feishu notification
+        env:
+          WEBHOOK_URL: ${{ secrets.ISSUE_SYNC_FEISHU_BOT_WEBHOOK }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_LABELS: ${{ join(github.event.issue.labels.*.name, ', ') }}
+          REPO: ${{ github.repository }}
+        run: |
+          BODY_SNIPPET="${ISSUE_BODY:0:200}"
+          [ "${#ISSUE_BODY}" -gt 200 ] && BODY_SNIPPET="${BODY_SNIPPET}..."
+
+          PAYLOAD=$(jq -n \
+            --arg title "[${REPO}] New Issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}" \
+            --arg author "$ISSUE_AUTHOR" \
+            --arg labels "${ISSUE_LABELS:-none}" \
+            --arg body "${BODY_SNIPPET:-(no description)}" \
+            --arg url "$ISSUE_URL" \
+            '{
+              msg_type: "interactive",
+              card: {
+                schema: "2.0",
+                header: {
+                  title: { tag: "plain_text", content: $title },
+                  template: "orange"
+                },
+                body: {
+                  direction: "vertical",
+                  elements: [
+                    { tag: "markdown", content: ("**Author:** " + $author) },
+                    { tag: "markdown", content: ("**Labels:** " + $labels) },
+                    { tag: "markdown", content: $body },
+                    {
+                      tag: "button",
+                      text: { tag: "plain_text", content: "View Issue" },
+                      url: $url,
+                      type: "primary"
+                    }
+                  ]
+                }
+              }
+            }')
+
+          curl -sS -f -X POST \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD" \
+            "$WEBHOOK_URL"

--- a/biome.json
+++ b/biome.json
@@ -59,7 +59,8 @@
       "*.d.ts",
       "openapi.json",
       "*.astro",
-      ".turbo"
+      ".turbo",
+      "docs/**"
     ]
   }
 }


### PR DESCRIPTION
## What

Adds a GitHub Actions workflow that sends a Feishu notification whenever a new issue is opened in the repo.

## Why

Closes the gap between GitHub issues and team visibility in Feishu — currently new issues go unnoticed unless someone checks GitHub. This gives the team real-time awareness without leaving Feishu.

## How

- New workflow file: `.github/workflows/feishu-issue-notify.yml`
- Triggers on `issues: [opened]`
- Builds an interactive Feishu card (schema 2.0) containing the issue title, author, labels, a 200-char body snippet, and a "View Issue" button
- Posts to Feishu via `ISSUE_SYNC_FEISHU_BOT_WEBHOOK` repository secret

## Affected areas

- [ ] Desktop app (Electron shell)
- [ ] Controller (backend / API)
- [ ] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [x] Build / CI / Tooling

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

## Notes for reviewers

Requires the `ISSUE_SYNC_FEISHU_BOT_WEBHOOK` secret to be set in the repo settings before the workflow can send notifications. The webhook URL can be obtained from the Feishu bot configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated notifications to Feishu for newly opened issues
  * Updated build configuration to exclude documentation files from processing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->