### PR TITLE
fix(desktop): allow display sleep while app stays active

### DIFF
--- a/apps/desktop/main/sleep-guard.ts
+++ b/apps/desktop/main/sleep-guard.ts
@@ -55,8 +55,8 @@ type SleepGuardDependencies = {
   onSnapshot?(snapshot: SleepGuardSnapshot): void;
 };
 
-// Strongest Electron-level policy: block idle system sleep and display sleep.
-const DEFAULT_BLOCKER_TYPE: SleepBlockerType = "prevent-display-sleep";
+// Keep the app active during idle without forcing the display to stay on.
+const DEFAULT_BLOCKER_TYPE: SleepBlockerType = "prevent-app-suspension";
 
 function cloneSnapshot(snapshot: SleepGuardSnapshot): SleepGuardSnapshot {
   return {

--- a/tests/desktop/sleep-guard.test.ts
+++ b/tests/desktop/sleep-guard.test.ts
@@ -66,29 +66,29 @@ function createGuard() {
 }
 
 describe("SleepGuard", () => {
-  it("starts the strongest available blocker and publishes active state", () => {
+  it("starts app-suspension blocker and publishes active state", () => {
     const { guard, logs, powerSaveBlocker, snapshots } = createGuard();
 
     guard.start("desktop-runtime-active");
 
     expect([...powerSaveBlocker.active.values()]).toEqual([
-      "prevent-display-sleep",
+      "prevent-app-suspension",
     ]);
     expect(snapshots.at(-1)).toMatchObject({
-      activeBlockerType: "prevent-display-sleep",
+      activeBlockerType: "prevent-app-suspension",
       blockerId: 1,
       isStarted: true,
       lastEvent: {
         onBatteryPower: false,
         type: "started",
       },
-      requestedBlockerType: "prevent-display-sleep",
+      requestedBlockerType: "prevent-app-suspension",
       status: "active",
     });
     expect(logs.at(-1)).toMatchObject({
       kind: "lifecycle",
       message:
-        "sleep guard enabled blockerType=prevent-display-sleep blockerId=1 reason=desktop-runtime-active onBatteryPower=false",
+        "sleep guard enabled blockerType=prevent-app-suspension blockerId=1 reason=desktop-runtime-active onBatteryPower=false",
       stream: "system",
     });
   });
@@ -117,7 +117,7 @@ describe("SleepGuard", () => {
       status: "active",
     });
     expect(logs.map((entry) => entry.message)).toContain(
-      "sleep guard observed system suspend while active=true blockerType=prevent-display-sleep onBatteryPower=true",
+      "sleep guard observed system suspend while active=true blockerType=prevent-app-suspension onBatteryPower=true",
     );
   });
 
@@ -142,11 +142,11 @@ describe("SleepGuard", () => {
     expect(logs.at(-1)).toMatchObject({
       kind: "lifecycle",
       message:
-        "sleep guard disabled blockerType=prevent-display-sleep blockerId=1 reason=app-before-quit",
+        "sleep guard disabled blockerType=prevent-app-suspension blockerId=1 reason=app-before-quit",
       stream: "system",
     });
     expect(logs.map((entry) => entry.message)).not.toContain(
-      "sleep guard observed system suspend while active=false blockerType=prevent-display-sleep onBatteryPower=false",
+      "sleep guard observed system suspend while active=false blockerType=prevent-app-suspension onBatteryPower=false",
     );
   });
 });


### PR DESCRIPTION
## Summary
- change the desktop sleep guard default from `prevent-display-sleep` to `prevent-app-suspension`
- keep the app active during idle without forcing the display to stay on
- update the desktop sleep guard tests to cover the downgraded blocker mode

## Verification
- `pnpm typecheck`
- `pnpm test`
- `pnpm lint`

Fixes #434

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated the default sleep blocker behavior to prevent app suspension instead of display sleep prevention, affecting how the system manages power states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->