### PR TITLE
chore: treat app/sentry as internal-equivalent

### DIFF
--- a/scripts/nexu-pal/lib/triage-opened-engine.mjs
+++ b/scripts/nexu-pal/lib/triage-opened-engine.mjs
@@ -11,6 +11,14 @@ export function createTriagePlan() {
   };
 }
 
+function isInternalEquivalentAuthor({ isInternalAuthor, issueAuthorLogin }) {
+  if (isInternalAuthor === true) {
+    return true;
+  }
+
+  return issueAuthorLogin === "app/sentry";
+}
+
 function buildTranslationComment({ translatedTitle, translatedSections }) {
   const maxCommentLength = 65_500;
   const truncationMarker = "… [truncated]";
@@ -313,13 +321,17 @@ function buildNeedsInformationComment({ missingItems, reason }) {
 export async function buildOpenedIssueTriagePlan({
   issueTitle,
   issueBody,
-  isInternalAuthor,
-  issueAuthorLogin,
-  repositoryOwner,
-  issueAuthorAssociation,
+  isInternalAuthor = false,
+  issueAuthorLogin = "",
+  repositoryOwner = "",
+  issueAuthorAssociation = "NONE",
   chat,
 }) {
   const plan = createTriagePlan();
+  const shouldShortCircuitAfterClassification = isInternalEquivalentAuthor({
+    isInternalAuthor,
+    issueAuthorLogin,
+  });
 
   const translation = await detectAndTranslate({ chat, issueTitle, issueBody });
   let englishTitle = issueTitle;
@@ -403,9 +415,15 @@ export async function buildOpenedIssueTriagePlan({
     `organization membership: ${isInternalAuthor === true ? "member" : "non-member"}`,
   );
 
-  if (isInternalAuthor === true) {
+  if (issueAuthorLogin === "app/sentry") {
     plan.diagnostics.push(
-      "organization member detected; skipped roadmap/duplicate/completeness/needs-triage checks",
+      "author is app/sentry; treated as internal-equivalent automation for triage short-circuit",
+    );
+  }
+
+  if (shouldShortCircuitAfterClassification === true) {
+    plan.diagnostics.push(
+      "internal-equivalent author detected; skipped roadmap/duplicate/completeness/needs-triage checks",
     );
     return plan;
   }

--- a/specs/current/nexu-pal.md
+++ b/specs/current/nexu-pal.md
@@ -23,11 +23,11 @@ Runs in order:
 
 3. **Intent classification** — Sends the normalized English title and body to the LLM and assigns only the `bug` label when the issue clearly describes broken behavior.
 
-4. **Internal-member short-circuit** — The workflow checks whether `issue.user.login` belongs to the repository owner's GitHub organization via the org-membership API. If the author is an org member, the opened-issue flow stops after translation + bug classification. Internal issues skip known-issue matching, completeness checks, and `needs-triage` labeling.
+4. **Internal-member short-circuit** — The workflow checks whether `issue.user.login` belongs to the repository owner's GitHub organization via the org-membership API. If the author is an org member, the opened-issue flow stops after translation + bug classification. The same short-circuit also applies to the repository-managed `app/sentry` issue source. These internal-equivalent issues skip known-issue matching, completeness checks, and `needs-triage` labeling.
 
-5. **Completeness check** — For non-internal authors, uses the LLM to decide whether the issue is too incomplete to continue triage. If so, adds `needs-information`, posts a follow-up comment, and pauses there.
+5. **Completeness check** — For authors that are not internal or internal-equivalent, uses the LLM to decide whether the issue is too incomplete to continue triage. If so, adds `needs-information`, posts a follow-up comment, and pauses there.
 
-6. **Triage label** — For non-internal authors, if the issue is not roadmap-matched and does not need more information, adds the `needs-triage` label.
+6. **Triage label** — For authors that are not internal or internal-equivalent, if the issue is not roadmap-matched and does not need more information, adds the `needs-triage` label.
 
 The opened-issue flow is split into a small pipeline:
 
@@ -60,7 +60,7 @@ Current transitions:
 
 Four GitHub Actions send Feishu webhook notifications for GitHub content:
 
-1. **Issue notification** — On `issues: [opened]`, sends the existing issue card to the legacy webhook, but skips notifications when the author is a repository-owner organization member.
+1. **Issue notification** — On `issues: [opened]`, sends the existing issue card to the legacy webhook, but skips notifications when the author is a repository-owner organization member. This suppression remains org-membership-based; the `app/sentry` internal-equivalent triage shortcut does not change the legacy notification rule.
 2. **Needs-triage issue notification** — On `issues: [labeled]`, when the added label is `needs-triage`, sends a triage card to either the bug or non-bug webhook based on the issue's current labels. The workflow maps GitHub secrets to internal env vars `BUG_WEBHOOK` and `REQ_WEBHOOK`.
 3. **Discussion notification** — On `discussion: [created]`, sends the existing discussion card format using the discussion category in place of labels, but skips notifications when the author is a repository-owner organization member.
 4. **Pull request notification** — On `pull_request: [opened]`, sends the existing card format using pull request labels, but skips notifications when the author is a repository-owner organization member.
@@ -83,7 +83,7 @@ The issue/discussion/pull-request workflows run `node scripts/notify/feishu-noti
 
 The three **nexu-pal** workflows create a short-lived token via `actions/create-github-app-token@v1` using secrets `NEXU_PAL_APP_ID` and `NEXU_PAL_PRIVATE_KEY_PEM`. All GitHub API calls and the first-interaction action use this App token.
 
-The issue / discussion / pull-request Feishu notification workflows also create a short-lived GitHub App token so they can reuse the org-membership check and suppress notifications for internal authors. The `needs-triage` Feishu workflow continues to use GitHub Actions event data plus Feishu incoming-webhook secrets.
+The issue / discussion / pull-request Feishu notification workflows also create a short-lived GitHub App token so they can reuse the org-membership check and suppress notifications for organization-member internal authors. The `needs-triage` Feishu workflow continues to use GitHub Actions event data plus Feishu incoming-webhook secrets.
 
 ## Secrets
 
@@ -118,5 +118,5 @@ scripts/nexu-pal/
   lib/signals/duplicate-detector.mjs  # duplicate detector stub
 scripts/notify/
   feishu-triage-notify.mjs # route needs-triage issue notifications via BUG_WEBHOOK / REQ_WEBHOOK
-  feishu-notify.mjs        # issue / discussion / pull-request Feishu webhook card notification with internal-author suppression
+  feishu-notify.mjs        # issue / discussion / pull-request Feishu webhook card notification with org-member suppression
 ```

--- a/tests/nexu-pal/triage-opened-engine.test.ts
+++ b/tests/nexu-pal/triage-opened-engine.test.ts
@@ -145,8 +145,13 @@ describe("buildOpenedIssueTriagePlan", () => {
     });
 
     expect(plan.commentsToAdd).toHaveLength(1);
-    expect(plan.commentsToAdd[0]).toContain("… [truncated]");
-    expect(plan.commentsToAdd[0].length).toBeLessThanOrEqual(65500);
+    const [translationComment] = plan.commentsToAdd;
+    expect(typeof translationComment).toBe("string");
+    if (typeof translationComment !== "string") {
+      throw new Error("expected translation comment");
+    }
+    expect(translationComment).toContain("… [truncated]");
+    expect(String(translationComment).length).toBeLessThanOrEqual(65500);
   });
 
   it("returns a full plan with stub diagnostics and bug-only labeling", async () => {
@@ -244,6 +249,46 @@ describe("buildOpenedIssueTriagePlan", () => {
     expect(plan.diagnostics).toEqual(
       expect.arrayContaining([
         "information completeness: missing reproduction details",
+      ]),
+    );
+  });
+
+  it("treats app/sentry as internal-equivalent and skips needs-information or needs-triage", async () => {
+    const chat = vi
+      .fn()
+      .mockResolvedValueOnce(
+        JSON.stringify({
+          should_translate: false,
+          detected_language: null,
+          translated_title:
+            "Error: Cannot write headers after they are sent to the client",
+          translated_body: "Sentry issue body",
+        }),
+      )
+      .mockResolvedValueOnce(
+        JSON.stringify({
+          is_bug: true,
+          reason: "clear broken behavior",
+        }),
+      );
+
+    const plan = await buildOpenedIssueTriagePlan({
+      issueTitle:
+        "Error: Cannot write headers after they are sent to the client",
+      issueBody: "Sentry issue body",
+      issueAuthorLogin: "app/sentry",
+      isInternalAuthor: false,
+      chat,
+    });
+
+    expect(plan.labelsToAdd).toEqual(["bug"]);
+    expect(plan.commentsToAdd).toEqual([]);
+    expect(chat).toHaveBeenCalledTimes(2);
+    expect(plan.diagnostics).toEqual(
+      expect.arrayContaining([
+        "organization membership: non-member",
+        "author is app/sentry; treated as internal-equivalent automation for triage short-circuit",
+        "internal-equivalent author detected; skipped roadmap/duplicate/completeness/needs-triage checks",
       ]),
     );
   });


### PR DESCRIPTION
## What
Treat app/sentry issues as internal-equivalent so the opened issue triage short-circuits after translation and classification and adjust docs/tests accordingly.

## Why
Sentry automation issues should skip duplicate/completeness/needs-triage steps (like org members) so automated reports stay out of the manual pipeline without changing the existing Feishu notification suppression.

## How
- add the isInternalEquivalentAuthor helper plus diagnostics and early return in buildOpenedIssueTriagePlan
- expand nexu-pal docs to describe the app/sentry shortcut and org-member notification behavior
- extend tests to guard translation comment handling and the app/sentry path

## Affected areas
- [ ] Desktop app (Electron shell)
- [ ] Controller (backend / API)
- [ ] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [ ] Build / CI / Tooling

## Checklist
- [ ] pnpm typecheck passes
- [ ] pnpm lint passes
- [ ] pnpm test passes
- [ ] pnpm generate-types run (if API routes/schemas changed)
- [ ] No credentials or tokens in code or logs
- [ ] No any types introduced (use unknown with narrowing)

## Notes for reviewers
- Not run: typecheck/lint/test/generate-types