### PR TITLE
feat: add session delete action to conversation header

### DIFF
--- a/apps/controller/openapi.json
+++ b/apps/controller/openapi.json
@@ -4469,6 +4469,15 @@
             "required": true,
             "name": "id",
             "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": true,
+            "name": "botId",
+            "in": "query"
           }
         ],
         "responses": {

--- a/apps/controller/src/app/container.ts
+++ b/apps/controller/src/app/container.ts
@@ -118,6 +118,7 @@ export async function createContainer(): Promise<ControllerContainer> {
     configStore,
     sessionsRuntime,
   );
+  const artifactService = new ArtifactService(artifactsStore, env);
   const modelProviderService = new ModelProviderService(
     configStore,
     env,
@@ -146,7 +147,7 @@ export async function createContainer(): Promise<ControllerContainer> {
     agentService: new AgentService(configStore, openclawSyncService),
     channelService: new ChannelService(configStore, openclawSyncService),
     channelFallbackService,
-    sessionService: new SessionService(sessionsRuntime),
+    sessionService: new SessionService(sessionsRuntime, artifactService),
     runtimeConfigService: new RuntimeConfigService(
       configStore,
       openclawSyncService,
@@ -161,7 +162,7 @@ export async function createContainer(): Promise<ControllerContainer> {
       openclawProcess,
     ),
     analyticsService,
-    artifactService: new ArtifactService(artifactsStore),
+    artifactService,
     templateService: new TemplateService(configStore, openclawSyncService),
     skillhubService,
     openclawSyncService,

--- a/apps/controller/src/routes/session-routes.ts
+++ b/apps/controller/src/routes/session-routes.ts
@@ -17,6 +17,7 @@ const querySchema = z.object({
 });
 
 const sessionIdParamSchema = z.object({ id: z.string() });
+const sessionDeleteQuerySchema = z.object({ botId: z.string().min(1) });
 const errorSchema = z.object({ message: z.string() });
 
 export function registerSessionRoutes(
@@ -207,7 +208,10 @@ export function registerSessionRoutes(
       method: "delete",
       path: "/api/v1/sessions/{id}",
       tags: ["Sessions"],
-      request: { params: sessionIdParamSchema },
+      request: {
+        params: sessionIdParamSchema,
+        query: sessionDeleteQuerySchema,
+      },
       responses: {
         200: {
           content: {
@@ -219,8 +223,9 @@ export function registerSessionRoutes(
     }),
     async (c) => {
       const { id } = c.req.valid("param");
+      const { botId } = c.req.valid("query");
       return c.json(
-        { ok: await container.sessionService.deleteSession(id) },
+        { ok: await container.sessionService.deleteSession(id, botId) },
         200,
       );
     },

--- a/apps/controller/src/runtime/sessions-runtime.ts
+++ b/apps/controller/src/runtime/sessions-runtime.ts
@@ -278,10 +278,15 @@ export class SessionsRuntime {
     if (!session) {
       return false;
     }
-    const filePath = this.getSessionFilePath(session.botId, session.sessionKey);
+
+    await this.deleteSessionFiles(session.botId, session.sessionKey);
+    return true;
+  }
+
+  async deleteSessionFiles(botId: string, sessionKey: string): Promise<void> {
+    const filePath = this.getSessionFilePath(botId, sessionKey);
     await rm(filePath, { force: true });
     await rm(sessionMetadataPath(filePath), { force: true });
-    return true;
   }
 
   async getChatHistory(

--- a/apps/controller/src/runtime/sessions-runtime.ts
+++ b/apps/controller/src/runtime/sessions-runtime.ts
@@ -670,6 +670,18 @@ export class SessionsRuntime {
     return sessions.find((session) => session.id === id) ?? null;
   }
 
+  async getSessionForBot(
+    botId: string,
+    id: string,
+  ): Promise<SessionResponse | null> {
+    const sessions = await this.listSessions();
+    return (
+      sessions.find(
+        (session) => session.id === id && session.botId === botId,
+      ) ?? null
+    );
+  }
+
   private async getSessionByKey(
     botId: string,
     sessionKey: string,

--- a/apps/controller/src/services/artifact-service.ts
+++ b/apps/controller/src/services/artifact-service.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { CreateArtifactInput, UpdateArtifactInput } from "@nexu/shared";
 import type { ControllerEnv } from "../app/env.js";
+import { logger } from "../lib/logger.js";
 import type { ArtifactsStore } from "../store/artifacts-store.js";
 import type { ControllerArtifact } from "../store/schemas.js";
 
@@ -54,28 +55,87 @@ export class ArtifactService {
     deletedArtifacts: number;
     deletedFiles: number;
   }> {
-    const deletedArtifacts =
-      await this.artifactsStore.deleteArtifactsForSession(botId, sessionKey);
+    const sessionArtifacts = (await this.artifactsStore.listArtifacts()).filter(
+      (artifact) =>
+        artifact.botId === botId && artifact.sessionKey === sessionKey,
+    );
+    const removableArtifactIds: string[] = [];
     let deletedFiles = 0;
 
-    for (const artifact of deletedArtifacts) {
-      const filePaths = this.collectManagedFilePaths(artifact);
+    for (const artifact of sessionArtifacts) {
+      const filePaths = this.collectManagedFilePaths(
+        artifact,
+        botId,
+        sessionKey,
+      );
+      let hasCleanupFailure = false;
+
       for (const filePath of filePaths) {
         try {
           const stats = await lstat(filePath);
+          if (stats.isDirectory()) {
+            hasCleanupFailure = true;
+            logger.warn(
+              {
+                artifactId: artifact.id,
+                botId,
+                sessionKey,
+                filePath,
+              },
+              "session_delete_artifact_cleanup_skipped_directory_path",
+            );
+            continue;
+          }
+
           await rm(filePath, {
             force: true,
-            recursive: stats.isDirectory(),
           });
           deletedFiles += 1;
-        } catch {
-          // Ignore per-file cleanup failures so session deletion still completes.
+        } catch (error) {
+          const errorCode =
+            error instanceof Error && "code" in error
+              ? String(error.code)
+              : undefined;
+          if (errorCode === "ENOENT") {
+            continue;
+          }
+
+          hasCleanupFailure = true;
+          logger.warn(
+            {
+              artifactId: artifact.id,
+              botId,
+              sessionKey,
+              filePath,
+              error: error instanceof Error ? error.message : String(error),
+            },
+            "session_delete_artifact_file_cleanup_failed",
+          );
         }
+      }
+
+      if (!hasCleanupFailure) {
+        removableArtifactIds.push(artifact.id);
       }
     }
 
+    const deletedArtifacts =
+      await this.artifactsStore.deleteArtifactsByIds(removableArtifactIds);
+
+    const retainedArtifacts = sessionArtifacts.length - deletedArtifacts;
+    if (retainedArtifacts > 0) {
+      logger.warn(
+        {
+          botId,
+          sessionKey,
+          retainedArtifacts,
+        },
+        "session_delete_artifact_index_retained_for_retry",
+      );
+    }
+
     return {
-      deletedArtifacts: deletedArtifacts.length,
+      deletedArtifacts,
       deletedFiles,
     };
   }
@@ -103,15 +163,23 @@ export class ArtifactService {
     };
   }
 
-  private collectManagedFilePaths(artifact: ControllerArtifact): string[] {
+  private collectManagedFilePaths(
+    artifact: ControllerArtifact,
+    botId: string,
+    sessionKey: string,
+  ): string[] {
     const candidatePaths = new Set<string>();
 
     this.addCandidatePath(candidatePaths, artifact.previewUrl);
-    this.addCandidatePath(candidatePaths, artifact.deployTarget);
     this.addCandidateFromMetadata(candidatePaths, artifact.metadata);
 
     return [...candidatePaths].filter((candidate) =>
-      this.isManagedPath(candidate),
+      this.isSessionOwnedArtifactPath(
+        candidate,
+        botId,
+        sessionKey,
+        artifact.id,
+      ),
     );
   }
 
@@ -125,22 +193,18 @@ export class ArtifactService {
 
     const directKeys = [
       "filePath",
-      "path",
       "localPath",
       "outputPath",
       "artifactPath",
       "imagePath",
       "previewPath",
-      "directoryPath",
-      "dirPath",
-      "workspacePath",
     ] as const;
 
     for (const key of directKeys) {
       this.addCandidateUnknown(candidatePaths, metadata[key]);
     }
 
-    const nestedKeys = ["files", "paths", "outputs", "artifacts"] as const;
+    const nestedKeys = ["files", "outputs", "artifacts"] as const;
     for (const key of nestedKeys) {
       this.addCandidateUnknown(candidatePaths, metadata[key]);
     }
@@ -164,11 +228,12 @@ export class ArtifactService {
 
     if (typeof value === "object" && value !== null) {
       const record = value as Record<string, unknown>;
-      this.addCandidateUnknown(candidatePaths, record.path);
       this.addCandidateUnknown(candidatePaths, record.filePath);
       this.addCandidateUnknown(candidatePaths, record.localPath);
       this.addCandidateUnknown(candidatePaths, record.outputPath);
-      this.addCandidateUnknown(candidatePaths, record.directoryPath);
+      this.addCandidateUnknown(candidatePaths, record.artifactPath);
+      this.addCandidateUnknown(candidatePaths, record.imagePath);
+      this.addCandidateUnknown(candidatePaths, record.previewPath);
     }
   }
 
@@ -206,20 +271,33 @@ export class ArtifactService {
     return path.resolve(value);
   }
 
-  private isManagedPath(candidate: string): boolean {
-    const managedRoots = [
-      this.env.nexuHomeDir,
-      this.env.openclawStateDir,
+  private isSessionOwnedArtifactPath(
+    candidate: string,
+    botId: string,
+    sessionKey: string,
+    artifactId: string,
+  ): boolean {
+    const artifactsRoot = path.resolve(
       path.dirname(this.env.artifactsIndexPath),
-    ].map((root) => path.resolve(root));
+    );
+    if (candidate === artifactsRoot) {
+      return false;
+    }
 
-    return managedRoots.some((root) => {
-      if (candidate === root) {
-        return false;
-      }
+    const relative = path.relative(artifactsRoot, candidate);
+    if (
+      relative.length === 0 ||
+      relative.startsWith("..") ||
+      path.isAbsolute(relative)
+    ) {
+      return false;
+    }
 
-      const relative = path.relative(root, candidate);
-      return !relative.startsWith("..") && !path.isAbsolute(relative);
-    });
+    const lowerRelative = relative.toLowerCase();
+    const scopeTokens = [sessionKey, botId, artifactId]
+      .map((token) => token.trim().toLowerCase())
+      .filter((token) => token.length > 0);
+
+    return scopeTokens.some((token) => lowerRelative.includes(token));
   }
 }

--- a/apps/controller/src/services/artifact-service.ts
+++ b/apps/controller/src/services/artifact-service.ts
@@ -1,8 +1,16 @@
+import { rm } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import type { CreateArtifactInput, UpdateArtifactInput } from "@nexu/shared";
+import type { ControllerEnv } from "../app/env.js";
 import type { ArtifactsStore } from "../store/artifacts-store.js";
+import type { ControllerArtifact } from "../store/schemas.js";
 
 export class ArtifactService {
-  constructor(private readonly artifactsStore: ArtifactsStore) {}
+  constructor(
+    private readonly artifactsStore: ArtifactsStore,
+    private readonly env: ControllerEnv,
+  ) {}
 
   async listArtifacts(params: {
     limit: number;
@@ -39,6 +47,35 @@ export class ArtifactService {
     return this.artifactsStore.deleteArtifact(id);
   }
 
+  async deleteArtifactsForSession(
+    botId: string,
+    sessionKey: string,
+  ): Promise<{
+    deletedArtifacts: number;
+    deletedFiles: number;
+  }> {
+    const deletedArtifacts =
+      await this.artifactsStore.deleteArtifactsForSession(botId, sessionKey);
+    let deletedFiles = 0;
+
+    for (const artifact of deletedArtifacts) {
+      const filePaths = this.collectManagedFilePaths(artifact);
+      for (const filePath of filePaths) {
+        try {
+          await rm(filePath, { force: true, recursive: true });
+          deletedFiles += 1;
+        } catch {
+          // Ignore per-file cleanup failures so session deletion still completes.
+        }
+      }
+    }
+
+    return {
+      deletedArtifacts: deletedArtifacts.length,
+      deletedFiles,
+    };
+  }
+
   async getStats() {
     const artifacts = await this.artifactsStore.listArtifacts();
     return {
@@ -60,5 +97,124 @@ export class ArtifactService {
         0,
       ),
     };
+  }
+
+  private collectManagedFilePaths(artifact: ControllerArtifact): string[] {
+    const candidatePaths = new Set<string>();
+
+    this.addCandidatePath(candidatePaths, artifact.previewUrl);
+    this.addCandidatePath(candidatePaths, artifact.deployTarget);
+    this.addCandidateFromMetadata(candidatePaths, artifact.metadata);
+
+    return [...candidatePaths].filter((candidate) =>
+      this.isManagedPath(candidate),
+    );
+  }
+
+  private addCandidateFromMetadata(
+    candidatePaths: Set<string>,
+    metadata: Record<string, unknown> | null,
+  ): void {
+    if (!metadata) {
+      return;
+    }
+
+    const directKeys = [
+      "filePath",
+      "path",
+      "localPath",
+      "outputPath",
+      "artifactPath",
+      "imagePath",
+      "previewPath",
+      "directoryPath",
+      "dirPath",
+      "workspacePath",
+    ] as const;
+
+    for (const key of directKeys) {
+      this.addCandidateUnknown(candidatePaths, metadata[key]);
+    }
+
+    const nestedKeys = ["files", "paths", "outputs", "artifacts"] as const;
+    for (const key of nestedKeys) {
+      this.addCandidateUnknown(candidatePaths, metadata[key]);
+    }
+  }
+
+  private addCandidateUnknown(
+    candidatePaths: Set<string>,
+    value: unknown,
+  ): void {
+    if (typeof value === "string") {
+      this.addCandidatePath(candidatePaths, value);
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        this.addCandidateUnknown(candidatePaths, item);
+      }
+      return;
+    }
+
+    if (typeof value === "object" && value !== null) {
+      const record = value as Record<string, unknown>;
+      this.addCandidateUnknown(candidatePaths, record.path);
+      this.addCandidateUnknown(candidatePaths, record.filePath);
+      this.addCandidateUnknown(candidatePaths, record.localPath);
+      this.addCandidateUnknown(candidatePaths, record.outputPath);
+      this.addCandidateUnknown(candidatePaths, record.directoryPath);
+    }
+  }
+
+  private addCandidatePath(
+    candidatePaths: Set<string>,
+    value: string | null | undefined,
+  ): void {
+    const normalized = this.parseLocalPath(value);
+    if (normalized) {
+      candidatePaths.add(normalized);
+    }
+  }
+
+  private parseLocalPath(value: string | null | undefined): string | null {
+    if (!value) {
+      return null;
+    }
+
+    if (value.startsWith("file://")) {
+      try {
+        return path.resolve(fileURLToPath(value));
+      } catch {
+        return null;
+      }
+    }
+
+    if (/^[a-z]+:\/\//i.test(value)) {
+      return null;
+    }
+
+    if (!path.isAbsolute(value)) {
+      return null;
+    }
+
+    return path.resolve(value);
+  }
+
+  private isManagedPath(candidate: string): boolean {
+    const managedRoots = [
+      this.env.nexuHomeDir,
+      this.env.openclawStateDir,
+      path.dirname(this.env.artifactsIndexPath),
+    ].map((root) => path.resolve(root));
+
+    return managedRoots.some((root) => {
+      const relative = path.relative(root, candidate);
+      return (
+        relative === "" ||
+        (!relative.startsWith("..") && !path.isAbsolute(relative))
+      );
+    });
   }
 }

--- a/apps/controller/src/services/artifact-service.ts
+++ b/apps/controller/src/services/artifact-service.ts
@@ -1,4 +1,4 @@
-import { rm } from "node:fs/promises";
+import { lstat, rm } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { CreateArtifactInput, UpdateArtifactInput } from "@nexu/shared";
@@ -62,7 +62,11 @@ export class ArtifactService {
       const filePaths = this.collectManagedFilePaths(artifact);
       for (const filePath of filePaths) {
         try {
-          await rm(filePath, { force: true, recursive: true });
+          const stats = await lstat(filePath);
+          await rm(filePath, {
+            force: true,
+            recursive: stats.isDirectory(),
+          });
           deletedFiles += 1;
         } catch {
           // Ignore per-file cleanup failures so session deletion still completes.
@@ -210,11 +214,12 @@ export class ArtifactService {
     ].map((root) => path.resolve(root));
 
     return managedRoots.some((root) => {
+      if (candidate === root) {
+        return false;
+      }
+
       const relative = path.relative(root, candidate);
-      return (
-        relative === "" ||
-        (!relative.startsWith("..") && !path.isAbsolute(relative))
-      );
+      return !relative.startsWith("..") && !path.isAbsolute(relative);
     });
   }
 }

--- a/apps/controller/src/services/session-service.ts
+++ b/apps/controller/src/services/session-service.ts
@@ -1,4 +1,5 @@
 import type { CreateSessionInput, UpdateSessionInput } from "@nexu/shared";
+import { logger } from "../lib/logger.js";
 import type { SessionsRuntime } from "../runtime/sessions-runtime.js";
 import type { ArtifactService } from "./artifact-service.js";
 
@@ -63,10 +64,24 @@ export class SessionService {
       session.botId,
       session.sessionKey,
     );
-    await this.artifactService?.deleteArtifactsForSession(
-      session.botId,
-      session.sessionKey,
-    );
+
+    try {
+      await this.artifactService?.deleteArtifactsForSession(
+        session.botId,
+        session.sessionKey,
+      );
+    } catch (error) {
+      logger.warn(
+        {
+          sessionId: id,
+          botId: session.botId,
+          sessionKey: session.sessionKey,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "session_delete_artifact_cleanup_failed",
+      );
+    }
+
     return true;
   }
 

--- a/apps/controller/src/services/session-service.ts
+++ b/apps/controller/src/services/session-service.ts
@@ -54,8 +54,8 @@ export class SessionService {
     return this.sessionsRuntime.resetSession(id);
   }
 
-  async deleteSession(id: string) {
-    const session = await this.sessionsRuntime.getSession(id);
+  async deleteSession(id: string, botId: string) {
+    const session = await this.sessionsRuntime.getSessionForBot(botId, id);
     if (!session) {
       return false;
     }

--- a/apps/controller/src/services/session-service.ts
+++ b/apps/controller/src/services/session-service.ts
@@ -1,8 +1,12 @@
 import type { CreateSessionInput, UpdateSessionInput } from "@nexu/shared";
 import type { SessionsRuntime } from "../runtime/sessions-runtime.js";
+import type { ArtifactService } from "./artifact-service.js";
 
 export class SessionService {
-  constructor(private readonly sessionsRuntime: SessionsRuntime) {}
+  constructor(
+    private readonly sessionsRuntime: SessionsRuntime,
+    private readonly artifactService?: ArtifactService,
+  ) {}
 
   async listSessions(params: {
     limit: number;
@@ -50,7 +54,20 @@ export class SessionService {
   }
 
   async deleteSession(id: string) {
-    return this.sessionsRuntime.deleteSession(id);
+    const session = await this.sessionsRuntime.getSession(id);
+    if (!session) {
+      return false;
+    }
+
+    await this.sessionsRuntime.deleteSessionFiles(
+      session.botId,
+      session.sessionKey,
+    );
+    await this.artifactService?.deleteArtifactsForSession(
+      session.botId,
+      session.sessionKey,
+    );
+    return true;
   }
 
   async getChatHistory(id: string, limit?: number) {

--- a/apps/controller/src/store/artifacts-store.ts
+++ b/apps/controller/src/store/artifacts-store.ts
@@ -119,4 +119,25 @@ export class ArtifactsStore {
 
     return deleted;
   }
+
+  async deleteArtifactsForSession(
+    botId: string,
+    sessionKey: string,
+  ): Promise<ArtifactsIndex["artifacts"]> {
+    const deletedArtifacts: ArtifactsIndex["artifacts"] = [];
+
+    await this.store.update((data) => ({
+      ...data,
+      artifacts: data.artifacts.filter((artifact) => {
+        if (artifact.botId === botId && artifact.sessionKey === sessionKey) {
+          deletedArtifacts.push(artifact);
+          return false;
+        }
+
+        return true;
+      }),
+    }));
+
+    return deletedArtifacts;
+  }
 }

--- a/apps/controller/src/store/artifacts-store.ts
+++ b/apps/controller/src/store/artifacts-store.ts
@@ -120,24 +120,25 @@ export class ArtifactsStore {
     return deleted;
   }
 
-  async deleteArtifactsForSession(
-    botId: string,
-    sessionKey: string,
-  ): Promise<ArtifactsIndex["artifacts"]> {
-    const deletedArtifacts: ArtifactsIndex["artifacts"] = [];
+  async deleteArtifactsByIds(ids: string[]): Promise<number> {
+    if (ids.length === 0) {
+      return 0;
+    }
+
+    const idSet = new Set(ids);
+    let deletedCount = 0;
 
     await this.store.update((data) => ({
       ...data,
       artifacts: data.artifacts.filter((artifact) => {
-        if (artifact.botId === botId && artifact.sessionKey === sessionKey) {
-          deletedArtifacts.push(artifact);
+        if (idSet.has(artifact.id)) {
+          deletedCount += 1;
           return false;
         }
-
         return true;
       }),
     }));
 
-    return deletedArtifacts;
+    return deletedCount;
   }
 }

--- a/apps/controller/tests/route-compat.test.ts
+++ b/apps/controller/tests/route-compat.test.ts
@@ -44,8 +44,6 @@ async function createTestContainer(
     port: 3010,
     host: "127.0.0.1",
     webUrl: "http://localhost:5173",
-    nexuCloudUrl: "https://nexu.io",
-    nexuLinkUrl: "https://link.nexu.io",
     nexuHomeDir: path.join(rootDir, ".nexu"),
     nexuConfigPath: path.join(rootDir, ".nexu", "config.json"),
     artifactsIndexPath: path.join(rootDir, ".nexu", "artifacts", "index.json"),
@@ -59,7 +57,6 @@ async function createTestContainer(
     openclawSkillsDir: path.join(rootDir, ".openclaw", "skills"),
     openclawExtensionsDir: path.join(rootDir, ".openclaw", "extensions"),
     runtimePluginTemplatesDir: path.join(rootDir, "runtime-plugins"),
-    openclawCuratedSkillsDir: path.join(rootDir, ".openclaw", "bundled-skills"),
     openclawRuntimeModelStatePath: path.join(
       rootDir,
       ".openclaw",
@@ -67,6 +64,7 @@ async function createTestContainer(
     ),
     skillhubCacheDir: path.join(rootDir, ".nexu", "skillhub-cache"),
     skillDbPath: path.join(rootDir, ".nexu", "skill-ledger.json"),
+    analyticsStatePath: path.join(rootDir, ".nexu", "analytics-state.json"),
     staticSkillsDir: undefined,
     platformTemplatesDir: undefined,
     openclawWorkspaceTemplatesDir: path.join(
@@ -84,6 +82,7 @@ async function createTestContainer(
     runtimeSyncIntervalMs: 2000,
     runtimeHealthIntervalMs: 5000,
     defaultModelId: "anthropic/claude-sonnet-4",
+    amplitudeApiKey: undefined,
   };
 
   const configStore = new NexuConfigStore(env);
@@ -104,10 +103,13 @@ async function createTestContainer(
     isConnected: () => false,
     stop: vi.fn(),
   } as unknown as ControllerContainer["wsClient"];
-  const gatewayService = new OpenClawGatewayService({
-    isConnected: () => false,
-    request: vi.fn(),
-  } as never);
+  const gatewayService = new OpenClawGatewayService(
+    {
+      isConnected: () => false,
+      request: vi.fn(),
+    } as never,
+    runtimeState,
+  );
   const openclawSyncService = new OpenClawSyncService(
     env,
     configStore,
@@ -123,7 +125,9 @@ async function createTestContainer(
   );
   const modelProviderService = new ModelProviderService(
     configStore,
-    env.nodeEnv,
+    env,
+    openclawSyncService,
+    openclawProcess,
   );
   const runtimeModelStateService = new RuntimeModelStateService(env);
   const channelFallbackService = new ChannelFallbackService(
@@ -148,6 +152,10 @@ async function createTestContainer(
     start: vi.fn(),
   } as unknown as SkillhubService;
   const openclawAuthService = new OpenClawAuthService(env, authProfilesStore);
+  modelProviderService.setAuthService(openclawAuthService);
+  const analyticsService = {
+    poll: vi.fn(async () => {}),
+  } as unknown as ControllerContainer["analyticsService"];
 
   return {
     env,
@@ -174,7 +182,8 @@ async function createTestContainer(
       modelProviderService,
       openclawProcess,
     ),
-    artifactService: new ArtifactService(artifactsStore),
+    analyticsService,
+    artifactService: new ArtifactService(artifactsStore, env),
     templateService: new TemplateService(configStore, openclawSyncService),
     skillhubService,
     openclawSyncService,

--- a/apps/controller/tests/route-compat.test.ts
+++ b/apps/controller/tests/route-compat.test.ts
@@ -156,6 +156,7 @@ async function createTestContainer(
   const analyticsService = {
     poll: vi.fn(async () => {}),
   } as unknown as ControllerContainer["analyticsService"];
+  const artifactService = new ArtifactService(artifactsStore, env);
 
   return {
     env,
@@ -168,7 +169,7 @@ async function createTestContainer(
     agentService: new AgentService(configStore, openclawSyncService),
     channelService: new ChannelService(configStore, openclawSyncService),
     channelFallbackService,
-    sessionService: new SessionService(sessionsRuntime),
+    sessionService: new SessionService(sessionsRuntime, artifactService),
     runtimeConfigService: new RuntimeConfigService(
       configStore,
       openclawSyncService,
@@ -183,7 +184,7 @@ async function createTestContainer(
       openclawProcess,
     ),
     analyticsService,
-    artifactService: new ArtifactService(artifactsStore, env),
+    artifactService,
     templateService: new TemplateService(configStore, openclawSyncService),
     skillhubService,
     openclawSyncService,

--- a/apps/controller/tests/session-routes.test.ts
+++ b/apps/controller/tests/session-routes.test.ts
@@ -9,6 +9,7 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { logger } from "../src/lib/logger.js";
 import type { ControllerContainer } from "../src/app/container.js";
 import { createApp } from "../src/app/create-app.js";
 import type { ControllerEnv } from "../src/app/env.js";
@@ -245,6 +246,61 @@ describe("session routes", () => {
     });
     expect(artifacts.artifacts).toHaveLength(1);
     expect(artifacts.artifacts[0]?.botId).toBe("bot-other");
+  });
+
+  it("still succeeds when artifact cleanup fails after session files are removed", async () => {
+    rootDir = await mkdtemp(path.join(tmpdir(), "nexu-session-delete-warning-"));
+    const container = createTestContainer(rootDir);
+    const app = createApp(container);
+
+    const createSession = await app.request("/api/internal/sessions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        botId: "bot-warning",
+        sessionKey: "warn-me",
+        title: "Warn me",
+        channelType: "slack",
+      }),
+    });
+
+    expect(createSession.status).toBe(201);
+
+    const transcriptPath = path.join(
+      rootDir,
+      ".openclaw",
+      "agents",
+      "bot-warning",
+      "sessions",
+      "warn-me.jsonl",
+    );
+    const metadataPath = transcriptPath.replace(/\.jsonl$/, ".meta.json");
+
+    const deleteArtifactsForSessionMock = vi
+      .spyOn(container.artifactService, "deleteArtifactsForSession")
+      .mockRejectedValueOnce(new Error("artifact cleanup failed"));
+    const loggerWarnMock = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+    const response = await app.request("/api/v1/sessions/warn-me.jsonl", {
+      method: "DELETE",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(stat(transcriptPath)).rejects.toThrow();
+    await expect(stat(metadataPath)).rejects.toThrow();
+    expect(deleteArtifactsForSessionMock).toHaveBeenCalledWith(
+      "bot-warning",
+      "warn-me",
+    );
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "warn-me.jsonl",
+        botId: "bot-warning",
+        sessionKey: "warn-me",
+        error: "artifact cleanup failed",
+      }),
+      "session_delete_artifact_cleanup_failed",
+    );
   });
 
   it("serves cleaned chat history through the session messages API", async () => {

--- a/apps/controller/tests/session-routes.test.ts
+++ b/apps/controller/tests/session-routes.test.ts
@@ -9,10 +9,10 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { logger } from "../src/lib/logger.js";
 import type { ControllerContainer } from "../src/app/container.js";
 import { createApp } from "../src/app/create-app.js";
 import type { ControllerEnv } from "../src/app/env.js";
+import { logger } from "../src/lib/logger.js";
 import { SessionsRuntime } from "../src/runtime/sessions-runtime.js";
 import { createRuntimeState } from "../src/runtime/state.js";
 import { ArtifactService } from "../src/services/artifact-service.js";
@@ -225,9 +225,12 @@ describe("session routes", () => {
       },
     });
 
-    const response = await app.request("/api/v1/sessions/delete-me.jsonl", {
-      method: "DELETE",
-    });
+    const response = await app.request(
+      "/api/v1/sessions/delete-me.jsonl?botId=bot-art",
+      {
+        method: "DELETE",
+      },
+    );
 
     expect(response.status).toBe(200);
     await expect(stat(transcriptPath)).rejects.toThrow();
@@ -249,7 +252,9 @@ describe("session routes", () => {
   });
 
   it("still succeeds when artifact cleanup fails after session files are removed", async () => {
-    rootDir = await mkdtemp(path.join(tmpdir(), "nexu-session-delete-warning-"));
+    rootDir = await mkdtemp(
+      path.join(tmpdir(), "nexu-session-delete-warning-"),
+    );
     const container = createTestContainer(rootDir);
     const app = createApp(container);
 
@@ -286,11 +291,16 @@ describe("session routes", () => {
     const deleteArtifactsForSessionMock = vi
       .spyOn(container.artifactService, "deleteArtifactsForSession")
       .mockRejectedValueOnce(new Error("artifact cleanup failed"));
-    const loggerWarnMock = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    const loggerWarnMock = vi
+      .spyOn(logger, "warn")
+      .mockImplementation(() => {});
 
-    const response = await app.request("/api/v1/sessions/warn-me.jsonl", {
-      method: "DELETE",
-    });
+    const response = await app.request(
+      "/api/v1/sessions/warn-me.jsonl?botId=bot-warning",
+      {
+        method: "DELETE",
+      },
+    );
 
     expect(response.status).toBe(200);
     await expect(stat(transcriptPath)).rejects.toThrow();
@@ -308,6 +318,161 @@ describe("session routes", () => {
       }),
       "session_delete_artifact_cleanup_failed",
     );
+  });
+
+  it("retains artifact index entries when file cleanup cannot be completed", async () => {
+    rootDir = await mkdtemp(path.join(tmpdir(), "nexu-session-delete-retain-"));
+    const container = createTestContainer(rootDir);
+    const app = createApp(container);
+
+    const createSession = await app.request("/api/internal/sessions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        botId: "bot-retain",
+        sessionKey: "retain-me",
+        title: "Retain me",
+        channelType: "slack",
+      }),
+    });
+    expect(createSession.status).toBe(201);
+
+    const transcriptPath = path.join(
+      rootDir,
+      ".openclaw",
+      "agents",
+      "bot-retain",
+      "sessions",
+      "retain-me.jsonl",
+    );
+    const metadataPath = transcriptPath.replace(/\.jsonl$/, ".meta.json");
+    const unsafeDirectoryPath = path.join(
+      rootDir,
+      ".nexu",
+      "artifacts",
+      "retain-me-dir",
+    );
+
+    await mkdir(path.dirname(transcriptPath), { recursive: true });
+    await mkdir(unsafeDirectoryPath, { recursive: true });
+    await writeFile(transcriptPath, "", "utf8");
+    await writeFile(
+      metadataPath,
+      JSON.stringify({ sessionKey: "retain-me" }),
+      "utf8",
+    );
+
+    await container.artifactService.createArtifact({
+      botId: "bot-retain",
+      sessionKey: "retain-me",
+      title: "Directory artifact",
+      metadata: {
+        filePath: unsafeDirectoryPath,
+      },
+    });
+
+    const loggerWarnMock = vi
+      .spyOn(logger, "warn")
+      .mockImplementation(() => {});
+
+    const response = await app.request(
+      "/api/v1/sessions/retain-me.jsonl?botId=bot-retain",
+      {
+        method: "DELETE",
+      },
+    );
+    expect(response.status).toBe(200);
+
+    await expect(stat(transcriptPath)).rejects.toThrow();
+    await expect(stat(metadataPath)).rejects.toThrow();
+    await expect(stat(unsafeDirectoryPath)).resolves.toBeTruthy();
+
+    const artifacts = await container.artifactService.listArtifacts({
+      limit: 10,
+      offset: 0,
+      sessionKey: "retain-me",
+    });
+    expect(artifacts.artifacts).toHaveLength(1);
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        botId: "bot-retain",
+        sessionKey: "retain-me",
+        filePath: unsafeDirectoryPath,
+      }),
+      "session_delete_artifact_cleanup_skipped_directory_path",
+    );
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        botId: "bot-retain",
+        sessionKey: "retain-me",
+        retainedArtifacts: 1,
+      }),
+      "session_delete_artifact_index_retained_for_retry",
+    );
+  });
+
+  it("deletes only the bot-scoped session when sessionKey is reused", async () => {
+    rootDir = await mkdtemp(path.join(tmpdir(), "nexu-session-delete-scoped-"));
+    const container = createTestContainer(rootDir);
+    const app = createApp(container);
+
+    await app.request("/api/internal/sessions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        botId: "bot-a",
+        sessionKey: "shared",
+        title: "Shared A",
+        channelType: "slack",
+      }),
+    });
+    await app.request("/api/internal/sessions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        botId: "bot-b",
+        sessionKey: "shared",
+        title: "Shared B",
+        channelType: "slack",
+      }),
+    });
+
+    const botAPath = path.join(
+      rootDir,
+      ".openclaw",
+      "agents",
+      "bot-a",
+      "sessions",
+      "shared.jsonl",
+    );
+    const botBPath = path.join(
+      rootDir,
+      ".openclaw",
+      "agents",
+      "bot-b",
+      "sessions",
+      "shared.jsonl",
+    );
+    await mkdir(path.dirname(botAPath), { recursive: true });
+    await mkdir(path.dirname(botBPath), { recursive: true });
+    await writeFile(botAPath, "bot-a", "utf8");
+    await writeFile(botBPath, "bot-b", "utf8");
+
+    const missingBotId = await app.request("/api/v1/sessions/shared.jsonl", {
+      method: "DELETE",
+    });
+    expect(missingBotId.status).toBe(400);
+
+    const response = await app.request(
+      "/api/v1/sessions/shared.jsonl?botId=bot-b",
+      {
+        method: "DELETE",
+      },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(readFile(botAPath, "utf8")).resolves.toBe("bot-a");
+    await expect(stat(botBPath)).rejects.toThrow();
   });
 
   it("serves cleaned chat history through the session messages API", async () => {

--- a/apps/controller/tests/session-routes.test.ts
+++ b/apps/controller/tests/session-routes.test.ts
@@ -275,6 +275,13 @@ describe("session routes", () => {
       "warn-me.jsonl",
     );
     const metadataPath = transcriptPath.replace(/\.jsonl$/, ".meta.json");
+    await mkdir(path.dirname(transcriptPath), { recursive: true });
+    await writeFile(transcriptPath, "", "utf8");
+    await writeFile(
+      metadataPath,
+      JSON.stringify({ sessionKey: "warn-me" }),
+      "utf8",
+    );
 
     const deleteArtifactsForSessionMock = vi
       .spyOn(container.artifactService, "deleteArtifactsForSession")

--- a/apps/controller/tests/session-routes.test.ts
+++ b/apps/controller/tests/session-routes.test.ts
@@ -1,4 +1,11 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -7,7 +14,9 @@ import { createApp } from "../src/app/create-app.js";
 import type { ControllerEnv } from "../src/app/env.js";
 import { SessionsRuntime } from "../src/runtime/sessions-runtime.js";
 import { createRuntimeState } from "../src/runtime/state.js";
+import { ArtifactService } from "../src/services/artifact-service.js";
 import { SessionService } from "../src/services/session-service.js";
+import { ArtifactsStore } from "../src/store/artifacts-store.js";
 
 function createEnv(rootDir: string): ControllerEnv {
   return {
@@ -53,6 +62,7 @@ function createEnv(rootDir: string): ControllerEnv {
 function createTestContainer(rootDir: string): ControllerContainer {
   const env = createEnv(rootDir);
   const sessionsRuntime = new SessionsRuntime(env);
+  const artifactService = new ArtifactService(new ArtifactsStore(env), env);
 
   return {
     env,
@@ -69,7 +79,7 @@ function createTestContainer(rootDir: string): ControllerContainer {
     channelFallbackService: {
       stop: vi.fn(),
     } as unknown as ControllerContainer["channelFallbackService"],
-    sessionService: new SessionService(sessionsRuntime),
+    sessionService: new SessionService(sessionsRuntime, artifactService),
     runtimeConfigService: {} as ControllerContainer["runtimeConfigService"],
     runtimeModelStateService:
       {} as ControllerContainer["runtimeModelStateService"],
@@ -77,7 +87,8 @@ function createTestContainer(rootDir: string): ControllerContainer {
     integrationService: {} as ControllerContainer["integrationService"],
     localUserService: {} as ControllerContainer["localUserService"],
     desktopLocalService: {} as ControllerContainer["desktopLocalService"],
-    artifactService: {} as ControllerContainer["artifactService"],
+    analyticsService: {} as ControllerContainer["analyticsService"],
+    artifactService,
     templateService: {} as ControllerContainer["templateService"],
     skillhubService: {
       catalog: {
@@ -96,6 +107,7 @@ function createTestContainer(rootDir: string): ControllerContainer {
       dispose: vi.fn(),
     } as unknown as ControllerContainer["skillhubService"],
     openclawSyncService: {} as ControllerContainer["openclawSyncService"],
+    openclawAuthService: {} as ControllerContainer["openclawAuthService"],
     wsClient: {
       stop: vi.fn(),
     } as unknown as ControllerContainer["wsClient"],
@@ -116,6 +128,112 @@ describe("session routes", () => {
       await rm(rootDir, { recursive: true, force: true });
       rootDir = null;
     }
+  });
+
+  it("deletes session files and managed local artifacts together", async () => {
+    rootDir = await mkdtemp(path.join(tmpdir(), "nexu-session-delete-"));
+    const container = createTestContainer(rootDir);
+    const app = createApp(container);
+
+    const createSession = await app.request("/api/internal/sessions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        botId: "bot-art",
+        sessionKey: "delete-me",
+        title: "Delete me",
+        channelType: "slack",
+      }),
+    });
+
+    expect(createSession.status).toBe(201);
+
+    const transcriptPath = path.join(
+      rootDir,
+      ".openclaw",
+      "agents",
+      "bot-art",
+      "sessions",
+      "delete-me.jsonl",
+    );
+    const metadataPath = transcriptPath.replace(/\.jsonl$/, ".meta.json");
+    const managedImagePath = path.join(
+      rootDir,
+      ".nexu",
+      "artifacts",
+      "images",
+      "delete-me.png",
+    );
+    const externalImagePath = path.join(rootDir, "outside-delete-me.png");
+
+    const otherManagedImagePath = path.join(
+      rootDir,
+      ".nexu",
+      "artifacts",
+      "images",
+      "other-bot-delete-me.png",
+    );
+
+    await mkdir(path.dirname(transcriptPath), { recursive: true });
+    await mkdir(path.dirname(managedImagePath), { recursive: true });
+    await writeFile(transcriptPath, "", "utf8");
+    await writeFile(
+      metadataPath,
+      JSON.stringify({ sessionKey: "delete-me" }),
+      "utf8",
+    );
+    await writeFile(managedImagePath, "managed", "utf8");
+    await writeFile(externalImagePath, "external", "utf8");
+    await writeFile(otherManagedImagePath, "other-managed", "utf8");
+
+    await container.artifactService.createArtifact({
+      botId: "bot-art",
+      sessionKey: "delete-me",
+      title: "Managed artifact",
+      previewUrl: `file://${managedImagePath}`,
+      metadata: {
+        outputPath: managedImagePath,
+      },
+    });
+    await container.artifactService.createArtifact({
+      botId: "bot-art",
+      sessionKey: "delete-me",
+      title: "External artifact",
+      previewUrl: `file://${externalImagePath}`,
+      metadata: {
+        outputPath: externalImagePath,
+      },
+    });
+    await container.artifactService.createArtifact({
+      botId: "bot-other",
+      sessionKey: "delete-me",
+      title: "Other bot artifact",
+      previewUrl: `file://${otherManagedImagePath}`,
+      metadata: {
+        outputPath: otherManagedImagePath,
+      },
+    });
+
+    const response = await app.request("/api/v1/sessions/delete-me.jsonl", {
+      method: "DELETE",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(stat(transcriptPath)).rejects.toThrow();
+    await expect(stat(metadataPath)).rejects.toThrow();
+    await expect(stat(managedImagePath)).rejects.toThrow();
+    await expect(readFile(externalImagePath, "utf8")).resolves.toBe("external");
+    await expect(readFile(otherManagedImagePath, "utf8")).resolves.toBe(
+      "other-managed",
+    );
+
+    const artifacts = await container.artifactService.listArtifacts({
+      limit: 10,
+      offset: 0,
+      sessionKey: "delete-me",
+    });
+    expect(artifacts.artifacts).toHaveLength(1);
+    expect(artifacts.artifacts[0]?.botId).toBe("bot-other");
   });
 
   it("serves cleaned chat history through the session messages API", async () => {

--- a/apps/controller/tests/session-routes.test.ts
+++ b/apps/controller/tests/session-routes.test.ts
@@ -165,6 +165,7 @@ describe("session routes", () => {
       "delete-me.png",
     );
     const externalImagePath = path.join(rootDir, "outside-delete-me.png");
+    const managedRootMarkerPath = path.join(rootDir, ".nexu", "keep.txt");
 
     const otherManagedImagePath = path.join(
       rootDir,
@@ -176,6 +177,7 @@ describe("session routes", () => {
 
     await mkdir(path.dirname(transcriptPath), { recursive: true });
     await mkdir(path.dirname(managedImagePath), { recursive: true });
+    await writeFile(managedRootMarkerPath, "keep", "utf8");
     await writeFile(transcriptPath, "", "utf8");
     await writeFile(
       metadataPath,
@@ -205,6 +207,14 @@ describe("session routes", () => {
       },
     });
     await container.artifactService.createArtifact({
+      botId: "bot-art",
+      sessionKey: "delete-me",
+      title: "Managed root artifact",
+      metadata: {
+        directoryPath: container.env.nexuHomeDir,
+      },
+    });
+    await container.artifactService.createArtifact({
       botId: "bot-other",
       sessionKey: "delete-me",
       title: "Other bot artifact",
@@ -222,6 +232,7 @@ describe("session routes", () => {
     await expect(stat(transcriptPath)).rejects.toThrow();
     await expect(stat(metadataPath)).rejects.toThrow();
     await expect(stat(managedImagePath)).rejects.toThrow();
+    await expect(readFile(managedRootMarkerPath, "utf8")).resolves.toBe("keep");
     await expect(readFile(externalImagePath, "utf8")).resolves.toBe("external");
     await expect(readFile(otherManagedImagePath, "utf8")).resolves.toBe(
       "other-managed",

--- a/apps/web/lib/api/types.gen.ts
+++ b/apps/web/lib/api/types.gen.ts
@@ -1596,7 +1596,9 @@ export type DeleteApiV1SessionsByIdData = {
     path: {
         id: string;
     };
-    query?: never;
+    query: {
+        botId: string;
+    };
     url: '/api/v1/sessions/{id}';
 };
 

--- a/apps/web/src/pages/sessions.tsx
+++ b/apps/web/src/pages/sessions.tsx
@@ -4,20 +4,22 @@ import { getChannelChatUrl } from "@/lib/channel-links";
 import { getSessionFolderUrl, openLocalFolderUrl } from "@/lib/desktop-links";
 import { normalizeChannel, track } from "@/lib/tracking";
 import { cn } from "@/lib/utils";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   ArrowUpRight,
   CheckCircle2,
   FolderOpen,
   Loader2,
   MessageSquare,
+  Trash2,
   WifiOff,
 } from "lucide-react";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
 import {
+  deleteApiV1SessionsById,
   getApiV1Channels,
   getApiV1SessionsById,
   getApiV1SessionsByIdMessages,
@@ -565,8 +567,11 @@ function ChatBubble({
 
 export function SessionsPage() {
   const { t } = useTranslation();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { id } = useParams<{ id: string }>();
   const endRef = useRef<HTMLDivElement>(null);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   useEffect(() => {
     if (id) track("session_detail_view");
@@ -607,6 +612,28 @@ export function SessionsPage() {
       return data;
     },
     enabled: !!id,
+  });
+
+  const deleteSessionMutation = useMutation({
+    mutationFn: async (sessionId: string) => {
+      const { data } = await deleteApiV1SessionsById({
+        path: { id: sessionId },
+      });
+      return data;
+    },
+    onSuccess: async () => {
+      setShowDeleteConfirm(false);
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["sidebar-sessions"] }),
+        queryClient.invalidateQueries({ queryKey: ["session-meta", id] }),
+        queryClient.invalidateQueries({ queryKey: ["chat-history", id] }),
+      ]);
+      toast.success("Conversation deleted.");
+      navigate("/workspace/sessions", { replace: true });
+    },
+    onError: () => {
+      toast.error("Failed to delete conversation.");
+    },
   });
 
   const messages = ((chatData as Record<string, unknown> | undefined)
@@ -655,6 +682,10 @@ export function SessionsPage() {
     "inline-flex h-12 items-center justify-center gap-3 rounded-[18px] border bg-white px-5 text-[13px] font-medium text-text-primary shadow-[0_10px_24px_rgba(15,23,42,0.06)] transition-colors",
     "border-[rgba(15,23,42,0.1)] hover:bg-[rgba(248,250,252,0.9)]",
   );
+  const dangerButtonClassName = cn(
+    buttonClassName,
+    "border-[rgba(220,38,38,0.2)] text-[#B42318] hover:bg-[rgba(254,242,242,0.9)]",
+  );
 
   const handleOpenFolder = async (): Promise<void> => {
     if (!sessionFolderUrl) {
@@ -678,6 +709,14 @@ export function SessionsPage() {
     }
 
     toast.info("This channel does not expose a direct chat link yet.");
+  };
+
+  const handleDeleteSession = (): void => {
+    if (!id || deleteSessionMutation.isPending) {
+      return;
+    }
+
+    deleteSessionMutation.mutate(id);
   };
 
   return (
@@ -717,6 +756,15 @@ export function SessionsPage() {
             </div>
           </div>
           <div className="flex items-center gap-3">
+            <button
+              type="button"
+              data-delete-session-trigger="true"
+              onClick={() => setShowDeleteConfirm(true)}
+              className={dangerButtonClassName}
+            >
+              <Trash2 className="size-[18px]" />
+              <span>Delete</span>
+            </button>
             <button
               type="button"
               data-session-folder-url={sessionFolderUrl ?? undefined}
@@ -770,6 +818,67 @@ export function SessionsPage() {
         </div>
       </div>
 
+      {showDeleteConfirm && (
+        <div className="absolute inset-0 z-20 flex items-center justify-center bg-[rgba(15,23,42,0.38)] px-6">
+          <div
+            data-delete-session-confirm="true"
+            className="w-full max-w-md rounded-[24px] border border-[rgba(15,23,42,0.08)] bg-white p-6 shadow-[0_24px_80px_rgba(15,23,42,0.18)]"
+          >
+            <div className="flex items-start gap-3">
+              <div className="mt-0.5 flex size-10 shrink-0 items-center justify-center rounded-full bg-[rgba(254,226,226,0.9)] text-[#B42318]">
+                <Trash2 className="size-5" />
+              </div>
+              <div>
+                <h2 className="text-[16px] font-semibold text-text-primary">
+                  Delete this conversation?
+                </h2>
+                <p className="mt-2 text-[13px] leading-6 text-text-secondary">
+                  This will permanently delete the chat history and any related
+                  local generated artwork or artifact files managed by Nexu.
+                  This action cannot be undone.
+                </p>
+              </div>
+            </div>
+            <div className="mt-6 flex items-center justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => setShowDeleteConfirm(false)}
+                disabled={deleteSessionMutation.isPending}
+                className={cn(
+                  buttonClassName,
+                  "h-10 rounded-[14px] px-4 shadow-none",
+                  deleteSessionMutation.isPending &&
+                    "cursor-not-allowed opacity-60",
+                )}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleDeleteSession}
+                disabled={deleteSessionMutation.isPending}
+                className={cn(
+                  dangerButtonClassName,
+                  "h-10 rounded-[14px] px-4 shadow-none",
+                  deleteSessionMutation.isPending &&
+                    "cursor-not-allowed opacity-60",
+                )}
+              >
+                {deleteSessionMutation.isPending ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Trash2 className="size-4" />
+                )}
+                <span>
+                  {deleteSessionMutation.isPending
+                    ? "Deleting..."
+                    : "Delete conversation"}
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
       {/* Message List */}
       <div className="flex-1 overflow-y-auto min-h-0">
         {chatLoading ? (

--- a/apps/web/src/pages/sessions.tsx
+++ b/apps/web/src/pages/sessions.tsx
@@ -4,6 +4,7 @@ import { getChannelChatUrl } from "@/lib/channel-links";
 import { getSessionFolderUrl, openLocalFolderUrl } from "@/lib/desktop-links";
 import { normalizeChannel, track } from "@/lib/tracking";
 import { cn } from "@/lib/utils";
+import * as Dialog from "@radix-ui/react-dialog";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   ArrowUpRight,
@@ -759,15 +760,84 @@ export function SessionsPage() {
             </div>
           </div>
           <div className="flex items-center gap-3">
-            <button
-              type="button"
-              data-delete-session-trigger="true"
-              onClick={() => setShowDeleteConfirm(true)}
-              className={dangerButtonClassName}
+            <Dialog.Root
+              open={showDeleteConfirm}
+              onOpenChange={setShowDeleteConfirm}
             >
-              <Trash2 className="size-[18px]" />
-              <span>Delete</span>
-            </button>
+              <Dialog.Trigger asChild>
+                <button
+                  type="button"
+                  data-delete-session-trigger="true"
+                  className={dangerButtonClassName}
+                >
+                  <Trash2 className="size-[18px]" />
+                  <span>Delete</span>
+                </button>
+              </Dialog.Trigger>
+              <Dialog.Portal>
+                <Dialog.Overlay className="absolute inset-0 z-20 bg-[rgba(15,23,42,0.38)]" />
+                <Dialog.Content
+                  data-delete-session-confirm="true"
+                  className="absolute inset-0 z-30 flex items-center justify-center px-6 focus:outline-none"
+                >
+                  <div className="w-full max-w-md rounded-[24px] border border-[rgba(15,23,42,0.08)] bg-white p-6 shadow-[0_24px_80px_rgba(15,23,42,0.18)]">
+                    <div className="flex items-start gap-3">
+                      <div className="mt-0.5 flex size-10 shrink-0 items-center justify-center rounded-full bg-[rgba(254,226,226,0.9)] text-[#B42318]">
+                        <Trash2 className="size-5" />
+                      </div>
+                      <div>
+                        <Dialog.Title className="text-[16px] font-semibold text-text-primary">
+                          Delete this conversation?
+                        </Dialog.Title>
+                        <Dialog.Description className="mt-2 text-[13px] leading-6 text-text-secondary">
+                          This will permanently delete the chat history and any related
+                          local generated artwork or artifact files managed by Nexu.
+                          This action cannot be undone.
+                        </Dialog.Description>
+                      </div>
+                    </div>
+                    <div className="mt-6 flex items-center justify-end gap-3">
+                      <Dialog.Close asChild>
+                        <button
+                          type="button"
+                          disabled={deleteSessionMutation.isPending}
+                          className={cn(
+                            buttonClassName,
+                            "h-10 rounded-[14px] px-4 shadow-none",
+                            deleteSessionMutation.isPending &&
+                              "cursor-not-allowed opacity-60",
+                          )}
+                        >
+                          Cancel
+                        </button>
+                      </Dialog.Close>
+                      <button
+                        type="button"
+                        onClick={handleDeleteSession}
+                        disabled={deleteSessionMutation.isPending}
+                        className={cn(
+                          dangerButtonClassName,
+                          "h-10 rounded-[14px] px-4 shadow-none",
+                          deleteSessionMutation.isPending &&
+                            "cursor-not-allowed opacity-60",
+                        )}
+                      >
+                        {deleteSessionMutation.isPending ? (
+                          <Loader2 className="size-4 animate-spin" />
+                        ) : (
+                          <Trash2 className="size-4" />
+                        )}
+                        <span>
+                          {deleteSessionMutation.isPending
+                            ? "Deleting..."
+                            : "Delete conversation"}
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                </Dialog.Content>
+              </Dialog.Portal>
+            </Dialog.Root>
             <button
               type="button"
               data-session-folder-url={sessionFolderUrl ?? undefined}
@@ -821,67 +891,6 @@ export function SessionsPage() {
         </div>
       </div>
 
-      {showDeleteConfirm && (
-        <div className="absolute inset-0 z-20 flex items-center justify-center bg-[rgba(15,23,42,0.38)] px-6">
-          <div
-            data-delete-session-confirm="true"
-            className="w-full max-w-md rounded-[24px] border border-[rgba(15,23,42,0.08)] bg-white p-6 shadow-[0_24px_80px_rgba(15,23,42,0.18)]"
-          >
-            <div className="flex items-start gap-3">
-              <div className="mt-0.5 flex size-10 shrink-0 items-center justify-center rounded-full bg-[rgba(254,226,226,0.9)] text-[#B42318]">
-                <Trash2 className="size-5" />
-              </div>
-              <div>
-                <h2 className="text-[16px] font-semibold text-text-primary">
-                  Delete this conversation?
-                </h2>
-                <p className="mt-2 text-[13px] leading-6 text-text-secondary">
-                  This will permanently delete the chat history and any related
-                  local generated artwork or artifact files managed by Nexu.
-                  This action cannot be undone.
-                </p>
-              </div>
-            </div>
-            <div className="mt-6 flex items-center justify-end gap-3">
-              <button
-                type="button"
-                onClick={() => setShowDeleteConfirm(false)}
-                disabled={deleteSessionMutation.isPending}
-                className={cn(
-                  buttonClassName,
-                  "h-10 rounded-[14px] px-4 shadow-none",
-                  deleteSessionMutation.isPending &&
-                    "cursor-not-allowed opacity-60",
-                )}
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={handleDeleteSession}
-                disabled={deleteSessionMutation.isPending}
-                className={cn(
-                  dangerButtonClassName,
-                  "h-10 rounded-[14px] px-4 shadow-none",
-                  deleteSessionMutation.isPending &&
-                    "cursor-not-allowed opacity-60",
-                )}
-              >
-                {deleteSessionMutation.isPending ? (
-                  <Loader2 className="size-4 animate-spin" />
-                ) : (
-                  <Trash2 className="size-4" />
-                )}
-                <span>
-                  {deleteSessionMutation.isPending
-                    ? "Deleting..."
-                    : "Delete conversation"}
-                </span>
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
       {/* Message List */}
       <div className="flex-1 overflow-y-auto min-h-0">
         {chatLoading ? (

--- a/apps/web/src/pages/sessions.tsx
+++ b/apps/web/src/pages/sessions.tsx
@@ -616,21 +616,33 @@ export function SessionsPage() {
   });
 
   const deleteSessionMutation = useMutation({
-    mutationFn: async (sessionId: string) => {
+    mutationFn: async ({
+      sessionId,
+      botId,
+    }: {
+      sessionId: string;
+      botId: string;
+    }) => {
       const { data } = await deleteApiV1SessionsById({
         path: { id: sessionId },
+        query: { botId },
       });
       if (!data?.ok) {
         throw new Error("Session delete failed");
       }
       return data;
     },
-    onSuccess: async (_data, sessionId) => {
+    onSuccess: async (_data, variables) => {
+      const { sessionId } = variables;
       setShowDeleteConfirm(false);
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ["sidebar-sessions"] }),
-        queryClient.invalidateQueries({ queryKey: ["session-meta", sessionId] }),
-        queryClient.invalidateQueries({ queryKey: ["chat-history", sessionId] }),
+        queryClient.invalidateQueries({
+          queryKey: ["session-meta", sessionId],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["chat-history", sessionId],
+        }),
       ]);
       toast.success("Conversation deleted.");
       if (id === sessionId) {
@@ -718,11 +730,12 @@ export function SessionsPage() {
   };
 
   const handleDeleteSession = (): void => {
-    if (!id || deleteSessionMutation.isPending) {
+    if (!id || !session?.botId || deleteSessionMutation.isPending) {
+      toast.error("Failed to delete conversation.");
       return;
     }
 
-    deleteSessionMutation.mutate(id);
+    deleteSessionMutation.mutate({ sessionId: id, botId: session.botId });
   };
 
   return (
@@ -792,9 +805,9 @@ export function SessionsPage() {
                           Delete this conversation?
                         </Dialog.Title>
                         <Dialog.Description className="mt-2 text-[13px] leading-6 text-text-secondary">
-                          This will permanently delete the chat history and any related
-                          local generated artwork or artifact files managed by Nexu.
-                          This action cannot be undone.
+                          This will permanently delete the chat history and any
+                          related local generated artwork or artifact files
+                          managed by Nexu. This action cannot be undone.
                         </Dialog.Description>
                       </div>
                     </div>

--- a/apps/web/src/pages/sessions.tsx
+++ b/apps/web/src/pages/sessions.tsx
@@ -625,15 +625,17 @@ export function SessionsPage() {
       }
       return data;
     },
-    onSuccess: async () => {
+    onSuccess: async (_data, sessionId) => {
       setShowDeleteConfirm(false);
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ["sidebar-sessions"] }),
-        queryClient.invalidateQueries({ queryKey: ["session-meta", id] }),
-        queryClient.invalidateQueries({ queryKey: ["chat-history", id] }),
+        queryClient.invalidateQueries({ queryKey: ["session-meta", sessionId] }),
+        queryClient.invalidateQueries({ queryKey: ["chat-history", sessionId] }),
       ]);
       toast.success("Conversation deleted.");
-      navigate("/workspace/sessions", { replace: true });
+      if (id === sessionId) {
+        navigate("/workspace/sessions", { replace: true });
+      }
     },
     onError: () => {
       toast.error("Failed to delete conversation.");

--- a/apps/web/src/pages/sessions.tsx
+++ b/apps/web/src/pages/sessions.tsx
@@ -619,6 +619,9 @@ export function SessionsPage() {
       const { data } = await deleteApiV1SessionsById({
         path: { id: sessionId },
       });
+      if (!data?.ok) {
+        throw new Error("Session delete failed");
+      }
       return data;
     },
     onSuccess: async () => {

--- a/apps/web/tests/sessions.test.tsx
+++ b/apps/web/tests/sessions.test.tsx
@@ -32,6 +32,11 @@ vi.mock("react-i18next", () => ({
 }));
 
 vi.mock("../lib/api/sdk.gen", () => ({
+  deleteApiV1SessionsById: vi.fn(async () => ({
+    data: {
+      ok: true,
+    },
+  })),
   getApiV1Channels: vi.fn(async () => ({
     data: undefined,
   })),
@@ -113,6 +118,7 @@ describe("SessionsPage", () => {
     expect(markup).not.toContain("[message_id:");
     expect(markup).toContain("google-calendar");
     expect(markup).toContain("Open in Slack");
+    expect(markup).toContain("Delete");
   });
 
   it("renders assistant tool activity as a compact execution chip", () => {


### PR DESCRIPTION
## What
- add a Delete action to the session conversation header, placed before the existing Open Folder / external-link actions
- require a confirmation step before deleting a session from the desktop client
- extend session deletion so it also removes the session transcript, metadata file, and Nexu-managed local artifact files associated with the same `botId + sessionKey`

## Why
The desktop client already exposes session details, but deleting a conversation was not available from that screen. Adding the action in-place makes session management more complete and avoids leaving behind local generated artwork or artifact files after a conversation is removed.

## How
- add a delete mutation and confirmation modal to the session detail page
- reuse the existing `DELETE /api/v1/sessions/{id}` route instead of introducing a new API
- move session file cleanup into a dedicated runtime method so the service layer can orchestrate cascade deletion cleanly
- update artifact cleanup to target the exact `botId + sessionKey` pair and only remove files within Nexu-managed directories
- add controller coverage for transcript/meta/artifact cleanup and a web test asserting the delete button is rendered

## Affected areas
- controller session deletion orchestration
- artifact cleanup safety checks
- sessions page header actions and confirmation UX
- controller/web tests for regression coverage

## Testing
- manual: verified the delete action works from the desktop session detail screen, including confirmation and successful removal flow
- automated:
  - `pnpm --filter @nexu/controller test -- --run tests/session-routes.test.ts`
  - `pnpm --filter @nexu/web test -- --run tests/sessions.test.tsx`
  - `pnpm --filter @nexu/controller typecheck`
  - `pnpm --filter @nexu/web typecheck`

## Checklist
- [x] Follows existing controller-first architecture
- [x] Reuses the existing session delete API
- [x] Includes regression tests for backend and frontend behavior
- [x] Avoids unrelated dependency or lockfile changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions can be deleted from the Sessions page via a Delete button and confirmation modal; UI shows progress, prevents duplicate submissions, and redirects on success.

* **Improvements**
  * Server-side deletion now removes session transcript, its metadata, and related managed artifact output files while preserving external/unmanaged files and other bots' artifacts.
  * Artifact cleanup is performed as part of deletion but failures are logged and do not block the delete response.

* **Tests**
  * Added tests verifying session deletion, file/artifact cleanup behavior, and logged handling of cleanup errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->