### PR TITLE
chore: fix Feishu Project notify for board drag (reordered)

### DIFF
--- a/.github/workflows/feishu-project-item-notify.yml
+++ b/.github/workflows/feishu-project-item-notify.yml
@@ -1,8 +1,26 @@
+# Feishu notifications for GitHub Projects (classic "new Projects").
+#
+# Requirements (otherwise this workflow never runs):
+# - Project must be an organization-level project under the same org as this repo
+#   (e.g. nexu-io). User-owned projects do not deliver `projects_v2_item` to org flows.
+# - Link this repository to the project when GitHub offers "Linked repositories"
+#   (Project … menu → Settings), so item activity can target this repo's workflows.
+#
+# Note: dragging a card between columns often emits `reordered`, not `edited`.
 name: Feishu Project Item Notification
 
 on:
   projects_v2_item:
-    types: [created, edited, archived, deleted, restored]
+    types:
+      [
+        created,
+        edited,
+        reordered,
+        converted,
+        archived,
+        deleted,
+        restored,
+      ]
 
 jobs:
   notify:

--- a/scripts/notify/feishu-project-notify.mjs
+++ b/scripts/notify/feishu-project-notify.mjs
@@ -12,7 +12,7 @@
  *
  * Environment variables:
  *   WEBHOOK_URL    — Feishu bot webhook URL
- *   ACTION         — projects_v2_item action (created | edited | archived | deleted | restored)
+ *   ACTION         — projects_v2_item action (created | edited | reordered | converted | archived | deleted | restored)
  *   CHANGES_JSON   — JSON string of github.event.changes (field_value changes)
  *   ITEM_NODE_ID   — GraphQL node ID of the project item
  *   PROJECT_NUMBER — Project number
@@ -191,7 +191,11 @@ function buildProjectUrl() {
 
 const ACTION_CONFIG = {
   created: { text: "📋 新建需求/Bug", color: "blue" },
-  edited: { text: "🔄 状态变更", color: "orange" },
+  edited: { text: "🔄 项目条目变更", color: "orange" },
+  /** Often fired when dragging a card between columns (e.g. TODO → In progress). */
+  reordered: { text: "📌 看板移动/重排", color: "orange" },
+  /** Draft (or item) converted to a tracked issue/PR. */
+  converted: { text: "🔗 已转为 Issue/PR", color: "turquoise" },
   archived: { text: "📦 已归档", color: "grey" },
   deleted: { text: "🗑️ 已删除", color: "red" },
   restored: { text: "♻️ 已恢复", color: "green" },
@@ -228,7 +232,7 @@ async function main() {
   let { text: actionText, color: headerColor } =
     ACTION_CONFIG[action] ?? ACTION_CONFIG.edited;
 
-  if (action === "edited" && changeInfo) {
+  if ((action === "edited" || action === "reordered") && changeInfo) {
     if (changeInfo.field === "Status") {
       actionText = "🔄 状态变更";
     } else if (changeInfo.field === "Assignees") {


### PR DESCRIPTION
## Problem

Moving a draft from TODO → In progress by **dragging on the board** often emits GitHub `projects_v2_item` action **`reordered`**, not `edited`. The previous workflow only listened to `edited`, so no Feishu message was sent.

## Changes

- Subscribe to `reordered` and `converted` in `feishu-project-item-notify.yml`.
- Map those actions in `feishu-project-notify.mjs` and treat `reordered` like `edited` when parsing field changes.
- Add workflow comments: org-level project + link repo when GitHub offers it.

## Checklist after merge

- [ ] In `nexu-io/nexu` → Actions, confirm a run appears when you drag a draft or change Status.
- [ ] If still no runs: confirm the Project lives under **nexu-io** (not a personal org) and that the project is **linked** to `nexu-io/nexu` in Project settings.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project notifications now support additional GitHub Projects V2 item events. Notifications are triggered when cards are reordered on your project board or when items are converted to issues or pull requests. Each event type includes tailored messaging and action-specific labels to clearly communicate the exact change made to your project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->