### PR TITLE
fix(controller): disable daily session auto-reset for desktop

### DIFF
--- a/apps/controller/src/lib/openclaw-config-compiler.ts
+++ b/apps/controller/src/lib/openclaw-config-compiler.ts
@@ -406,6 +406,8 @@ export function compileOpenClawConfig(
           mode: "safeguard",
           maxHistoryShare: 0.5,
           keepRecentTokens: 20000,
+          recentTurnsPreserve: 5,
+          qualityGuard: { enabled: true },
           memoryFlush: {
             enabled: true,
           },


### PR DESCRIPTION
Relates to #414

https://github.com/openclaw/openclaw/blob/42a1394c5/src/config/sessions/reset.ts#L20-L21
<img width="1016" height="140" alt="image" src="https://github.com/user-attachments/assets/4a941c66-685c-4091-aa5a-de6d7c220d55" />



## Summary

- OpenClaw defaults to resetting all sessions daily at 4 AM (`mode: "daily"`, `atHour: 4`), which silently archives conversation history and starts a fresh session with a new UUID
- This is completely unexpected for a desktop chat app — users expect persistent conversations that survive across days
- Switch to `idle` reset mode with a 1-year timeout (525,600 minutes) so sessions effectively never auto-reset
- Conversation context management is handled by compaction (`safeguard` mode) which summarizes old messages while preserving context, rather than dropping history entirely

### Reset vs Compaction

| | Session Reset (was happening) | Compaction (what should manage context) |
|---|---|---|
| Effect | Archives entire transcript, creates new session UUID | Summarizes old messages in-place, preserves context |
| History | **Lost** | **Preserved** (summarized + recent turns verbatim) |
| Trigger | Daily 4 AM / idle timeout / `/new` | Context window overflow / manual `/compact` |

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] Start desktop runtime, verify `compiled-openclaw.json` contains `session.reset.mode: "idle"` and `idleMinutes: 525600`
- [ ] Confirm sessions persist across midnight without auto-reset
- [ ] Verify `/new` and `/reset` commands still work for manual reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversation compaction now preserves the most recent 5 turns and enables a quality guard to improve response relevance.

* **Bug Fixes**
  * Session reset behavior updated to use an explicit idle reset mode with a one-year idle timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->