### PR TITLE
chore: use GitHub App token in nexu-pol bot workflow

### DIFF
--- a/.github/workflows/nexu-pal.yml
+++ b/.github/workflows/nexu-pal.yml
@@ -20,12 +20,19 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.NEXU_PAL_APP_ID }}
+          private-key: ${{ secrets.NEXU_PAL_PRIVATE_KEY_PEM }}
+
       - name: Process issue
         env:
           LITELLM_ENDPOINT: ${{ secrets.LITELLM_ENDPOINT }}
           LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
           LITELLM_MODEL: "google/gemini-2.5-flash"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_BODY: ${{ github.event.issue.body }}


### PR DESCRIPTION
## What

- add a GitHub App token creation step to the Nexu PAL issue workflow and use that token when processing issues

## Why

- the workflow needs an app-authenticated token so the PAL bot can act with the permissions granted to the GitHub App instead of using the default `GITHUB_TOKEN`

## How

- call `actions/create-github-app-token@v1` with the existing secrets and pass its output token into the `Process issue` job

## Affected areas

- [ ] Desktop app (Electron shell)
- [ ] Controller (backend / API)
- [ ] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [x] Build / CI / Tooling

## Checklist

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

## Screenshots / recordings

- Not applicable.

## Notes for reviewers

- None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated GitHub Actions workflow authentication for improved security and reliability in issue processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->