### PR TITLE
fix: auto-mark stable releases as Latest on GitHub

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -270,6 +270,13 @@ jobs:
             "apps/desktop/release-artifacts/desktop-sha256.txt" \
             --clobber
 
+      - name: Mark release as latest (stable only)
+        if: steps.meta.outputs.prerelease != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ steps.meta.outputs.tag_name }}
+        run: gh release edit "$TAG_NAME" --latest
+
       - name: Patch latest-mac.yml for channel naming
         env:
           VERSION: ${{ steps.meta.outputs.desktop_version }}


### PR DESCRIPTION
## Summary
- 在 `desktop-release.yml` 中新增一步：release assets 上传完成后，自动将非预发布版本标记为 GitHub Latest
- 之前每次发版后需要手动 `gh release edit --latest`，现在自动化了
- 仅对 stable release 生效，prerelease（beta/nightly）不受影响

## Test plan
- [ ] 下次发布 stable 版本时确认 GitHub 侧边栏自动显示最新版本号


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to automatically mark stable releases as the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->