### PR TITLE
fix(web): show live channel runtime status on channels page

### DIFF
--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -367,6 +367,8 @@ const en = {
   "channels.comingSoon": "Microsoft Teams, Line and more coming soon",
   "channels.backToConfig": "Back to configuration",
   "channels.statusConnected": "{{platform}} Bot Connected",
+  "channels.statusConnecting": "Connecting...",
+  "channels.statusError": "Connection Error",
   "channels.configuredDate": "configured {{date}}",
   "channels.connectionActive": "connection active",
   "channels.setupGuide": "Setup Guide",

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -352,6 +352,8 @@ const zhCN = {
   "channels.comingSoon": "Microsoft Teams、Line 等更多平台即将支持",
   "channels.backToConfig": "返回配置",
   "channels.statusConnected": "{{platform}} Bot 已连接",
+  "channels.statusConnecting": "连接中...",
+  "channels.statusError": "连接异常",
   "channels.configuredDate": "配置于 {{date}}",
   "channels.connectionActive": "连接正常",
   "channels.setupGuide": "配置指南",

--- a/apps/web/src/pages/channels.tsx
+++ b/apps/web/src/pages/channels.tsx
@@ -33,6 +33,7 @@ import "@/lib/api";
 import {
   deleteApiV1ChannelsByChannelId,
   getApiV1Channels,
+  getApiV1ChannelsLiveStatus,
 } from "../../lib/api/sdk.gen";
 
 type Platform =
@@ -42,6 +43,16 @@ type Platform =
   | "wechat"
   | "telegram"
   | "whatsapp";
+
+type LiveStatusData = {
+  gatewayConnected: boolean;
+  channels: {
+    channelType: string;
+    channelId: string;
+    status: string;
+    lastError: string | null;
+  }[];
+};
 
 const PLATFORMS: { id: Platform; emoji: string; desc: string }[] = [
   { id: "whatsapp", emoji: "\u{1F4DE}", desc: "Personal WhatsApp" },
@@ -93,6 +104,16 @@ export function ChannelsPage() {
     },
   });
 
+  const { data: liveStatusData } = useQuery({
+    queryKey: ["channels-live-status"],
+    queryFn: async () => {
+      const { data } = await getApiV1ChannelsLiveStatus();
+      return data as LiveStatusData | undefined;
+    },
+    refetchInterval: 3000,
+    enabled: (channelsData?.channels?.length ?? 0) > 0,
+  });
+
   const { available: quotaAvailable, resetsAt } = useBotQuota();
 
   const channels = channelsData?.channels ?? [];
@@ -129,7 +150,14 @@ export function ChannelsPage() {
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-3 mb-6">
         {PLATFORMS.map((p) => {
           const isActive = platform === p.id;
-          const connected = channels.some((ch) => ch.channelType === p.id);
+          const configuredChannel = channels.find(
+            (ch) => ch.channelType === p.id,
+          );
+          const connected = !!configuredChannel;
+          const channelLive = liveStatusData?.channels?.find(
+            (e) => e.channelId === configuredChannel?.id,
+          );
+          const channelLiveStatus = channelLive?.status;
           return (
             <button
               type="button"
@@ -159,10 +187,20 @@ export function ChannelsPage() {
                 </div>
               </div>
               {connected ? (
-                <CheckCircle2
-                  size={14}
-                  className="text-[var(--color-success)] shrink-0"
-                />
+                channelLiveStatus === "error" ? (
+                  <Shield size={14} className="text-red-500 shrink-0" />
+                ) : channelLiveStatus === "connecting" ||
+                  channelLiveStatus === "restarting" ? (
+                  <Loader2
+                    size={14}
+                    className="text-amber-500 shrink-0 animate-spin"
+                  />
+                ) : (
+                  <CheckCircle2
+                    size={14}
+                    className="text-[var(--color-success)] shrink-0"
+                  />
+                )
               ) : (
                 <Circle size={14} className="text-text-muted/30 shrink-0" />
               )}
@@ -231,6 +269,7 @@ export function ChannelsPage() {
           channel={currentChannel}
           queryClient={queryClient}
           onShowGuide={() => setForceGuide(true)}
+          liveStatusData={liveStatusData}
         />
       ) : null}
     </div>
@@ -244,6 +283,7 @@ function ConfiguredView({
   channel,
   queryClient,
   onShowGuide,
+  liveStatusData,
 }: {
   platform: Platform;
   channel: {
@@ -257,10 +297,17 @@ function ConfiguredView({
   };
   queryClient: ReturnType<typeof useQueryClient>;
   onShowGuide: () => void;
+  liveStatusData: LiveStatusData | undefined;
 }) {
   const { t } = useTranslation();
   const [copied, setCopied] = useState(false);
   const [showResetConfirm, setShowResetConfirm] = useState(false);
+
+  const liveEntry = liveStatusData?.channels?.find(
+    (e) => e.channelId === channel.id,
+  );
+  const liveStatus = liveEntry?.status ?? "connected";
+  const liveError = liveEntry?.lastError ?? null;
 
   const disconnectMutation = useMutation({
     mutationFn: async () => {
@@ -346,22 +393,58 @@ function ConfiguredView({
     <>
       <div className="space-y-4 sm:space-y-5">
         {/* Status banner */}
-        <div className="flex flex-col items-start gap-3 p-4 rounded-xl border bg-[var(--color-success-subtle)] border-[var(--color-success-border)] sm:flex-row sm:items-center">
-          <div className="flex justify-center items-center w-9 h-9 rounded-lg bg-[var(--color-success-muted)] shrink-0">
-            <CheckCircle2 size={18} className="text-[var(--color-success)]" />
+        <div
+          className={`flex flex-col items-start gap-3 p-4 rounded-xl border sm:flex-row sm:items-center ${
+            liveStatus === "error"
+              ? "bg-red-500/5 border-red-500/20"
+              : liveStatus === "connecting" || liveStatus === "restarting"
+                ? "bg-amber-500/5 border-amber-500/20"
+                : "bg-[var(--color-success-subtle)] border-[var(--color-success-border)]"
+          }`}
+        >
+          <div
+            className={`flex justify-center items-center w-9 h-9 rounded-lg shrink-0 ${
+              liveStatus === "error"
+                ? "bg-red-500/10"
+                : liveStatus === "connecting" || liveStatus === "restarting"
+                  ? "bg-amber-500/10"
+                  : "bg-[var(--color-success-muted)]"
+            }`}
+          >
+            {liveStatus === "error" ? (
+              <Shield size={18} className="text-red-500" />
+            ) : liveStatus === "connecting" || liveStatus === "restarting" ? (
+              <Loader2 size={18} className="text-amber-500 animate-spin" />
+            ) : (
+              <CheckCircle2 size={18} className="text-[var(--color-success)]" />
+            )}
           </div>
           <div className="flex-1">
             <div className="text-[13px] font-semibold text-text-primary">
-              {t("channels.statusConnected", {
-                platform: PLATFORM_LABELS[platform],
-              })}
+              {liveStatus === "error"
+                ? `${PLATFORM_LABELS[platform]} ${t("channels.statusError")}`
+                : liveStatus === "connecting" || liveStatus === "restarting"
+                  ? `${PLATFORM_LABELS[platform]} ${t("channels.statusConnecting")}`
+                  : t("channels.statusConnected", {
+                      platform: PLATFORM_LABELS[platform],
+                    })}
             </div>
             <div className="text-[11px] text-text-muted mt-0.5">
-              {channel.teamName ?? channel.accountId}
-              {channel.createdAt &&
-                ` \u00B7 ${t("channels.configuredDate", { date: new Date(channel.createdAt).toLocaleDateString() })}`}
-              {" \u00B7 "}
-              {t("channels.connectionActive")}
+              {liveError ? (
+                <span className="text-red-400">{liveError}</span>
+              ) : (
+                <>
+                  {channel.teamName ?? channel.accountId}
+                  {channel.createdAt &&
+                    ` \u00B7 ${t("channels.configuredDate", { date: new Date(channel.createdAt).toLocaleDateString() })}`}
+                  {liveStatus === "connected" && (
+                    <>
+                      {" \u00B7 "}
+                      {t("channels.connectionActive")}
+                    </>
+                  )}
+                </>
+              )}
             </div>
           </div>
           <button


### PR DESCRIPTION
## What

The channels page now shows real-time channel runtime status instead of a hardcoded "Connected" banner.

## Why

Previously, the channels page showed a green "Connected" status based solely on the Nexu config record. This was misleading when the actual channel runtime was in error state (e.g., WeChat session expired, Discord gateway disconnected). Users saw "Connected" but their bot wasn't responding to messages.

## How

- Poll the existing `/api/v1/channels/live-status` endpoint every 3s (same mechanism the home page already uses)
- Map runtime status to visual states:
  - **Green checkmark**: channel running normally
  - **Amber spinner**: connecting or restarting  
  - **Red shield + error message**: error (e.g., "session expired")
- Platform selector icons also reflect live status
- Added i18n keys for error/connecting states (en + zh-CN)

## Affected areas

- [x] Web frontend

## Checklist

- [x] `pnpm typecheck` passes
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced