### PR TITLE
fix: drop internal block messages in Feishu and Weixin reply dispatchers

### DIFF
--- a/apps/controller/static/runtime-plugins/openclaw-weixin/src/messaging/process-message.ts
+++ b/apps/controller/static/runtime-plugins/openclaw-weixin/src/messaging/process-message.ts
@@ -341,7 +341,14 @@ export async function processOneMessage(
     deps.channelRuntime.reply.createReplyDispatcherWithTyping({
       humanDelay,
       typingCallbacks,
-      deliver: async (payload) => {
+      deliver: async (payload, info) => {
+        // Drop internal block chunks (tool-call outputs, script runs,
+        // dependency installs). These are execution-level details that must
+        // never surface in user-facing IM chat (#606).
+        if (info?.kind === "block") {
+          return;
+        }
+
         const text = markdownToPlainText(payload.text ?? "");
         const mediaUrl = payload.mediaUrl ?? payload.mediaUrls?.[0];
         logger.debug(

--- a/openclaw-runtime-patches/openclaw/extensions/feishu/src/reply-dispatcher.ts
+++ b/openclaw-runtime-patches/openclaw/extensions/feishu/src/reply-dispatcher.ts
@@ -284,15 +284,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
 
           if (info?.kind === "block") {
-            // Drop internal block chunks unless we can safely consume them as
-            // streaming-card fallback content.
-            if (!(streamingEnabled && useCard)) {
-              return;
-            }
-            startStreaming();
-            if (streamingStartPromise) {
-              await streamingStartPromise;
-            }
+            // Always drop internal block chunks (tool-call outputs, script
+            // runs, dependency installs). These are execution-level details
+            // that must never surface in user-facing IM chat (#606).
+            return;
           }
 
           if (info?.kind === "final" && streamingEnabled && useCard) {


### PR DESCRIPTION
## What

Drop all `info.kind === "block"` messages in the Feishu and Weixin reply dispatchers so internal execution logs never reach end users in IM chat.

## Why

Internal execution logs (tool calls, script runs, dependency installs) were leaking into user-facing IM chat. The Feishu dispatcher had a streaming+card exception that forwarded block content into the streaming card, and the Weixin dispatcher had no block filtering at all.

Closes #606

## How

- **Feishu reply-dispatcher**: Removed the `streamingEnabled && useCard` exception — block messages are now unconditionally dropped instead of being streamed as card delta updates.
- **Weixin process-message**: Added the `info` parameter to the `deliver` callback and added early-return filtering for `info?.kind === "block"`.
- **Slack**: No change needed — uses OpenClaw's built-in Slack extension with `streaming: "partial"` and `verboseDefault: "off"`, which prevents block messages at the core level.

## Affected areas

- [x] OpenClaw runtime
- [x] Controller (backend / API)

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

## Notes for reviewers

The `disableBlockStreaming: true` flag in Feishu's `replyOptions` was already signaling intent to suppress block output, but the `deliver` callback still had a code path that consumed block messages for streaming cards. This PR aligns the deliver callback with that intent.