### PR TITLE
fix(desktop): prevent unhandled rejection in cloud status refresh

### DIFF
--- a/apps/desktop/src/pages/cloud-profile-page.tsx
+++ b/apps/desktop/src/pages/cloud-profile-page.tsx
@@ -74,7 +74,6 @@ export function CloudProfilePage() {
               : "Failed to load cloud status.",
           );
         }
-        throw error;
       }
     },
     [],


### PR DESCRIPTION
## What

Remove erroneous `throw error` from `refreshCloudStatus` that caused unhandled promise rejections when the controller is temporarily unreachable.

## Why

Sentry issue [NEXU-DESKTOP-PROD-B](https://refly-ai.sentry.io/issues/7360845550/) — 12 occurrences since v0.1.6. Every window focus, tab switch, or 2-second polling cycle during cloud connect produced an unhandled rejection when the controller was down. Closes #535

## How

`refreshCloudStatus()` already handles the error correctly by setting `cloudStatusPhase("error")` and displaying a user-facing message. The `throw error` at the end of the catch block is unnecessary — all three callers invoke it fire-and-forget (`void refreshCloudStatus(...)`), so the re-thrown error has no consumer and surfaces as an unhandled rejection.

Removed the `throw error` line. No behavior change for the user — the error UI already renders properly without it.

## Affected areas

- [x] Desktop app (Electron shell)

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error resilience for cloud profile status. When cloud status retrieval fails, the application now displays an appropriate error message while maintaining stability and responsiveness. Error handling has been improved to prevent error propagation, ensuring the application remains fully functional and users experience no disruptions to other features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->