### PR TITLE
fix(desktop): window close hides to background instead of showing quit dialog

### DIFF
--- a/apps/desktop/main/services/quit-handler.ts
+++ b/apps/desktop/main/services/quit-handler.ts
@@ -1,13 +1,11 @@
 /**
  * Quit Handler - Desktop exit behavior with launchd services
  *
- * On macOS, window close is intercepted to show a quit dialog.
- * - Quit Completely: stop all launchd services and exit
- * - Run in Background: hide window, keep services running
- * - Cancel: do nothing
+ * Window close (red traffic light) → hide to background, services keep running.
+ * Cmd+Q / Dock Quit → full teardown and exit.
  */
 
-import { BrowserWindow, app, dialog } from "electron";
+import { BrowserWindow, app } from "electron";
 import type { EmbeddedWebServer } from "./embedded-web-server";
 import { teardownLaunchdServices } from "./launchd-bootstrap";
 import type { LaunchdManager } from "./launchd-manager";
@@ -28,56 +26,6 @@ export interface QuitHandlerOptions {
 }
 
 export type QuitDecision = "quit-completely" | "run-in-background" | "cancel";
-
-const i18n = {
-  en: {
-    buttons: ["Quit Completely", "Run in Background", "Cancel"],
-    title: "Quit Nexu",
-    message: "Choose exit mode",
-    detail:
-      "Running in background keeps services running, bots continue working.\n\n" +
-      "To fully stop services, choose 'Quit Completely'.",
-  },
-  zh: {
-    buttons: ["完全退出", "后台运行", "取消"],
-    title: "退出 Nexu",
-    message: "选择退出方式",
-    detail:
-      "后台运行将保持服务运行，机器人继续工作。\n\n" +
-      "如需完全停止服务，请选择「完全退出」。",
-  },
-} as const;
-
-function getQuitDialogLocale(): {
-  buttons: readonly string[];
-  title: string;
-  message: string;
-  detail: string;
-} {
-  const locale = app.getLocale();
-  return locale.startsWith("zh") ? i18n.zh : i18n.en;
-}
-
-async function showQuitDialog(): Promise<QuitDecision> {
-  const t = getQuitDialogLocale();
-  const { response } = await dialog.showMessageBox({
-    type: "question",
-    buttons: [...t.buttons],
-    defaultId: 0,
-    title: t.title,
-    message: t.message,
-    detail: t.detail,
-  });
-
-  switch (response) {
-    case 0:
-      return "quit-completely";
-    case 1:
-      return "run-in-background";
-    default:
-      return "cancel";
-  }
-}
 
 /**
  * Install quit handler for launchd-managed services.
@@ -123,9 +71,7 @@ async function runTeardownAndExit(
 }
 
 export function installLaunchdQuitHandler(opts: QuitHandlerOptions): void {
-  let dialogOpen = false;
-
-  // Intercept main window close to show quit dialog
+  // Intercept main window close — hide to background (no dialog)
   const interceptWindowClose = (window: BrowserWindow) => {
     window.on("close", (event) => {
       // If a force-quit is in progress, let the window close
@@ -140,32 +86,11 @@ export function installLaunchdQuitHandler(opts: QuitHandlerOptions): void {
         return;
       }
 
-      // Prevent close while dialog is showing
-      if (dialogOpen) {
-        event.preventDefault();
-        return;
-      }
-
+      // Window close (red traffic light) → hide to background.
+      // Services keep running so bots stay online.
+      // "Quit Completely" is only triggered via Cmd+Q / Dock Quit.
       event.preventDefault();
-      dialogOpen = true;
-
-      void (async () => {
-        const decision = await showQuitDialog();
-        dialogOpen = false;
-
-        if (decision === "cancel") {
-          return;
-        }
-
-        if (decision === "run-in-background") {
-          window.hide();
-          return;
-        }
-
-        // "quit-completely" — onForceQuit only fires on explicit user choice
-        opts.onForceQuit?.();
-        await runTeardownAndExit(opts, "packaged-quit");
-      })();
+      window.hide();
     });
   };
 
@@ -186,16 +111,10 @@ export function installLaunchdQuitHandler(opts: QuitHandlerOptions): void {
       return;
     }
 
-    // Packaged: redirect to window close handler for dialog.
+    // Packaged Cmd+Q / Dock Quit → full teardown and exit.
     event.preventDefault();
-    const win = BrowserWindow.getAllWindows()[0];
-    if (win) {
-      if (!win.isVisible()) win.show();
-      win.close();
-    } else {
-      // No window (renderer crashed or already destroyed).
-      void runTeardownAndExit(opts, "packaged-no-window");
-    }
+    opts.onForceQuit?.();
+    void runTeardownAndExit(opts, "packaged-quit");
   });
 }
 

--- a/tests/desktop/quit-handler-full.test.ts
+++ b/tests/desktop/quit-handler-full.test.ts
@@ -145,9 +145,9 @@ describe("installLaunchdQuitHandler", () => {
   });
 
   // -------------------------------------------------------------------------
-  // 2. Window close in packaged mode shows quit dialog (prevent default)
+  // 2. Window close in packaged mode hides to background (no dialog)
   // -------------------------------------------------------------------------
-  it("prevents default and shows quit dialog in packaged mode", async () => {
+  it("hides window to background on close in packaged mode", async () => {
     mockApp.isPackaged = true;
 
     const { installLaunchdQuitHandler } = await import(
@@ -159,9 +159,10 @@ describe("installLaunchdQuitHandler", () => {
     const event = simulateClose();
 
     expect(event.preventDefault).toHaveBeenCalled();
-    // Dialog is shown asynchronously
-    await flush();
-    expect(mockDialog.showMessageBox).toHaveBeenCalledTimes(1);
+    expect(mockWindow.hide).toHaveBeenCalledTimes(1);
+    // No dialog, no teardown, no exit
+    expect(mockTeardown).not.toHaveBeenCalled();
+    expect(mockApp.exit).not.toHaveBeenCalled();
   });
 
   // -------------------------------------------------------------------------
@@ -210,130 +211,45 @@ describe("installLaunchdQuitHandler", () => {
   });
 
   // -------------------------------------------------------------------------
-  // 5. Dialog "cancel" (response=2) does nothing
+  // 5. Multiple window closes just hide repeatedly (no state leak)
   // -------------------------------------------------------------------------
-  it("cancel response does nothing", async () => {
-    mockDialog.showMessageBox.mockResolvedValue({ response: 2 });
-
-    const opts = createQuitOpts();
-    const { installLaunchdQuitHandler } = await import(
-      "../../apps/desktop/main/services/quit-handler"
-    );
-
-    installLaunchdQuitHandler(opts as never);
-
-    simulateClose();
-    await flush();
-
-    expect(mockWindow.hide).not.toHaveBeenCalled();
-    expect(opts.onBeforeQuit).not.toHaveBeenCalled();
-    expect(mockApp.exit).not.toHaveBeenCalled();
-  });
-
-  // -------------------------------------------------------------------------
-  // 6. Dialog "run-in-background" (response=1) hides window
-  // -------------------------------------------------------------------------
-  it("run-in-background hides window", async () => {
-    mockDialog.showMessageBox.mockResolvedValue({ response: 1 });
-
-    const opts = createQuitOpts();
-    const { installLaunchdQuitHandler } = await import(
-      "../../apps/desktop/main/services/quit-handler"
-    );
-
-    installLaunchdQuitHandler(opts as never);
-
-    simulateClose();
-    await flush();
-
-    expect(mockWindow.hide).toHaveBeenCalledTimes(1);
-    expect(mockTeardown).not.toHaveBeenCalled();
-    expect(mockApp.exit).not.toHaveBeenCalled();
-  });
-
-  // -------------------------------------------------------------------------
-  // 7. Dialog "quit-completely" (response=0) full teardown sequence
-  // -------------------------------------------------------------------------
-  it("quit-completely calls onBeforeQuit, webServer.close, teardown, exit", async () => {
-    mockDialog.showMessageBox.mockResolvedValue({ response: 0 });
-
-    const opts = createQuitOpts();
-    const { installLaunchdQuitHandler } = await import(
-      "../../apps/desktop/main/services/quit-handler"
-    );
-
-    installLaunchdQuitHandler(opts as never);
-
-    simulateClose();
-    await flush();
-
-    expect(opts.onBeforeQuit).toHaveBeenCalledTimes(1);
-    expect(opts.webServer.close).toHaveBeenCalledTimes(1);
-    expect(mockTeardown).toHaveBeenCalledWith({
-      launchd: opts.launchd,
-      labels: opts.labels,
-      plistDir: "/tmp/test-plist",
-    });
-    expect(mockApp.exit).toHaveBeenCalledWith(0);
-  });
-
-  // -------------------------------------------------------------------------
-  // 8. dialogOpen guard prevents re-entrant close
-  // -------------------------------------------------------------------------
-  it("prevents re-entrant close while dialog is open", async () => {
-    // Make the dialog hang until we resolve it
-    let resolveDialog!: (value: { response: number }) => void;
-    mockDialog.showMessageBox.mockReturnValue(
-      new Promise((resolve) => {
-        resolveDialog = resolve;
-      }),
-    );
-
-    const { installLaunchdQuitHandler } = await import(
-      "../../apps/desktop/main/services/quit-handler"
-    );
-
-    installLaunchdQuitHandler(createQuitOpts() as never);
-
-    // First close triggers dialog
-    const event1 = simulateClose();
-    expect(event1.preventDefault).toHaveBeenCalled();
-
-    // Allow microtask to start the dialog
-    await flush();
-    expect(mockDialog.showMessageBox).toHaveBeenCalledTimes(1);
-
-    // Second close while dialog is open — should preventDefault but not show another dialog
-    const event2 = simulateClose();
-    expect(event2.preventDefault).toHaveBeenCalled();
-    await flush();
-    expect(mockDialog.showMessageBox).toHaveBeenCalledTimes(1); // Still just 1
-
-    // Resolve the dialog
-    resolveDialog({ response: 2 }); // cancel
-    await flush();
-  });
-
-  // -------------------------------------------------------------------------
-  // 9. before-quit in packaged mode prevents quit and shows window
-  // -------------------------------------------------------------------------
-  it("before-quit in packaged mode prevents quit and shows/closes window", async () => {
+  it("repeated window close just hides each time", async () => {
     mockApp.isPackaged = true;
-    mockWindow.isVisible.mockReturnValue(false);
 
     const { installLaunchdQuitHandler } = await import(
       "../../apps/desktop/main/services/quit-handler"
     );
 
     installLaunchdQuitHandler(createQuitOpts() as never);
+
+    simulateClose();
+    simulateClose();
+
+    expect(mockWindow.hide).toHaveBeenCalledTimes(2);
+    expect(mockTeardown).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // 9. before-quit (Cmd+Q) in packaged mode does full teardown
+  // -------------------------------------------------------------------------
+  it("before-quit in packaged mode runs teardown and exits", async () => {
+    mockApp.isPackaged = true;
+
+    const { installLaunchdQuitHandler } = await import(
+      "../../apps/desktop/main/services/quit-handler"
+    );
+
+    const opts = createQuitOpts();
+    installLaunchdQuitHandler(opts as never);
 
     const handler = getBeforeQuitHandler();
     const event = { preventDefault: vi.fn() };
     handler(event);
 
     expect(event.preventDefault).toHaveBeenCalled();
-    expect(mockWindow.show).toHaveBeenCalled();
-    expect(mockWindow.close).toHaveBeenCalled();
+    await flush();
+    expect(mockTeardown).toHaveBeenCalledTimes(1);
+    expect(mockApp.exit).toHaveBeenCalledWith(0);
   });
 
   // -------------------------------------------------------------------------
@@ -403,62 +319,5 @@ describe("installLaunchdQuitHandler", () => {
     handler(event);
 
     expect(event.preventDefault).not.toHaveBeenCalled();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// getQuitDialogLocale (tested indirectly via showMessageBox call content)
-// ---------------------------------------------------------------------------
-
-describe("getQuitDialogLocale", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    closeHandlers.length = 0;
-    mockGetAllWindows.mockReturnValue([mockWindow]);
-    mockApp.__nexuForceQuit = false;
-    mockApp.isPackaged = true;
-    mockTeardown.mockResolvedValue(undefined);
-  });
-
-  // -------------------------------------------------------------------------
-  // 12. Returns zh for zh-CN locale
-  // -------------------------------------------------------------------------
-  it("uses Chinese locale for zh-CN", async () => {
-    mockApp.getLocale.mockReturnValue("zh-CN");
-    mockDialog.showMessageBox.mockResolvedValue({ response: 2 }); // cancel
-
-    const { installLaunchdQuitHandler } = await import(
-      "../../apps/desktop/main/services/quit-handler"
-    );
-
-    installLaunchdQuitHandler(createQuitOpts() as never);
-
-    simulateClose();
-    await flush();
-
-    const dialogCall = mockDialog.showMessageBox.mock.calls[0][0];
-    expect(dialogCall.title).toBe("\u9000\u51FA Nexu");
-    expect(dialogCall.buttons).toContain("\u5B8C\u5168\u9000\u51FA");
-  });
-
-  // -------------------------------------------------------------------------
-  // 13. Returns en for non-zh locale
-  // -------------------------------------------------------------------------
-  it("uses English locale for non-zh locale", async () => {
-    mockApp.getLocale.mockReturnValue("en-US");
-    mockDialog.showMessageBox.mockResolvedValue({ response: 2 }); // cancel
-
-    const { installLaunchdQuitHandler } = await import(
-      "../../apps/desktop/main/services/quit-handler"
-    );
-
-    installLaunchdQuitHandler(createQuitOpts() as never);
-
-    simulateClose();
-    await flush();
-
-    const dialogCall = mockDialog.showMessageBox.mock.calls[0][0];
-    expect(dialogCall.title).toBe("Quit Nexu");
-    expect(dialogCall.buttons).toContain("Quit Completely");
   });
 });


### PR DESCRIPTION
## What

Remove the quit dialog when closing the window. Instead, follow standard macOS behavior.

## Why

Users expect clicking the red traffic light to hide the app to background (like Slack, Discord, Telegram). The quit dialog was confusing and added friction.

## How

- **Window close (red traffic light)** → `window.hide()`, services keep running in background
- **Cmd+Q / Dock Quit** → full `teardownLaunchdServices` and `app.exit(0)`
- Removed `showQuitDialog`, `getQuitDialogLocale`, i18n strings, `dialog` import
- `-92 lines` of dialog code, `+11 lines` of simpler hide logic

## Behavior matrix

| Action | Before | After |
|--------|--------|-------|
| Red traffic light | Shows 3-choice dialog | Hides to background |
| Cmd+Q | Redirected to dialog | Direct teardown + exit |
| Dock Quit | Redirected to dialog | Direct teardown + exit |
| Click Dock icon while hidden | Shows window | Shows window (unchanged) |

## Checklist
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (58 files, 614 tests)
- [x] Tests updated: dialog tests removed, hide-to-background tests added

🤖 Generated with [Claude Code](https://claude.com/claude-code)