### PR TITLE
chore: add Feishu notification for GitHub discussions

### DIFF
--- a/.github/workflows/feishu-discussion-notify.yml
+++ b/.github/workflows/feishu-discussion-notify.yml
@@ -1,0 +1,26 @@
+name: Feishu Discussion Notification
+
+on:
+  discussion:
+    types: [created]
+
+jobs:
+  notify:
+    name: Notify Feishu
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: scripts/notify
+      - name: Send Feishu notification
+        env:
+          WEBHOOK_URL: ${{ secrets.ISSUE_SYNC_FEISHU_BOT_WEBHOOK }}
+          EVENT_TYPE: discussion
+          TITLE: ${{ github.event.discussion.title }}
+          URL: ${{ github.event.discussion.html_url }}
+          NUMBER: ${{ github.event.discussion.number }}
+          AUTHOR: ${{ github.event.discussion.user.login }}
+          BODY: ${{ github.event.discussion.body }}
+          LABELS_OR_CATEGORY: ${{ github.event.discussion.category.name }}
+          REPO: ${{ github.repository }}
+        run: node scripts/notify/feishu-notify.mjs

--- a/.github/workflows/feishu-issue-notify.yml
+++ b/.github/workflows/feishu-issue-notify.yml
@@ -9,52 +9,18 @@ jobs:
     name: Notify Feishu
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: scripts/notify
       - name: Send Feishu notification
         env:
           WEBHOOK_URL: ${{ secrets.ISSUE_SYNC_FEISHU_BOT_WEBHOOK }}
-          ISSUE_TITLE: ${{ github.event.issue.title }}
-          ISSUE_URL: ${{ github.event.issue.html_url }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
-          ISSUE_BODY: ${{ github.event.issue.body }}
-          ISSUE_LABELS: ${{ join(github.event.issue.labels.*.name, ', ') }}
+          EVENT_TYPE: issue
+          TITLE: ${{ github.event.issue.title }}
+          URL: ${{ github.event.issue.html_url }}
+          NUMBER: ${{ github.event.issue.number }}
+          AUTHOR: ${{ github.event.issue.user.login }}
+          BODY: ${{ github.event.issue.body }}
+          LABELS_OR_CATEGORY: ${{ join(github.event.issue.labels.*.name, ', ') }}
           REPO: ${{ github.repository }}
-        run: |
-          BODY_SNIPPET="${ISSUE_BODY:0:200}"
-          [ "${#ISSUE_BODY}" -gt 200 ] && BODY_SNIPPET="${BODY_SNIPPET}..."
-
-          PAYLOAD=$(jq -n \
-            --arg title "[${REPO}] New Issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}" \
-            --arg author "$ISSUE_AUTHOR" \
-            --arg labels "${ISSUE_LABELS:-none}" \
-            --arg body "${BODY_SNIPPET:-(no description)}" \
-            --arg url "$ISSUE_URL" \
-            '{
-              msg_type: "interactive",
-              card: {
-                schema: "2.0",
-                header: {
-                  title: { tag: "plain_text", content: $title },
-                  template: "orange"
-                },
-                body: {
-                  direction: "vertical",
-                  elements: [
-                    { tag: "markdown", content: ("**Author:** " + $author) },
-                    { tag: "markdown", content: ("**Labels:** " + $labels) },
-                    { tag: "markdown", content: $body },
-                    {
-                      tag: "button",
-                      text: { tag: "plain_text", content: "View Issue" },
-                      url: $url,
-                      type: "primary"
-                    }
-                  ]
-                }
-              }
-            }')
-
-          curl -sS -f -X POST \
-            -H "Content-Type: application/json" \
-            -d "$PAYLOAD" \
-            "$WEBHOOK_URL"
+        run: node scripts/notify/feishu-notify.mjs

--- a/scripts/notify/feishu-notify.mjs
+++ b/scripts/notify/feishu-notify.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+/**
+ * Send a Feishu interactive card notification via incoming webhook.
+ *
+ * Environment variables:
+ *   WEBHOOK_URL        — Feishu bot webhook URL
+ *   EVENT_TYPE         — "issue" or "discussion"
+ *   TITLE              — Event title
+ *   URL                — Event HTML URL
+ *   NUMBER             — Event number
+ *   AUTHOR             — Event author login
+ *   BODY               — Event body (may be empty)
+ *   LABELS_OR_CATEGORY — Comma-separated labels or discussion category name
+ *   REPO               — owner/repo
+ */
+
+const webhookUrl = process.env.WEBHOOK_URL;
+const eventType = process.env.EVENT_TYPE ?? "issue";
+const title = process.env.TITLE ?? "";
+const url = process.env.URL ?? "";
+const number = process.env.NUMBER ?? "";
+const author = process.env.AUTHOR ?? "";
+const body = process.env.BODY ?? "";
+const labelsOrCategory = process.env.LABELS_OR_CATEGORY || "none";
+const repo = process.env.REPO ?? "";
+
+if (!webhookUrl) {
+  console.error("WEBHOOK_URL is required");
+  process.exit(1);
+}
+
+const isDiscussion = eventType === "discussion";
+const typeLabel = isDiscussion ? "Discussion" : "Issue";
+const headerColor = isDiscussion ? "turquoise" : "orange";
+const metaLabel = isDiscussion ? "Category" : "Labels";
+
+const bodySnippet =
+  body.length > 200 ? `${body.slice(0, 200)}...` : body || "(no description)";
+
+const payload = {
+  msg_type: "interactive",
+  card: {
+    schema: "2.0",
+    header: {
+      title: {
+        tag: "plain_text",
+        content: `[${repo}] New ${typeLabel} #${number}: ${title}`,
+      },
+      template: headerColor,
+    },
+    body: {
+      direction: "vertical",
+      elements: [
+        { tag: "markdown", content: `**Author:** ${author}` },
+        { tag: "markdown", content: `**${metaLabel}:** ${labelsOrCategory}` },
+        { tag: "markdown", content: bodySnippet },
+        {
+          tag: "button",
+          text: { tag: "plain_text", content: `View ${typeLabel}` },
+          url,
+          type: "primary",
+        },
+      ],
+    },
+  },
+};
+
+const response = await fetch(webhookUrl, {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify(payload),
+});
+
+if (!response.ok) {
+  const text = await response.text();
+  console.error(`Webhook request failed (${response.status}): ${text}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

- Extract inline Feishu card logic from the issue notification workflow into a shared `scripts/notify/feishu-notify.mjs` script
- Add a new `feishu-discussion-notify` workflow that fires when a GitHub Discussion is created
- Refactor the existing `feishu-issue-notify` workflow to use the shared script

Both workflows reuse the same `ISSUE_SYNC_FEISHU_BOT_WEBHOOK` secret. The shared script handles event-type differences (header color, "Labels" vs "Category", button text).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automatic notifications to Feishu for new GitHub Discussions.
  * Refactored GitHub issue notifications to Feishu for improved notification handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->