### PR TITLE
fix: retry curated skill installs on every startup

### DIFF
--- a/apps/controller/src/services/skillhub-service.ts
+++ b/apps/controller/src/services/skillhub-service.ts
@@ -13,7 +13,6 @@ export class SkillhubService {
   private readonly dirWatcher: SkillDirWatcher;
   private readonly db: SkillDb;
   private readonly env: ControllerEnv;
-  private readonly isFirstLaunch: boolean;
 
   private constructor(
     env: ControllerEnv,
@@ -21,20 +20,15 @@ export class SkillhubService {
     installQueue: InstallQueue,
     dirWatcher: SkillDirWatcher,
     db: SkillDb,
-    isFirstLaunch: boolean,
   ) {
     this.env = env;
     this.catalogManager = catalogManager;
     this.installQueue = installQueue;
     this.dirWatcher = dirWatcher;
     this.db = db;
-    this.isFirstLaunch = isFirstLaunch;
   }
 
   static async create(env: ControllerEnv): Promise<SkillhubService> {
-    // Check if ledger exists BEFORE SkillDb.create() (which creates it)
-    const isFirstLaunch = !existsSync(env.skillDbPath);
-
     const skillDb = await SkillDb.create(env.skillDbPath);
     const log = (level: "info" | "error" | "warn", message: string) => {
       console[level === "error" ? "error" : "log"](`[skillhub] ${message}`);
@@ -76,7 +70,6 @@ export class SkillhubService {
       installQueue,
       dirWatcher,
       skillDb,
-      isFirstLaunch,
     );
   }
 
@@ -84,22 +77,23 @@ export class SkillhubService {
     this.catalogManager.start();
     if (process.env.CI) return;
 
-    // Always reconcile disk state with ledger FIRST on every startup.
+    // Reconcile disk state with ledger FIRST on every startup.
     // This ensures on-disk skills are recorded before curated enqueue
     // checks the ledger, preventing unnecessary re-downloads.
     this.dirWatcher.syncNow();
 
-    if (this.isFirstLaunch) {
-      this.initialize();
-    }
+    // Copy static skills + enqueue missing curated skills (idempotent)
+    this.initialize();
 
     // Always start watching for external skill changes (agent installs)
     this.dirWatcher.start();
   }
 
   /**
-   * First-launch initialization: copy static skills, enqueue curated skills.
-   * Only runs when the skill ledger did not exist (fresh install or reinstall).
+   * Copy static skills and enqueue missing curated skills.
+   * Runs on every non-CI startup. Both operations are idempotent:
+   * - copyStaticSkills skips when SKILL.md exists on disk OR slug is known in ledger
+   * - getCuratedSlugsToEnqueue filters against all known slugs in ledger
    */
   private initialize(): void {
     // Step 1: Copy static bundled skills to skills dir + record in DB

--- a/apps/controller/src/services/skillhub/curated-skills.ts
+++ b/apps/controller/src/services/skillhub/curated-skills.ts
@@ -70,9 +70,17 @@ export function copyStaticSkills(params: {
     return { copied, skipped };
   }
 
+  const knownSlugs = params.skillDb.getAllKnownSlugs();
+
   for (const slug of STATIC_SKILL_SLUGS) {
     const destDir = resolve(params.targetDir, slug);
     if (existsSync(resolve(destDir, "SKILL.md"))) {
+      skipped.push(slug);
+      continue;
+    }
+
+    // Skip if ledger already knows this slug (user uninstalled it, or it's tracked)
+    if (knownSlugs.has(slug)) {
       skipped.push(slug);
       continue;
     }

--- a/apps/controller/tests/skillhub-service.test.ts
+++ b/apps/controller/tests/skillhub-service.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -458,6 +458,25 @@ describe("SkillhubService", () => {
     expect(catalog.getCuratedSlugsToEnqueue).not.toHaveBeenCalled();
     expect(queue.enqueue).not.toHaveBeenCalled();
     expect(watcher.start).not.toHaveBeenCalled();
+  });
+
+  it("start() enqueues curated skills even when ledger already exists", async () => {
+    const env = createEnv(rootDir);
+    // Pre-create the ledger so this simulates a second launch
+    mkdirSync(path.dirname(env.skillDbPath), { recursive: true });
+    writeFileSync(env.skillDbPath, JSON.stringify({ skills: [] }));
+
+    const db = createMockSkillDb();
+    mocks.mockSkillDbCreate.mockResolvedValueOnce(db);
+
+    const service = await SkillhubService.create(env);
+    const catalog = mocks.catalogManagerInstances[0];
+    catalog.getCuratedSlugsToEnqueue.mockReturnValue(["failed-skill"]);
+
+    service.start();
+
+    const queue = mocks.installQueueInstances[0];
+    expect(queue.enqueue).toHaveBeenCalledWith("failed-skill", "managed");
   });
 
   it("enqueueInstall() delegates to queue with source 'managed'", async () => {

--- a/apps/desktop/main/runtime/manifests.ts
+++ b/apps/desktop/main/runtime/manifests.ts
@@ -234,7 +234,14 @@ export function createRuntimeUnitManifests(
     path.resolve(openclawRuntimeRoot, "state"),
   );
   const openclawTempDir = ensureDir(path.resolve(openclawRuntimeRoot, "tmp"));
-  ensureDir(getOpenclawSkillsDir(userDataPath));
+  ensureDir(
+    isPackaged
+      ? getOpenclawSkillsDir(userDataPath)
+      : path.resolve(
+          runtimeConfig.paths.nexuHome,
+          "runtime/openclaw/state/skills",
+        ),
+  );
   ensureDir(path.resolve(openclawStateDir, "plugin-docs"));
   ensureDir(path.resolve(openclawStateDir, "agents"));
   const openclawPackageRoot = path.resolve(
@@ -322,7 +329,14 @@ export function createRuntimeUnitManifests(
         NEXU_HOME: runtimeConfig.paths.nexuHome,
         OPENCLAW_STATE_DIR: openclawStateDir,
         OPENCLAW_CONFIG_PATH: path.resolve(openclawConfigDir, "openclaw.json"),
-        OPENCLAW_SKILLS_DIR: getOpenclawSkillsDir(userDataPath),
+        OPENCLAW_SKILLS_DIR: isPackaged
+          ? getOpenclawSkillsDir(userDataPath)
+          : ensureDir(
+              path.resolve(
+                runtimeConfig.paths.nexuHome,
+                "runtime/openclaw/state/skills",
+              ),
+            ),
         SKILLHUB_STATIC_SKILLS_DIR: isPackaged
           ? path.resolve(electronRoot, "static/bundled-skills")
           : path.resolve(repoRoot, "apps/desktop/static/bundled-skills"),


### PR DESCRIPTION
Relates to #612

## What
Curated skills that failed ClawHub download during first launch were never retried on subsequent boots.

## Why
`initialize()` (which enqueues curated skills) only ran when `isFirstLaunch` was true — i.e., when the skill ledger file didn't exist. Failed installs wrote no ledger record, so they'd be eligible for retry, but the code never re-checked after the first launch.

## How
- Remove `isFirstLaunch` gate — `initialize()` now runs on every non-CI startup
- Add ledger check in `copyStaticSkills` so user-uninstalled static skills are not re-copied
- Both operations are idempotent: `copyStaticSkills` skips when SKILL.md exists on disk OR slug is known in ledger; `getCuratedSlugsToEnqueue` filters against all known slugs
- Fix dev mode `OPENCLAW_SKILLS_DIR` to use `NEXU_HOME`-scoped path for consistent dev/packaged behavior

## Affected areas
- `apps/controller/src/services/skillhub-service.ts`
- `apps/controller/src/services/skillhub/curated-skills.ts`
- `apps/desktop/main/runtime/manifests.ts`

## Checklist
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (199 tests, including new retry test)
- [x] `pnpm lint` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced skill initialization to run consistently on every startup, ensuring reliable skill setup across launches.
  * Improved curated skills management to better track and prevent duplicate skill processing.
  * Refined skills directory path handling for development and production builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
