### PR TITLE
chore: add required pr_message to first-interaction action

### DIFF
--- a/.github/workflows/nexu-pal-issue-opened.yml
+++ b/.github/workflows/nexu-pal-issue-opened.yml
@@ -33,6 +33,8 @@ jobs:
           repo_token: ${{ steps.app-token.outputs.token }}
           issue_message: |
             Hey, welcome to Nexu! 🎉 Thanks so much for taking the time to open your first issue here — we really appreciate it. A maintainer will be along shortly to take a look. In the meantime, feel free to share any extra context that might help us help you!
+          pr_message: |
+            Hey, welcome to Nexu! 🎉 Thanks so much for opening your first pull request — we really appreciate the contribution. A maintainer will review it shortly.
 
       - name: Process issue
         env:


### PR DESCRIPTION
## What

Add the required `pr_message` input to `actions/first-interaction@v3` in the nexu-pal issue-opened workflow.

## Why

`actions/first-interaction@v3` requires both `issue_message` and `pr_message` inputs. The missing `pr_message` caused the workflow to fail immediately on every issue open event. Closes the failure seen in [run 23524167413](https://github.com/nexu-io/nexu/actions/runs/23524167413/job/68473655266).

## How

Added `pr_message` alongside the existing `issue_message`. The message won't fire for issues (only for PRs), but the input must be present for the action to start.

## Affected areas

- [x] Build / CI / Tooling

## Checklist

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved contributor experience with a tailored welcome message for first-time pull request contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->