### PR TITLE
chore(desktop): add structured bootstrap diagnostics for launchd services

### DIFF
--- a/apps/desktop/main/services/launchd-bootstrap.ts
+++ b/apps/desktop/main/services/launchd-bootstrap.ts
@@ -510,7 +510,9 @@ export async function bootstrapWithLaunchd(
       const reason = versionMismatch
         ? `App version changed (${recovered.appVersion} → ${env.appVersion})`
         : "Build identity mismatch (openclawStateDir, userDataPath, or buildSource differ)";
-      console.log(`${reason}, tearing down stale services`);
+      console.log(
+        `[bootstrap] teardown: ${reason} (controller=${controllerRunning ? "running" : "stopped"} openclaw=${openclawRunning ? "running" : "stopped"})`,
+      );
       await Promise.allSettled([
         controllerRunning
           ? launchd.bootoutService(labels.controller)
@@ -572,7 +574,7 @@ export async function bootstrapWithLaunchd(
     // corrupted). We can't know the ports they're using, so tear them down
     // and do a clean cold start with fresh ports.
     console.log(
-      "Services running but no runtime-ports.json found, tearing down for clean start",
+      `[bootstrap] teardown: no runtime-ports.json but services running (controller=${controllerRunning ? "running" : "stopped"} openclaw=${openclawRunning ? "running" : "stopped"})`,
     );
     await Promise.allSettled([
       controllerRunning
@@ -587,6 +589,9 @@ export async function bootstrapWithLaunchd(
   // --- Per-service: validate running ones, start missing ones ---
 
   // Health check running services
+  console.log(
+    `[bootstrap] health check: controller=${controllerRunning ? "running" : "stopped"} openclaw=${openclawRunning ? "running" : "stopped"} useRecoveredPorts=${useRecoveredPorts}`,
+  );
   let controllerHealthy = false;
   let openclawHealthy = false;
   let needsControllerReady = true;
@@ -660,25 +665,37 @@ export async function bootstrapWithLaunchd(
     label: string,
     type: "controller" | "openclaw",
   ) => {
+    console.log(`[bootstrap] ${type} installService begin label=${label}`);
     const plist = generatePlist(type, plistEnv);
     await launchd.installService(label, plist);
+    console.log(`[bootstrap] ${type} installService done label=${label}`);
   };
 
-  const ensureRunning = async (label: string) => {
+  const ensureRunning = async (label: string, type: string) => {
     const status = await launchd.getServiceStatus(label);
+    console.log(
+      `[bootstrap] ${type} ensureRunning status=${status.status} pid=${status.pid ?? "none"} label=${label}`,
+    );
     if (status.status !== "running") {
       await launchd.startService(label);
-      console.log(`Started ${label}`);
+      const afterStatus = await launchd.getServiceStatus(label);
+      console.log(
+        `[bootstrap] ${type} kickstart done status=${afterStatus.status} pid=${afterStatus.pid ?? "none"} label=${label}`,
+      );
     }
   };
 
   if (!controllerHealthy) {
     await ensureService(labels.controller, "controller");
-    await ensureRunning(labels.controller);
+    await ensureRunning(labels.controller, "controller");
+  } else {
+    console.log("[bootstrap] controller already healthy, skipping");
   }
   if (!openclawHealthy) {
     await ensureService(labels.openclaw, "openclaw");
-    await ensureRunning(labels.openclaw);
+    await ensureRunning(labels.openclaw, "openclaw");
+  } else {
+    console.log("[bootstrap] openclaw already healthy, skipping");
   }
 
   // Start embedded web server with port retry.
@@ -1279,6 +1296,7 @@ export async function ensureExternalNodeRunner(
     "MacOS",
     binaryName,
   );
+  await fs.mkdir(path.dirname(stagingRoot), { recursive: true });
 
   // Clone the full app bundle so the runner keeps a valid macOS app layout,
   // including signed resources like _CodeSignature and Resources.


### PR DESCRIPTION
## What

Add `[bootstrap]` prefixed structured logs at each decision point in `bootstrapWithLaunchd()`.

## Why

When the desktop app resumes from sleep or encounters partial service state (e.g. controller running but openclaw missing), current logs don't capture enough to distinguish between:
- teardown triggered by version/identity mismatch
- teardown triggered by missing `runtime-ports.json`
- `installService` / `startService` failures that were silently swallowed
- services skipped because they were judged "already healthy"

A real user incident (sleep → wake → "Agent 启动中..." stuck) could not be root-caused from diagnostics alone because the bootstrap flow had no per-service step logging.

## How

- Log teardown reason with service states at each bootout path
- Log health check entry with `controllerRunning` / `openclawRunning` / `useRecoveredPorts`
- Log `installService` begin/done per service type
- Log `ensureRunning` status before and after `kickstart`
- Log skip when a service is already healthy

All logs use `[bootstrap]` prefix for easy grep in diagnostic bundles.

## Affected areas

- [x] Desktop app (Electron shell)

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced