### PR TITLE
fix(web): i18n skill card install/uninstall buttons

### DIFF
--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -495,6 +495,10 @@ const en = {
   "skills.justNow": "just now",
   "skills.hoursAgo": "{{count}}h ago",
   "skills.daysAgo": "{{count}}d ago",
+  "skills.installAction": "Install",
+  "skills.uninstallAction": "Uninstall",
+  "skills.installingAction": "Installing…",
+  "skills.uninstallingAction": "Uninstalling…",
 
   // ── Skill Detail Page ──
   "skillDetail.backToSkills": "Back to Skills",

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -472,6 +472,10 @@ const zhCN = {
   "skills.justNow": "刚刚",
   "skills.hoursAgo": "{{count}}小时前",
   "skills.daysAgo": "{{count}}天前",
+  "skills.installAction": "安装",
+  "skills.uninstallAction": "卸载",
+  "skills.installingAction": "安装中…",
+  "skills.uninstallingAction": "卸载中…",
 
   // ── Skill Detail Page ──
   "skillDetail.backToSkills": "返回技能列表",

--- a/apps/web/src/pages/skills.tsx
+++ b/apps/web/src/pages/skills.tsx
@@ -71,6 +71,7 @@ function SkillCard({
   detailTo: string;
   isDetailAvailable: boolean;
 }) {
+  const { t } = useTranslation();
   const installMutation = useInstallSkill();
   const uninstallMutation = useUninstallSkill();
   const [pendingAction, setPendingAction] = useState<
@@ -174,7 +175,7 @@ function SkillCard({
         {isQueueActive || (isMutating && pendingAction === "install") ? (
           <span className="inline-flex items-center gap-1.5 rounded-[8px] px-[14px] py-[5px] text-[12px] font-medium border border-border text-text-muted cursor-default">
             <Loader2 size={12} className="animate-spin" />
-            Installing…
+            {t("skills.installingAction")}
           </span>
         ) : isInstalled ? (
           <button
@@ -187,7 +188,9 @@ function SkillCard({
             disabled={isMutating}
             className="text-[12px] font-medium text-text-muted hover:text-[var(--color-danger)] transition-colors"
           >
-            {pendingAction === "uninstall" ? "Uninstalling…" : "Uninstall"}
+            {pendingAction === "uninstall"
+              ? t("skills.uninstallingAction")
+              : t("skills.uninstallAction")}
           </button>
         ) : (
           <button
@@ -200,7 +203,7 @@ function SkillCard({
             disabled={isMutating}
             className="rounded-[8px] px-[14px] py-[5px] text-[12px] font-medium border border-border text-text-primary hover:bg-surface-2 hover:border-border-hover transition-colors"
           >
-            Install
+            {t("skills.installAction")}
           </button>
         )}
       </div>


### PR DESCRIPTION
## What

Internationalize skill card Install/Uninstall button labels so they render in the user's locale.

## Why

Button text on skill cards ("Install", "Uninstall", "Installing…", "Uninstalling…") was hardcoded in English. When switching to Chinese, these labels stayed in English instead of showing 安装/卸载/安装中…/卸载中….

## How

- Added four i18n keys (`skills.installAction`, `skills.uninstallAction`, `skills.installingAction`, `skills.uninstallingAction`) to both `en.ts` and `zh-CN.ts`
- Replaced hardcoded strings in `SkillCard` with `t()` calls

## Affected areas

- [x] Web dashboard (React UI)

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)