### PR TITLE
Add skill install and uninstall analytics events

### DIFF
--- a/apps/web/src/components/skills/import-skill-modal.tsx
+++ b/apps/web/src/components/skills/import-skill-modal.tsx
@@ -83,6 +83,11 @@ export default function ImportSkillModal({
     if (!selectedFile) return;
     try {
       const result = await importMutation.mutateAsync(selectedFile);
+      track("workspace_skill_install", {
+        skill_name: result.slug ?? "unknown_skill",
+        skill_source: "custom",
+        success: true,
+      });
       track("workspace_skill_enable", {
         name: result.slug ?? "unknown_skill",
         skill_source: "custom",
@@ -90,6 +95,11 @@ export default function ImportSkillModal({
       setDone(true);
       autoCloseControllerRef.current.schedule(handleClose, 1200);
     } catch {
+      track("workspace_skill_install", {
+        skill_name: "unknown_skill",
+        skill_source: "custom",
+        success: false,
+      });
       // Error state handled by mutation
     }
   };

--- a/apps/web/src/pages/skills.tsx
+++ b/apps/web/src/pages/skills.tsx
@@ -24,6 +24,14 @@ type YoursSubTab = "all" | "recommended" | "installed";
 
 const PAGE_SIZE = 50;
 
+function getSkillType(tags: readonly string[]): string | null {
+  const primaryTag = tags[0]?.trim();
+  if (!primaryTag) {
+    return null;
+  }
+  return primaryTag.toLowerCase();
+}
+
 function useDebounce<T>(value: T, delayMs: number): T {
   const [debounced, setDebounced] = useState(value);
 
@@ -68,11 +76,25 @@ function SkillCard({
 
   async function handleInstall() {
     setPendingAction("install");
+    const skillType = getSkillType(skill.tags);
     try {
       await installMutation.mutateAsync(skill.slug);
+      track("workspace_skill_install", {
+        skill_name: skill.name,
+        skill_type: skillType,
+        skill_source: skillSource,
+        success: true,
+      });
       track("workspace_skill_enable", {
         name: skill.name,
         skill_source: skillSource,
+      });
+    } catch {
+      track("workspace_skill_install", {
+        skill_name: skill.name,
+        skill_type: skillType,
+        skill_source: skillSource,
+        success: false,
       });
     } finally {
       setPendingAction(null);
@@ -82,11 +104,25 @@ function SkillCard({
   async function handleToggle(checked: boolean) {
     if (checked) {
       setPendingAction("install");
+      const skillType = getSkillType(skill.tags);
       try {
         await installMutation.mutateAsync(skill.slug);
+        track("workspace_skill_install", {
+          skill_name: skill.name,
+          skill_type: skillType,
+          skill_source: skillSource,
+          success: true,
+        });
         track("workspace_skill_enable", {
           name: skill.name,
           skill_source: skillSource,
+        });
+      } catch {
+        track("workspace_skill_install", {
+          skill_name: skill.name,
+          skill_type: skillType,
+          skill_source: skillSource,
+          success: false,
         });
       } finally {
         setPendingAction(null);
@@ -95,9 +131,20 @@ function SkillCard({
       setPendingAction("uninstall");
       try {
         await uninstallMutation.mutateAsync(skill.slug);
+        track("workspace_skill_uninstall", {
+          skill_name: skill.name,
+          skill_source: skillSource,
+          success: true,
+        });
         track("workspace_skill_disable", {
           name: skill.name,
           skill_source: skillSource,
+        });
+      } catch {
+        track("workspace_skill_uninstall", {
+          skill_name: skill.name,
+          skill_source: skillSource,
+          success: false,
         });
       } finally {
         setPendingAction(null);


### PR DESCRIPTION
## Summary
- add workspace_skill_install tracking for explore installs and zip imports
- add workspace_skill_uninstall tracking for uninstall success and failure paths
- keep existing workspace_skill_enable and workspace_skill_disable events and dual-send the new lifecycle events

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test

## Notes
- skill_type is derived from the first explore catalog tag when available
- zip imports track skill_source custom and omit skill_type because the import flow has no stable tag metadata


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved analytics tracking by capturing additional skill import, installation, and uninstallation events, including success/failure status and skill metadata for better insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->