### PR TITLE
fix: desktop runtime port/plugin reliability

### DIFF
--- a/apps/controller/src/lib/openclaw-config-compiler.ts
+++ b/apps/controller/src/lib/openclaw-config-compiler.ts
@@ -349,13 +349,26 @@ export function compileOpenClawConfig(
       config.runtime.defaultModelId,
   );
 
+  // When the controller manages the OpenClaw process, the env port and
+  // auth mode are the source of truth (desktop may allocate a different
+  // port on each launch).  Persisted config values are only authoritative
+  // when running against an externally managed gateway.
+  const gatewayPort = env.manageOpenclawProcess
+    ? env.openclawGatewayPort
+    : config.runtime.gateway.port;
+  const gatewayAuthMode = env.manageOpenclawProcess
+    ? env.openclawGatewayToken
+      ? "token"
+      : "none"
+    : config.runtime.gateway.authMode;
+
   const openClawConfig: OpenClawConfig = {
     gateway: {
-      port: config.runtime.gateway.port,
+      port: gatewayPort,
       mode: "local",
       bind: config.runtime.gateway.bind,
       auth: {
-        mode: config.runtime.gateway.authMode,
+        mode: gatewayAuthMode,
         ...(env.openclawGatewayToken
           ? { token: env.openclawGatewayToken }
           : {}),

--- a/apps/controller/src/runtime/openclaw-runtime-plugin-writer.ts
+++ b/apps/controller/src/runtime/openclaw-runtime-plugin-writer.ts
@@ -1,5 +1,5 @@
 import { cp, mkdir, readdir } from "node:fs/promises";
-import path from "node:path";
+import path, { basename } from "node:path";
 import type { ControllerEnv } from "../app/env.js";
 
 export class OpenClawRuntimePluginWriter {
@@ -30,7 +30,12 @@ export class OpenClawRuntimePluginWriter {
         entry.name,
       );
       const targetDir = path.join(this.env.openclawExtensionsDir, entry.name);
-      await cp(sourceDir, targetDir, { recursive: true, force: true });
+      await cp(sourceDir, targetDir, {
+        recursive: true,
+        force: true,
+        dereference: true,
+        filter: (source) => basename(source) !== ".bin",
+      });
     }
   }
 }

--- a/apps/desktop/scripts/dist-mac.mjs
+++ b/apps/desktop/scripts/dist-mac.mjs
@@ -449,7 +449,7 @@ async function main() {
   }
 
   const controllerPort =
-    process.env.NEXU_CONTROLLER_PORT ?? process.env.NEXU_API_PORT ?? "50800";
+    env.NEXU_CONTROLLER_PORT ?? env.NEXU_API_PORT ?? "50800";
 
   await rm(releaseRoot, rmWithRetriesOptions);
   await rm(resolve(electronRoot, ".dist-runtime"), rmWithRetriesOptions);


### PR DESCRIPTION
## Summary
- **Config compiler stale port**: When `manageOpenclawProcess` is true (desktop), use `env.openclawGatewayPort` and derive `authMode` from env directly, bypassing persisted config. Prevents stale port after dynamic reallocation.
- **Plugin writer .bin filter**: Use `dereference: true` with `filter: basename !== ".bin"` instead of rejecting all symlinks. Preserves non-.bin symlinked content in runtime plugins.
- **dist-mac controller port**: Read `NEXU_CONTROLLER_PORT` from merged `env` (includes `desktopEnv` from `.env`) instead of bare `process.env`, fixing wrong `VITE_API_BASE_URL` in packaged builds.

## Test plan
- [ ] `pnpm typecheck && pnpm test` — all pass
- [ ] `pnpm start` — desktop boots without EINVAL crash on plugin copy
- [ ] Change `OPENCLAW_GATEWAY_PORT` between runs — verify compiled config uses new port
- [ ] `pnpm dist:mac:unsigned` with `NEXU_CONTROLLER_PORT` in `apps/desktop/.env` — verify web build uses correct port

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway configuration to correctly use environment-managed settings when applicable
  * Enhanced plugin installation process to handle symlinks properly and exclude invalid entries
  * Fixed build configuration to correctly read environment settings from all available sources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->