### PR TITLE
fix: backfill session channel types for messaging channels

### DIFF
--- a/apps/controller/src/runtime/sessions-runtime.ts
+++ b/apps/controller/src/runtime/sessions-runtime.ts
@@ -52,6 +52,15 @@ type SessionHints = {
   metadata?: SessionMetadataRecord;
   feishuMessageId?: string;
 };
+type SessionsIndexEntry = {
+  sessionId?: string;
+  sessionFile?: string;
+  lastChannel?: string;
+  origin?: {
+    provider?: string;
+    label?: string;
+  };
+};
 type ControllerConfigRecord = {
   channels?: Array<{
     id?: string;
@@ -93,6 +102,7 @@ export class SessionsRuntime {
         }
 
         const sessionsDir = path.join(agentsDir, agentEntry.name, "sessions");
+        const sessionsIndex = await this.readSessionsIndex(sessionsDir);
         let files: Dirent[];
         try {
           files = await readdir(sessionsDir, { withFileTypes: true });
@@ -113,7 +123,19 @@ export class SessionsRuntime {
           // Read the first user message metadata block and backfill exact
           // Feishu chat targets for existing sessions without touching
           // OpenClaw's transcript writer.
-          const hints = await this.inferSessionHints(filePath);
+          const transcriptHints = await this.inferSessionHints(filePath);
+          const indexHints = this.inferSessionHintsFromIndex(
+            sessionsIndex,
+            filePath,
+            sessionKey,
+          );
+          const hints: SessionHints = {
+            senderName: transcriptHints.senderName ?? indexHints.senderName,
+            channelType: transcriptHints.channelType ?? indexHints.channelType,
+            metadata: transcriptHints.metadata ?? indexHints.metadata,
+            feishuMessageId:
+              transcriptHints.feishuMessageId ?? indexHints.feishuMessageId,
+          };
           const resolvedHintMetadata = await this.resolveExactChatMetadata(
             agentEntry.name,
             extra.metadata,
@@ -688,6 +710,48 @@ export class SessionsRuntime {
     );
   }
 
+  private async readSessionsIndex(
+    sessionsDir: string,
+  ): Promise<Record<string, SessionsIndexEntry>> {
+    const indexPath = path.join(sessionsDir, "sessions.json");
+    try {
+      const raw = await readFile(indexPath, "utf8");
+      const parsed = JSON.parse(raw) as Record<string, SessionsIndexEntry>;
+      return parsed;
+    } catch {
+      return {};
+    }
+  }
+
+  private inferSessionHintsFromIndex(
+    index: Record<string, SessionsIndexEntry>,
+    filePath: string,
+    sessionKey: string,
+  ): SessionHints {
+    const entry = Object.values(index).find((item) => {
+      if (item.sessionId === sessionKey) {
+        return true;
+      }
+      if (typeof item.sessionFile === "string") {
+        return path.resolve(item.sessionFile) === path.resolve(filePath);
+      }
+      return false;
+    });
+
+    if (!entry) {
+      return {};
+    }
+
+    const rawChannel = entry.lastChannel ?? entry.origin?.provider ?? undefined;
+    const channelType = this.normalizeInferredChannelType(rawChannel);
+    const senderName = entry.origin?.label;
+
+    return {
+      senderName,
+      channelType,
+    };
+  }
+
   private async readSessionMetadata(
     filePath: string,
   ): Promise<SessionMetadata> {
@@ -824,7 +888,7 @@ export class SessionsRuntime {
 
     return {
       senderName,
-      channelType,
+      channelType: this.normalizeInferredChannelType(channelType),
       metadata: this.extractExactChatTargetMetadata(
         senderMeta,
         conversationMeta,
@@ -832,6 +896,21 @@ export class SessionsRuntime {
       feishuMessageId:
         this.readStringValue(conversationMeta, "message_id") ?? undefined,
     };
+  }
+
+  private normalizeInferredChannelType(
+    channelType: string | undefined,
+  ): string | undefined {
+    if (!channelType) {
+      return undefined;
+    }
+
+    const normalized = channelType.trim().toLowerCase();
+    if (normalized === "wechat") {
+      return "openclaw-weixin";
+    }
+
+    return normalized || undefined;
   }
 
   private parseJsonMetadataBlock(

--- a/apps/controller/tests/sessions-runtime.test.ts
+++ b/apps/controller/tests/sessions-runtime.test.ts
@@ -424,6 +424,164 @@ describe("SessionsRuntime", () => {
     expect(session?.title).toBe("WeChat ClawBot");
   });
 
+  it("backfills channel types from sessions.json when transcript metadata is not channel-specific", async () => {
+    rootDir = await mkdtemp(path.join(tmpdir(), "nexu-sessions-runtime-"));
+    const runtime = new SessionsRuntime(
+      createEnv({
+        openclawStateDir: rootDir,
+        openclawConfigPath: path.join(rootDir, "openclaw.json"),
+        openclawSkillsDir: path.join(rootDir, "skills"),
+        openclawWorkspaceTemplatesDir: path.join(
+          rootDir,
+          "workspace-templates",
+        ),
+      }),
+    );
+
+    const sessionsDir = path.join(
+      rootDir,
+      "agents",
+      "bot-cross-channel",
+      "sessions",
+    );
+    await mkdir(sessionsDir, { recursive: true });
+
+    const whatsappSessionPath = path.join(sessionsDir, "whatsapp.jsonl");
+    await writeFile(
+      whatsappSessionPath,
+      `${JSON.stringify({
+        type: "message",
+        id: "msg-whatsapp-1",
+        timestamp: "2026-03-26T08:22:07.967Z",
+        message: {
+          role: "user",
+          timestamp: 1774513327964,
+          content: [
+            {
+              type: "text",
+              text: [
+                "Conversation info (untrusted metadata):",
+                "```json",
+                JSON.stringify(
+                  {
+                    message_id: "AC2095457BE8A88A52DF303FC76D74B6",
+                    sender_id: "+447925140412",
+                    sender: "xirui0328",
+                  },
+                  null,
+                  2,
+                ),
+                "```",
+                "",
+                "Sender (untrusted metadata):",
+                "```json",
+                JSON.stringify(
+                  {
+                    label: "xirui0328 (+447925140412)",
+                    id: "+447925140412",
+                    name: "xirui0328",
+                    e164: "+447925140412",
+                  },
+                  null,
+                  2,
+                ),
+                "```",
+              ].join("\n"),
+            },
+          ],
+        },
+      })}\n`,
+      "utf8",
+    );
+
+    const telegramSessionPath = path.join(sessionsDir, "telegram.jsonl");
+    await writeFile(
+      telegramSessionPath,
+      `${JSON.stringify({
+        type: "message",
+        id: "msg-telegram-1",
+        timestamp: "2026-03-25T13:12:22.898Z",
+        message: {
+          role: "user",
+          timestamp: 1774444342895,
+          content: [
+            {
+              type: "text",
+              text: [
+                "Conversation info (untrusted metadata):",
+                "```json",
+                JSON.stringify(
+                  {
+                    message_id: "1",
+                    sender_id: "6658353153",
+                    sender: "Markeyda Williams",
+                  },
+                  null,
+                  2,
+                ),
+                "```",
+                "",
+                "Sender (untrusted metadata):",
+                "```json",
+                JSON.stringify(
+                  {
+                    label: "Markeyda Williams (6658353153)",
+                    id: "6658353153",
+                    name: "Markeyda Williams",
+                  },
+                  null,
+                  2,
+                ),
+                "```",
+              ].join("\n"),
+            },
+          ],
+        },
+      })}\n`,
+      "utf8",
+    );
+
+    await writeFile(
+      path.join(sessionsDir, "sessions.json"),
+      JSON.stringify(
+        {
+          "agent:bot-cross-channel:direct:+447925140412": {
+            sessionId: "whatsapp",
+            sessionFile: whatsappSessionPath,
+            lastChannel: "whatsapp",
+            origin: {
+              provider: "whatsapp",
+              label: "+447925140412",
+            },
+          },
+          "agent:bot-cross-channel:direct:6658353153": {
+            sessionId: "telegram",
+            sessionFile: telegramSessionPath,
+            lastChannel: "telegram",
+            origin: {
+              provider: "telegram",
+              label: "Markeyda Williams id:6658353153",
+            },
+          },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const sessions = await runtime.listSessions();
+
+    expect(
+      sessions.find((session) => session.sessionKey === "whatsapp")
+        ?.channelType,
+    ).toBe("whatsapp");
+    expect(
+      sessions.find((session) => session.sessionKey === "telegram")
+        ?.channelType,
+    ).toBe("telegram");
+  });
+
   it("normalizes Feishu chat history before returning it", async () => {
     rootDir = await mkdtemp(path.join(tmpdir(), "nexu-sessions-runtime-"));
     const runtime = new SessionsRuntime(

--- a/apps/web/src/components/activity-feed.tsx
+++ b/apps/web/src/components/activity-feed.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { getApiV1Sessions } from "../../lib/api/sdk.gen";
+import { PlatformIcon } from "./platform-icons";
 
 /**
  * Activity Feed component showing recent session activity.
@@ -39,6 +40,10 @@ const CHANNEL_LABELS: Record<string, string> = {
   feishu: "飞书",
   slack: "Slack",
   discord: "Discord",
+  telegram: "Telegram",
+  whatsapp: "WhatsApp",
+  wechat: "WeChat",
+  "openclaw-weixin": "openclaw-weixin",
   web: "Web",
 };
 
@@ -135,7 +140,8 @@ export function ActivityFeed() {
                 </p>
                 <div className="mt-1.5 flex items-center gap-2">
                   {session.channelType && (
-                    <span className="text-[10px] px-2 py-0.5 rounded-full bg-surface-2 text-text-muted">
+                    <span className="inline-flex items-center gap-1 text-[10px] px-2 py-0.5 rounded-full bg-surface-2 text-text-muted">
+                      <PlatformIcon platform={session.channelType} size={12} />
                       {CHANNEL_LABELS[session.channelType] ??
                         session.channelType}
                     </span>

--- a/apps/web/src/layouts/workspace-layout.tsx
+++ b/apps/web/src/layouts/workspace-layout.tsx
@@ -67,6 +67,7 @@ type Platform =
   | "whatsapp"
   | "telegram"
   | "feishu"
+  | "wechat"
   | "openclaw-weixin"
   | "web";
 
@@ -74,6 +75,7 @@ const PLATFORM_LABELS: Record<Platform, string> = {
   discord: "Discord",
   slack: "Slack",
   feishu: "Feishu",
+  wechat: "WeChat",
   "openclaw-weixin": "WeChat",
   whatsapp: "WhatsApp",
   telegram: "Telegram",
@@ -1082,7 +1084,9 @@ function WorkspaceLayoutInner() {
                               : "text-text-secondary hover:text-text-primary hover:bg-surface-3",
                           )}
                         >
-                          <SidebarPlatformIcon platform={s.channelType} />
+                          <SidebarPlatformIcon
+                            platform={s.channelType ?? "web"}
+                          />
                           <div className="flex-1 min-w-0">
                             <div className="flex items-center gap-2 min-w-0">
                               <div className="text-[13px] truncate font-medium">

--- a/apps/web/src/lib/tracking.ts
+++ b/apps/web/src/lib/tracking.ts
@@ -2,7 +2,13 @@ import * as amplitude from "@amplitude/unified";
 import { Identify } from "@amplitude/unified";
 
 export type AnalyticsAuthSource = "welcome_page" | "settings";
-export type AnalyticsChannel = "wechat" | "feishu" | "slack" | "discord";
+export type AnalyticsChannel =
+  | "wechat"
+  | "feishu"
+  | "slack"
+  | "discord"
+  | "telegram"
+  | "whatsapp";
 export type AnalyticsSidebarTarget =
   | "home"
   | "conversations"
@@ -48,7 +54,13 @@ export function normalizeChannel(
   if (channel === "openclaw-weixin" || channel === "wechat") {
     return "wechat";
   }
-  if (channel === "feishu" || channel === "slack" || channel === "discord") {
+  if (
+    channel === "feishu" ||
+    channel === "slack" ||
+    channel === "discord" ||
+    channel === "telegram" ||
+    channel === "whatsapp"
+  ) {
     return channel;
   }
   return null;

--- a/apps/web/tests/activity-feed.test.tsx
+++ b/apps/web/tests/activity-feed.test.tsx
@@ -61,6 +61,35 @@ function renderActivityFeed(): string {
   );
 }
 
+function renderActivityFeedWithSession(session: {
+  id: string;
+  title: string;
+  channelType: string;
+  lastMessageAt: string;
+  messageCount: number;
+  status: string;
+}): string {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  queryClient.setQueryData(["sessions-recent"], {
+    sessions: [session],
+  });
+
+  return renderToStaticMarkup(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <ActivityFeed />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
 describe("ActivityFeed", () => {
   it("links recent activity rows to the matching workspace session", () => {
     const markup = renderActivityFeed();
@@ -68,5 +97,29 @@ describe("ActivityFeed", () => {
     expect(markup).toContain('data-activity-session-link="sess-1"');
     expect(markup).toContain('href="/workspace/sessions/sess-1"');
     expect(markup).toContain("唐其远");
+  });
+
+  it("renders Telegram and WhatsApp activity with distinct badges", () => {
+    const telegramMarkup = renderActivityFeedWithSession({
+      id: "sess-tg",
+      title: "Telegram thread",
+      channelType: "telegram",
+      lastMessageAt: "2026-03-20T08:58:00.000Z",
+      messageCount: 2,
+      status: "active",
+    });
+    const whatsappMarkup = renderActivityFeedWithSession({
+      id: "sess-wa",
+      title: "WhatsApp thread",
+      channelType: "whatsapp",
+      lastMessageAt: "2026-03-20T08:58:00.000Z",
+      messageCount: 2,
+      status: "active",
+    });
+
+    expect(telegramMarkup).toContain("Telegram");
+    expect(telegramMarkup).toContain("<title>Telegram</title>");
+    expect(whatsappMarkup).toContain("WhatsApp");
+    expect(whatsappMarkup).toContain("<title>WhatsApp</title>");
   });
 });

--- a/apps/web/tests/sessions.test.tsx
+++ b/apps/web/tests/sessions.test.tsx
@@ -401,6 +401,68 @@ describe("SessionsPage", () => {
     );
   });
 
+  it("renders WhatsApp session headers with the platform icon and open-chat action", () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+
+    queryClient.setQueryData(["session-meta", "sess-whatsapp"], {
+      id: "sess-whatsapp",
+      botId: "bot-whatsapp",
+      sessionKey: "sess-whatsapp",
+      channelId: "channel-whatsapp-1",
+      title: "Alice",
+      channelType: "whatsapp",
+      messageCount: 5,
+      lastMessageAt: "2026-03-20T08:58:00.000Z",
+      metadata: {},
+    });
+    queryClient.setQueryData(["chat-history", "sess-whatsapp"], {
+      messages: [
+        {
+          id: "msg-whatsapp-1",
+          role: "assistant",
+          content: "Hello from WhatsApp",
+          timestamp: new Date("2026-03-20T08:58:00.000Z").getTime(),
+          createdAt: "2026-03-20T08:58:00.000Z",
+        },
+      ],
+    });
+    queryClient.setQueryData(["channels"], {
+      channels: [
+        {
+          id: "channel-whatsapp-1",
+          channelType: "whatsapp",
+          accountId: "whatsapp-default",
+          teamName: "WhatsApp",
+          appId: null,
+          botUserId: null,
+          status: "connected",
+        },
+      ],
+    });
+
+    const markup = renderToStaticMarkup(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/workspace/sessions/sess-whatsapp"]}>
+          <Routes>
+            <Route path="/workspace/sessions/:id" element={<SessionsPage />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(markup).toContain('data-session-platform="whatsapp"');
+    expect(markup).toContain("<title>WhatsApp</title>");
+    expect(markup).toContain("WhatsApp · 5 messages");
+    expect(markup).toContain('href="https://web.whatsapp.com/"');
+    expect(markup).toContain("Open in WhatsApp");
+  });
+
   it("strips assistant reply markers and keeps tool-only activity visible", () => {
     const queryClient = new QueryClient({
       defaultOptions: {

--- a/apps/web/tests/workspace-layout.test.tsx
+++ b/apps/web/tests/workspace-layout.test.tsx
@@ -151,4 +151,50 @@ describe("WorkspaceLayout", () => {
     expect(markup).toContain("<title>Slack</title>");
     expect(markup).toContain("Design sync thread");
   });
+
+  it("renders WhatsApp sessions with the correct sidebar icon and label", () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+
+    queryClient.setQueryData(
+      ["sidebar-sessions"],
+      [
+        {
+          id: "sess-wa",
+          title: "Alice",
+          channelType: "whatsapp",
+          lastTime: "2026-03-20T08:57:00.000Z",
+          status: "active",
+        },
+      ],
+    );
+    queryClient.setQueryData(["me"], {
+      email: "alice@example.com",
+      name: "Alice",
+    });
+
+    const markup = renderToStaticMarkup(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/workspace/sessions/sess-wa"]}>
+          <Routes>
+            <Route element={<WorkspaceLayout />}>
+              <Route
+                path="/workspace/sessions/:id"
+                element={<div>Session body</div>}
+              />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(markup).toContain('data-session-channel-type="whatsapp"');
+    expect(markup).toContain("<title>WhatsApp</title>");
+    expect(markup).toContain("WhatsApp");
+  });
 });


### PR DESCRIPTION
Relates to #620, #621

## What

  Backfill session channel types from the OpenClaw session index and expose Telegram / WhatsApp badges consistently in
  the web UI.

  ## Why

  Recent Telegram and WhatsApp conversations were falling back to `Web` in recent activity, the conversations sidebar,
  and the session header because some historical session transcripts do not include channel-specific markers in their
  message text. The runtime already knows the real source channel in `sessions.json`, but that data was not being used
  when building session responses.

  ## How

  - read `sessions.json` alongside each agent session directory and use `lastChannel` / `origin.provider` to backfill
  `channelType` when transcript inference is missing
  - normalize inferred `wechat` values to `openclaw-weixin`
  - extend recent activity, sidebar, and analytics channel mapping so Telegram / WhatsApp render with their own badges
  and icons instead of falling back to `Web`
  - add controller and web tests covering the index backfill path and the updated UI rendering

  ## Affected areas

  - [ ] Desktop app (Electron shell)
  - [x] Controller (backend / API)
  - [x] Web dashboard (React UI)
  - [ ] OpenClaw runtime
  - [ ] Skills
  - [ ] Shared schemas / packages
  - [ ] Build / CI / Tooling

  ## Checklist

  - [x] `pnpm typecheck` passes
  - [x] `pnpm lint` passes
  - [ ] `pnpm test` passes
  - [ ] `pnpm generate-types` run (if API routes/schemas changed)
  - [x] No credentials or tokens in code or logs
  - [x] No `any` types introduced (use `unknown` with narrowing)

  ## Notes for reviewers

  Targeted verification run:
  - `pnpm exec vitest run --dir apps/controller tests/sessions-runtime.test.ts`
  - `pnpm exec vitest run --dir apps/web tests/activity-feed.test.tsx tests/workspace-layout.test.tsx tests/
  sessions.test.tsx`

  I did not mark full `pnpm test` as passing because the repository currently has unrelated failing tests outside this
  change set.
