### PR TITLE
docs: add English WeChat channel setup guide

### DIFF
--- a/docs/en/guide/channels/wechat.md
+++ b/docs/en/guide/channels/wechat.md
@@ -1,0 +1,89 @@
+# WeChat
+
+With the nexu client, just **one scan** connects your personal WeChat to OpenClaw 🦞 ClawBot — the whole process takes less than 5 minutes.
+
+## Prerequisites
+
+- **WeChat** ≥ 8.0.7 (minimum version supporting the ClawBot plugin)
+- **macOS** 12+ (Apple Silicon)
+
+## Step 1: Update WeChat to 8.0.7
+
+Open WeChat and update to version 8.0.7 or later. This is the minimum version that supports the ClawBot plugin.
+
+## Step 2: Download and install nexu
+
+1. Go to the [nexu website](https://nexu.io) and click "Download for Mac".
+
+![nexu download page](/assets/wechat/step1-download.webp)
+
+2. Open the downloaded `.dmg` file and drag the **Nexu** icon into the **Applications** folder.
+
+![Install nexu](/assets/wechat/step1-install.webp)
+
+## Step 3: Launch nexu and sign in
+
+1. Open nexu from Applications.
+2. On the welcome screen, choose a sign-in method:
+   - **Use your Nexu account** (recommended) — sign in with your nexu account to get free access to top models like Claude, GPT, and Gemini.
+   - **Use your own models (BYOK)** — enter your own API Key, no registration required.
+
+![Choose sign-in method](/assets/wechat/step2-login.webp)
+
+## Step 4: Select the WeChat channel
+
+After signing in, on the nexu home screen, click **WeChat** in the "Choose a channel to get started" section.
+
+![Select WeChat channel](/assets/wechat/step3-choose-wechat.webp)
+
+## Step 5: Scan to connect WeChat
+
+1. When the "Connect WeChat" dialog appears, click the green "Scan to Connect" button.
+
+![Click Scan to Connect](/assets/wechat/step4-connect-dialog.webp)
+
+2. nexu will automatically install the WeChat ClawBot plugin and generate a QR code. The screen shows "Waiting for scan…".
+
+![Waiting for scan](/assets/wechat/step4-scan-qrcode.webp)
+
+3. Open **WeChat** on your phone, use "Scan" to scan the QR code on screen, then tap **Confirm** on your phone.
+
+## Step 6: Connected
+
+After confirming the scan, the WeChat channel on the nexu home screen shows a **Connected** status.
+
+![WeChat connected](/assets/wechat/step5-connected.webp)
+
+## Step 7: Chat in WeChat
+
+Open WeChat and you'll see a conversation named **WeChat ClawBot**. Send a message to start chatting with your OpenClaw Agent — available anytime on your phone, no desktop required.
+
+![Chat with ClawBot in WeChat](/assets/wechat/step6-chat.webp)
+
+---
+
+## FAQ
+
+**Q: Do I need a public server?**
+
+No. nexu connects directly through the WeChat ClawBot plugin — no public IP or callback URL required.
+
+**Q: Do I need WeChat Work or an Official Account?**
+
+No. WeChat 8.0.7 natively supports the ClawBot plugin. A personal WeChat account is all you need.
+
+**Q: Will my account get banned?**
+
+No. ClawBot is an official WeChat plugin and is fully compliant.
+
+**Q: Can the Agent reply when both my phone and computer are off?**
+
+The nexu client needs to stay running. As long as nexu is running in the background (and your computer is not asleep), the Agent can reply to WeChat messages 24/7.
+
+**Q: Can I connect multiple channels at the same time?**
+
+Yes. nexu supports connecting WeChat, Feishu, Slack, Discord, and more simultaneously.
+
+**Q: How do I switch AI models?**
+
+Use the model selector at the top of the nexu home screen to switch between Claude, GPT, Gemini, and other models with one click.


### PR DESCRIPTION
## Summary

- Add `docs/en/guide/channels/wechat.md` — the English version of the WeChat channel setup guide
- Fixes 404 at https://docs.nexu.io/guide/channels/wechat (the sidebar already linked to this page but the file was missing)
- Translated from the existing Chinese guide (`docs/zh/guide/channels/wechat.md`), covering prerequisites, 7-step setup walkthrough, and FAQ

## Test plan

- [ ] Verify `pnpm docs:build` succeeds without errors
- [ ] Confirm https://docs.nexu.io/guide/channels/wechat resolves correctly after deploy
- [ ] Check that all `/assets/wechat/*.webp` images render properly on the page


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive WeChat setup guide covering installation prerequisites, nexu client setup, authentication options, channel connection, and FAQ with common questions about server requirements, account types, and multi-channel support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->