### PR TITLE
fix(desktop): inject amplitude env into packaged builds

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -193,6 +193,8 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          VITE_AMPLITUDE_API_KEY: ${{ secrets.AMPLITUDE_API_KEY }}
+          AMPLITUDE_API_KEY: ${{ secrets.AMPLITUDE_API_KEY }}
         run: pnpm --filter @nexu/desktop dist:mac
 
       - name: Prepare artifacts

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -157,6 +157,8 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          VITE_AMPLITUDE_API_KEY: ${{ secrets.AMPLITUDE_API_KEY }}
+          AMPLITUDE_API_KEY: ${{ secrets.AMPLITUDE_API_KEY }}
         run: pnpm --filter @nexu/desktop dist:mac
 
       - name: Prepare release artifacts


### PR DESCRIPTION
## Summary
- inject VITE_AMPLITUDE_API_KEY and AMPLITUDE_API_KEY into desktop packaged build workflows
- cover stable release via desktop-release.yml
- cover beta and nightly via reusable desktop-build.yml

## Why
Local verification showed analytics recovered once env keys were present. The desktop release workflows were not passing Amplitude env vars into the build and runtime chain, so packaged builds could ship without analytics initialized.

## Validation
- inspected desktop release workflows and build scripts
- confirmed both stable and reusable beta/nightly workflows now export the Amplitude env vars to pnpm --filter @nexu/desktop dist:mac


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced desktop application build process configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->