### PR TITLE
fix(web): close channel connect modal on request failure

### DIFF
--- a/apps/web/src/components/channel-connect-modal.tsx
+++ b/apps/web/src/components/channel-connect-modal.tsx
@@ -220,6 +220,7 @@ export function ChannelConnectModal({
           toast.info(t("modal.channelConnected"));
         } else {
           toast.error(error.message ?? t("modal.connectFailed"));
+          onClose();
           return;
         }
       } else {


### PR DESCRIPTION
## What
Close the channel connect modal when a non-409 API request fails.

## Why
Previously, non-conflict errors left the modal open with a toast error but no way to dismiss the modal state. Users had to manually close it. Closes the modal automatically so the UI resets cleanly.

## How
Added `onClose()` call before the early `return` in the non-409 error branch of the connect handler.

## Affected areas
- [x] Web dashboard (React UI)

## Checklist
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)