### PR TITLE
fix(desktop): correct inherited mac entitlements

### DIFF
--- a/apps/desktop/build/entitlements.mac.inherit.plist
+++ b/apps/desktop/build/entitlements.mac.inherit.plist
@@ -2,11 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
-    <key>com.apple.security.cs.allow-jit</key>
-    <true/>
-    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-    <true/>
-    <key>com.apple.security.cs.disable-library-validation</key>
+    <key>com.apple.security.inherit</key>
     <true/>
   </dict>
 </plist>


### PR DESCRIPTION
## What

Fix the macOS desktop app's inherited entitlements so helper and nested binaries use `com.apple.security.inherit` instead of main-app hardened runtime exceptions.

## Why

Closes #508.

Sentry issue `NEXU-DESKTOP-PROD-9` reported a fatal native crash in `_libsecinit_appsandbox.cold.6` during packaged app launch on macOS. The root cause was that `apps/desktop/build/entitlements.mac.inherit.plist` granted helper processes the same hardened runtime entitlements as the main app (`allow-jit`, `allow-unsigned-executable-memory`, `disable-library-validation`), which can cause sandbox/secinit aborts very early in startup.

## How

- Investigated GitHub issue 508 and the linked Sentry issue `7359842523`
- Confirmed the crash was a native `EXC_BREAKPOINT` / `minidump` in `_libsecinit_appsandbox`
- Updated the inherited entitlements plist to the minimal helper entitlement:
  - `com.apple.security.inherit = true`
- Left the main app entitlements unchanged so the top-level app still keeps the hardened runtime exceptions it needs

## Affected areas

- [x] Desktop app (Electron shell)
- [ ] Controller (backend / API)
- [ ] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [ ] Build / CI / Tooling

## Checklist

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

## Notes for reviewers

`pnpm typecheck` and `pnpm lint` are currently blocked in this local workspace by an environment/tooling issue unrelated to this plist-only change: the repo is missing installed workspace dependencies / is using an older TypeScript binary, so the workspace config in `tsconfig.base.json` is not understood. No application logic changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS application entitlements configuration to enable entitlements inheritance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->