### PR TITLE
chore: switch nexu-pal LLM backend from LiteLLM proxy to OpenRouter

### DIFF
--- a/.github/workflows/nexu-pal-issue-opened.yml
+++ b/.github/workflows/nexu-pal-issue-opened.yml
@@ -38,9 +38,9 @@ jobs:
 
       - name: Process issue
         env:
-          LITELLM_ENDPOINT: ${{ secrets.LITELLM_ENDPOINT }}
-          LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
-          LITELLM_MODEL: "google/gemini-2.5-flash"
+          OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_MODEL: "google/gemini-2.5-flash"
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_TITLE: ${{ github.event.issue.title }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,12 @@ This repo is desktop-first. Prefer the controller-first path and remove or ignor
 - Prefer merging the latest `main` into long-running feature branches instead of rewriting shared history once a PR is under review.
 - After a PR merges, sync local `main`, then delete the merged feature branch locally and remotely when it is no longer needed.
 
+## Commit & PR conventions
+
+- **No co-author trailer.** Never append `Co-Authored-By:` lines to commit messages.
+- **Conventional commit prefix.** Use `chore:` for changes that are invisible to end users (CI/CD, issue bots, tooling, config). These are excluded from release notes. Use `feat:` / `fix:` / `docs:` etc. for user-visible changes.
+- **PR format.** When creating a pull request, always follow `.github/pull_request_template.md` — fill in What / Why / How / Affected areas / Checklist sections.
+
 ## Desktop local development
 
 - Use `pnpm install` first, then `pnpm start` / `pnpm stop` / `pnpm restart` / `pnpm status` as the standard local desktop workflow.

--- a/scripts/nexu-pal/process-issue.mjs
+++ b/scripts/nexu-pal/process-issue.mjs
@@ -7,9 +7,9 @@
  * 2. Classifies intent → tags `bug`, `enhancement`, or `help-wanted`
  *
  * Environment variables:
- *   LITELLM_ENDPOINT  — LiteLLM proxy base URL (e.g. https://litellm.example.com/v1)
- *   LITELLM_API_KEY   — API key for the proxy
- *   LITELLM_MODEL     — Model ID (default: google/gemini-2.5-flash)
+ *   OPENAI_BASE_URL   — OpenRouter base URL (e.g. https://openrouter.ai/api/v1)
+ *   OPENAI_API_KEY    — OpenRouter API key
+ *   OPENAI_MODEL      — Model ID (default: google/gemini-2.5-flash)
  *   GITHUB_TOKEN      — GitHub token with issues write permission
  *   GITHUB_REPOSITORY — owner/repo
  *   ISSUE_NUMBER      — Issue number to process
@@ -22,9 +22,9 @@
 // Config
 // ---------------------------------------------------------------------------
 
-const endpoint = process.env.LITELLM_ENDPOINT;
-const apiKey = process.env.LITELLM_API_KEY;
-const model = process.env.LITELLM_MODEL ?? "google/gemini-2.5-flash";
+const endpoint = process.env.OPENAI_BASE_URL;
+const apiKey = process.env.OPENAI_API_KEY;
+const model = process.env.OPENAI_MODEL ?? "google/gemini-2.5-flash";
 const ghToken = process.env.GITHUB_TOKEN;
 const repo = process.env.GITHUB_REPOSITORY; // owner/repo
 const issueNumber = process.env.ISSUE_NUMBER;
@@ -33,7 +33,7 @@ const issueBody = process.env.ISSUE_BODY ?? "";
 
 if (!endpoint || !apiKey || !ghToken || !repo || !issueNumber) {
   console.error(
-    "Missing required env: LITELLM_ENDPOINT, LITELLM_API_KEY, GITHUB_TOKEN, GITHUB_REPOSITORY, ISSUE_NUMBER",
+    "Missing required env: OPENAI_BASE_URL, OPENAI_API_KEY, GITHUB_TOKEN, GITHUB_REPOSITORY, ISSUE_NUMBER",
   );
   process.exit(1);
 }

--- a/specs/current/nexu-pal.md
+++ b/specs/current/nexu-pal.md
@@ -15,7 +15,7 @@ Runs in order:
 
 1. **First-time contributor welcome** — Uses `actions/first-interaction@v3`. If the author has never opened an issue in this repo before, posts a welcome comment.
 
-2. **Language detection & translation** — Sends the issue title and body to an LLM (`google/gemini-2.5-flash` via LiteLLM proxy). If the content is primarily non-English, posts a comment with the English translation and adds the `ai-translated` label.
+2. **Language detection & translation** — Sends the issue title and body to an LLM (`google/gemini-2.5-flash` via OpenRouter). If the content is primarily non-English, posts a comment with the English translation and adds the `ai-translated` label.
 
 3. **Intent classification** — Sends the (English) title and body to the LLM and assigns one label: `bug`, `enhancement`, or `help-wanted`.
 
@@ -45,8 +45,8 @@ Both workflows create a short-lived token via `actions/create-github-app-token@v
 |--------|---------|
 | `NEXU_PAL_APP_ID` | GitHub App ID |
 | `NEXU_PAL_PRIVATE_KEY_PEM` | GitHub App private key |
-| `LITELLM_ENDPOINT` | LiteLLM proxy base URL |
-| `LITELLM_API_KEY` | LiteLLM proxy API key |
+| `OPENAI_BASE_URL` | OpenRouter base URL |
+| `OPENAI_API_KEY` | OpenRouter API key |
 
 ## File map
 


### PR DESCRIPTION
## What

Switch nexu-pal's LLM backend from the LiteLLM proxy (powerformer.net) to OpenRouter, and rename all related secrets/env vars to use the `OPENAI_` prefix.

## Why

The LiteLLM proxy at `powerformer.net` is blocked by Cloudflare for GitHub Actions runner IPs, causing `process-issue` to fail with a 403 on every issue opened. Closes the regression introduced in run [23535201312](https://github.com/nexu-io/nexu/actions/runs/23535201312).

## How

Replaced `LITELLM_ENDPOINT` / `LITELLM_API_KEY` / `LITELLM_MODEL` with `OPENAI_BASE_URL` / `OPENAI_API_KEY` / `OPENAI_MODEL` across the workflow and script. No logic changes — OpenRouter exposes the same OpenAI-compatible `/chat/completions` API.

Required repo secret updates:
- Add `OPENAI_BASE_URL` = `https://openrouter.ai/api/v1`
- Add `OPENAI_API_KEY` = OpenRouter API key
- Delete `LITELLM_ENDPOINT`, `LITELLM_API_KEY`

## Affected areas

- [x] Build / CI / Tooling

## Checklist

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched the issue-processing bot to use OpenAI-compatible provider configuration.

* **Documentation**
  * Updated the issue-processing spec to reflect the provider change.
  * Added commit & PR conventions (commit prefixes and PR template requirements).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->