### PR TITLE
fix(desktop): ignore external Chromium crash noise

### DIFF
--- a/apps/desktop/main/index.ts
+++ b/apps/desktop/main/index.ts
@@ -170,6 +170,87 @@ function readNativeCrashTestKind(event: Sentry.Event): string | null {
   return typeof crashpadKind === "string" ? crashpadKind : null;
 }
 
+function readElectronCrashpadSwitches(event: Sentry.Event): string[] {
+  const electronContext = event.contexts?.electron as
+    | Record<string, unknown>
+    | undefined;
+
+  if (!electronContext) {
+    return [];
+  }
+
+  return Object.entries(electronContext)
+    .filter(([key, value]) => key.startsWith("crashpad.switch-") && typeof value === "string")
+    .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey))
+    .map(([, value]) => value as string);
+}
+
+function readNativeCrashCodeFile(event: Sentry.Event): string | null {
+  const eventRecord = event as Record<string, unknown>;
+  const entries = eventRecord["entries"];
+
+  if (!Array.isArray(entries)) {
+    return null;
+  }
+
+  for (const entry of entries) {
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+
+    const entryRecord = entry as Record<string, unknown>;
+
+    if (entryRecord["type"] !== "debugmeta") {
+      continue;
+    }
+
+    const data = entryRecord["data"];
+
+    if (!data || typeof data !== "object") {
+      continue;
+    }
+
+    const images = (data as Record<string, unknown>)["images"];
+
+    if (!Array.isArray(images)) {
+      continue;
+    }
+
+    for (const image of images) {
+      if (!image || typeof image !== "object") {
+        continue;
+      }
+
+      const codeFile = (image as Record<string, unknown>)["code_file"];
+
+      if (typeof codeFile === "string") {
+        return codeFile;
+      }
+    }
+  }
+
+  return null;
+}
+
+function shouldIgnoreExternalBrowserCrash(event: Sentry.Event): boolean {
+  if (event.tags?.mechanism !== "minidump") {
+    return false;
+  }
+
+  const crashpadSwitches = new Set(readElectronCrashpadSwitches(event));
+  const codeFile = readNativeCrashCodeFile(event);
+  const isRodChromiumCrash =
+    typeof codeFile === "string" &&
+    (codeFile.includes("/.cache/rod/browser/") ||
+      codeFile.endsWith("/Chromium.app/Contents/MacOS/Chromium"));
+
+  return (
+    isRodChromiumCrash &&
+    crashpadSwitches.has("--headless") &&
+    crashpadSwitches.has("--dump-dom")
+  );
+}
+
 if (sentryDsn) {
   const sentryBuildMetadata = getDesktopSentryBuildMetadata(
     runtimeConfig.buildInfo,
@@ -181,6 +262,10 @@ if (sentryDsn) {
     release: sentryBuildMetadata.release,
     ...(sentryBuildMetadata.dist ? { dist: sentryBuildMetadata.dist } : {}),
     beforeSend(event) {
+      if (shouldIgnoreExternalBrowserCrash(event)) {
+        return null;
+      }
+
       const testTitle = readNativeCrashTestTitle(event);
 
       if (!testTitle) {


### PR DESCRIPTION
## What

Filter a specific class of false-positive native crash reports from desktop Sentry when the crashing process is an external rod-managed headless Chromium binary rather than Nexu itself.

## Why

Closes #559.

The linked Sentry event was reported as a desktop fatal crash, but the minidump debug metadata showed the crashing executable was `~/.cache/rod/browser/.../Chromium.app/Contents/MacOS/Chromium` with headless automation flags like `--headless` and `--dump-dom`. This creates noisy desktop crash alerts for failures outside the Nexu packaged binary.

## How

Add a `beforeSend` guard in `apps/desktop/main/index.ts` that:

- reads crashpad switches from the Electron context
- reads the crashing executable path from native `debugmeta`
- drops the event only when it matches the rod Chromium executable path plus the headless dump-dom signature

Real Nexu native crashes and existing native crash test handling remain unchanged.

## Affected areas

- [x] Desktop app (Electron shell)
- [ ] Controller (backend / API)
- [ ] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [ ] Build / CI / Tooling

## Checklist

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

## Notes for reviewers

Verification in this worktree is partially blocked by local environment issues:

- `pnpm exec biome check apps/desktop/main/index.ts` passes
- workspace `typecheck` / `lint` fail because the local TypeScript/tooling is missing or incompatible
- `pnpm test` fails because `vitest` is not available in this worktree


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crash event filtering to exclude irrelevant crashes from error reports, enhancing diagnostic accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->