### PR TITLE
fix(nexu-pal): skip triage for internal issue authors

### DIFF
--- a/.github/workflows/nexu-pal-issue-opened.yml
+++ b/.github/workflows/nexu-pal-issue-opened.yml
@@ -45,4 +45,5 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_AUTHOR_ASSOCIATION: ${{ github.event.issue.author_association }}
         run: node scripts/nexu-pal/process-issue-opened.mjs

--- a/scripts/nexu-pal/lib/triage-opened-engine.mjs
+++ b/scripts/nexu-pal/lib/triage-opened-engine.mjs
@@ -116,6 +116,10 @@ function sanitizeJsonResponse(raw) {
   return raw.replace(/^```(?:json)?\s*\n?/m, "").replace(/\n?```\s*$/m, "");
 }
 
+function isInternalIssueAuthor(authorAssociation) {
+  return authorAssociation === "MEMBER" || authorAssociation === "OWNER";
+}
+
 async function detectAndTranslate({ chat, issueTitle, issueBody }) {
   const content = `Title: ${issueTitle}\n\nBody:\n${issueBody}`;
 
@@ -249,6 +253,7 @@ function buildNeedsInformationComment({ missingItems, reason }) {
 export async function buildOpenedIssueTriagePlan({
   issueTitle,
   issueBody,
+  issueAuthorAssociation,
   chat,
 }) {
   const plan = createTriagePlan();
@@ -298,6 +303,31 @@ export async function buildOpenedIssueTriagePlan({
     plan.diagnostics.push(...translation.diagnostics);
   }
 
+  const classification = await classifyBugOnly({
+    chat,
+    englishTitle,
+    englishBody,
+  });
+
+  if (classification.is_bug === true) {
+    plan.labelsToAdd.push("bug");
+  }
+
+  plan.diagnostics.push(
+    `bug classification: ${classification.reason ?? "no reason provided"}`,
+  );
+
+  plan.diagnostics.push(
+    `author association: ${issueAuthorAssociation ?? "unknown"}`,
+  );
+
+  if (isInternalIssueAuthor(issueAuthorAssociation)) {
+    plan.diagnostics.push(
+      "internal author detected; skipped roadmap/duplicate/completeness/needs-triage checks",
+    );
+    return plan;
+  }
+
   const roadmap = await matchRoadmap({
     title: englishTitle,
     body: englishBody,
@@ -314,20 +344,6 @@ export async function buildOpenedIssueTriagePlan({
   if (Array.isArray(duplicate.diagnostics)) {
     plan.diagnostics.push(...duplicate.diagnostics);
   }
-
-  const classification = await classifyBugOnly({
-    chat,
-    englishTitle,
-    englishBody,
-  });
-
-  if (classification.is_bug === true) {
-    plan.labelsToAdd.push("bug");
-  }
-
-  plan.diagnostics.push(
-    `bug classification: ${classification.reason ?? "no reason provided"}`,
-  );
 
   const completeness = await assessInformationCompleteness({
     chat,

--- a/scripts/nexu-pal/process-issue-opened.mjs
+++ b/scripts/nexu-pal/process-issue-opened.mjs
@@ -14,6 +14,7 @@ const repo = process.env.GITHUB_REPOSITORY;
 const issueNumber = process.env.ISSUE_NUMBER;
 const issueTitle = process.env.ISSUE_TITLE ?? "";
 const issueBody = process.env.ISSUE_BODY ?? "";
+const issueAuthorAssociation = process.env.ISSUE_AUTHOR_ASSOCIATION ?? "NONE";
 
 if (!endpoint || !apiKey || !ghToken || !repo || !issueNumber) {
   console.error(
@@ -55,6 +56,7 @@ async function main() {
   const plan = await buildOpenedIssueTriagePlan({
     issueTitle,
     issueBody,
+    issueAuthorAssociation,
     chat,
   });
 

--- a/specs/current/nexu-pal.md
+++ b/specs/current/nexu-pal.md
@@ -22,9 +22,11 @@ Runs in order:
 
 3. **Intent classification** — Sends the normalized English title and body to the LLM and assigns only the `bug` label when the issue clearly describes broken behavior.
 
-4. **Completeness check** — Uses the LLM to decide whether the issue is too incomplete to continue triage. If so, adds `needs-information`, posts a follow-up comment, and pauses there.
+4. **Internal-member short-circuit** — If `issue.author_association` is `MEMBER` or `OWNER`, the opened-issue flow stops after translation + bug classification. Internal issues skip known-issue matching, completeness checks, and `needs-triage` labeling.
 
-5. **Triage label** — If the issue is not roadmap-matched and does not need more information, adds the `needs-triage` label.
+5. **Completeness check** — For non-internal authors, uses the LLM to decide whether the issue is too incomplete to continue triage. If so, adds `needs-information`, posts a follow-up comment, and pauses there.
+
+6. **Triage label** — For non-internal authors, if the issue is not roadmap-matched and does not need more information, adds the `needs-triage` label.
 
 The opened-issue flow is split into a small pipeline:
 


### PR DESCRIPTION
## What

Skip the opened-issue triage flow for issues created by internal organization members after translation and bug classification.

## Why

Internal team issues should still get AI translation and automatic bug labeling, but they should not be routed through the external intake flow that adds `needs-information`, known-issue checks, or `needs-triage`.

## How

- pass `issue.author_association` from the issue-opened workflow into the triage script
- treat `MEMBER` and `OWNER` as internal authors in the triage engine
- short-circuit the opened-issue plan after translation and bug classification for internal authors
- log the author association in diagnostics and document the new behavior

## Affected areas

- [ ] Desktop app (Electron shell)
- [ ] Controller (backend / API)
- [ ] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [x] Build / CI / Tooling

## Checklist

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

## Notes for reviewers

`pnpm lint` and `pnpm test` do not pass in the current local environment because workspace dependencies/tooling are not installed (`node_modules` missing, `vitest` not found, and TypeScript tooling is not ready). Syntax checks for the touched nexu-pal scripts passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced issue triage automation to differentiate issues by author type (internal vs. external)
  * Internal team members' issues now skip certain triage checks for faster processing
  * External user submissions continue to receive full triage evaluation and automated labeling
  * Improved workflow efficiency for team-authored issues while maintaining standard assessment for external reports

<!-- end of auto-generated comment: release notes by coderabbit.ai -->