### PR TITLE
fix(desktop): avoid unhandled launchd readiness rejection

### DIFF
--- a/apps/desktop/main/index.ts
+++ b/apps/desktop/main/index.ts
@@ -602,10 +602,13 @@ async function runLaunchdColdStart(): Promise<void> {
     diagnosticsReporter?.markColdStartRunning(
       "waiting for controller readiness",
     );
-    const controllerReady = await launchdResult.controllerReady;
-    if (!controllerReady.ok) {
-      throw controllerReady.error;
-    }
+  }
+
+  const controllerReady = await launchdResult.controllerReady;
+  if (!controllerReady.ok) {
+    throw controllerReady.error;
+  }
+  if (!launchdResult.isAttach) {
     logColdStart("controller ready");
   }
 

--- a/apps/desktop/main/services/launchd-bootstrap.ts
+++ b/apps/desktop/main/services/launchd-bootstrap.ts
@@ -95,9 +95,7 @@ export interface LaunchdBootstrapResult {
   isAttach: boolean;
 }
 
-type ControllerReadyResult =
-  | { ok: true }
-  | { ok: false; error: Error };
+type ControllerReadyResult = { ok: true } | { ok: false; error: Error };
 
 /** Metadata persisted between sessions for attach discovery */
 interface RuntimePortsMetadata {

--- a/tests/desktop/launchd-startup-scenarios.test.ts
+++ b/tests/desktop/launchd-startup-scenarios.test.ts
@@ -807,7 +807,7 @@ describe("Launchd Startup Scenarios", () => {
     const result = await bootstrapWithLaunchd(makeBootstrapEnv() as never);
 
     // controllerReady should be a promise that resolves (fetch mock returns 200)
-    await expect(result.controllerReady).resolves.toBeUndefined();
+    await expect(result.controllerReady).resolves.toEqual({ ok: true });
   });
 
   // -----------------------------------------------------------------------
@@ -831,7 +831,7 @@ describe("Launchd Startup Scenarios", () => {
     const result = await bootstrapWithLaunchd(makeBootstrapEnv() as never);
 
     // controllerReady should resolve immediately (already healthy)
-    await expect(result.controllerReady).resolves.toBeUndefined();
+    await expect(result.controllerReady).resolves.toEqual({ ok: true });
     expect(result.isAttach).toBe(true);
   });
 


### PR DESCRIPTION
## What

Avoid an unhandled rejection during launchd cold start by making the controller readiness promise settle to a structured result and only throwing when the startup flow explicitly awaits it.

## Why

Closes #558.

Packaged desktop startup could emit a Sentry error when the launchd controller readiness probe timed out before the promise was awaited. That produced a noisy unhandled rejection even though the startup path later handled the failure.

## How

- change `controllerReady` in the launchd bootstrap to always resolve with an `{ ok: true | false }` result
- preserve the existing startup failure behavior by re-throwing at the explicit await site in `runLaunchdColdStart()`
- keep the fix scoped to launchd desktop startup flow

## Affected areas

- [x] Desktop app (Electron shell)
- [ ] Controller (backend / API)
- [ ] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [ ] Build / CI / Tooling

## Checklist

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

## Notes for reviewers

Local verification is blocked by this workspace environment:
- `pnpm typecheck` / `pnpm lint` fail because dependencies/tooling are not installed correctly here (`node_modules` missing / incompatible TypeScript in `packages/shared`)
- `pnpm test` fails because `vitest` is not available in this environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop app startup reliability by explicitly validating controller readiness, aborting startup on readiness failure, and ensuring readiness is only logged when appropriate.
* **Tests**
  * Updated startup tests to expect an explicit success/failure readiness result instead of a silent/undefined resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->