### PR TITLE
fix: disable Cmd+R page reload in production desktop builds

### DIFF
--- a/apps/desktop/main/index.ts
+++ b/apps/desktop/main/index.ts
@@ -902,7 +902,7 @@ app.on("web-contents-created", (_event, contents) => {
       if (productionDebugMode) return;
       if (input.type !== "keyDown") return;
       const isReload =
-        (input.key === "r" && (input.meta || input.control)) ||
+        (input.key.toLowerCase() === "r" && (input.meta || input.control)) ||
         input.key === "F5";
       if (isReload) {
         event.preventDefault();


### PR DESCRIPTION
## What

Disable Cmd+R / Ctrl+R / F5 page reload and hide the Develop menu in production desktop builds, with a hidden shortcut to re-enable them for debugging.

## Why

In production, pressing Cmd+R triggers a full page reload that briefly flashes the internal "starting local service" screen — an implementation detail that should not be visible to end users. Closes #399

## How

1. **Custom View menu** — replaced `{ role: "viewMenu" }` with a hand-built View menu that conditionally includes Reload / Force Reload items only in dev mode (or when debug mode is active).
2. **`before-input-event` guard** — intercepts reload key combos (Cmd+R, Ctrl+R, Ctrl+Shift+R, F5) at the `webContents` level in packaged builds as a defense-in-depth layer.
3. **Develop menu gated** — only shown in dev mode or when debug mode is active.
4. **Hidden debug toggle** — `Cmd+Shift+Alt+D` (`globalShortcut`) toggles `productionDebugMode` at runtime, rebuilding the menu to show/hide dev items and unblocking the input guard. This allows developers to access reload and the Develop menu for troubleshooting without exposing them by default.

## Affected areas

- [x] Desktop app (Electron shell)
- [ ] Controller (backend / API)
- [ ] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [ ] Build / CI / Tooling

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

## Notes for reviewers

- The `globalShortcut` for `Cmd+Shift+Alt+D` is only registered in packaged builds — no effect in dev.
- The `before-input-event` handler checks `productionDebugMode` on every keypress so the toggle takes effect immediately without needing to re-attach listeners.
- Only one file changed: `apps/desktop/main/index.ts`.

https://claude.ai/code/session_011HgRMGtVKZrTki8N2cvNcp