### PR TITLE
feat(ci): nightly changelog with linked issues + LLM summary + Feishu notification

### DIFF
--- a/.github/workflows/desktop-nightly.yml
+++ b/.github/workflows/desktop-nightly.yml
@@ -182,8 +182,8 @@ jobs:
       - name: Generate LLM summary
         id: llm
         env:
-          LITELLM_ENDPOINT: ${{ secrets.LITELLM_ENDPOINT }}
-          LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
+          OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         shell: bash
         run: |
           set -euo pipefail
@@ -191,19 +191,19 @@ jobs:
           changelog=$(cat /tmp/changelog_plain.txt)
           pr_count="${{ steps.changelog.outputs.pr_count }}"
 
-          if [ "$pr_count" -eq 0 ] || [ -z "$LITELLM_ENDPOINT" ] || [ -z "$LITELLM_API_KEY" ]; then
+          if [ "$pr_count" -eq 0 ] || [ -z "$OPENAI_BASE_URL" ] || [ -z "$OPENAI_API_KEY" ]; then
             echo "summary=无新增变更" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Ask LLM for a concise Chinese summary
+          # Ask LLM for a concise Chinese summary (same endpoint as nexu-pal)
           prompt="你是一个桌面应用的发布助手。以下是自上次发布以来合并的 PR 列表（带关联 issue）：\n\n${changelog}\n\n请用中文生成一段简洁的变更摘要（3-5 句话），重点说明用户可感知的改进和修复。不要列举 PR 编号，用自然语言概括。如果有 bug 修复请优先提及。"
 
-          response=$(curl -sf --max-time 30 "${LITELLM_ENDPOINT}/chat/completions" \
-            -H "Authorization: Bearer ${LITELLM_API_KEY}" \
+          response=$(curl -sf --max-time 30 "${OPENAI_BASE_URL}/chat/completions" \
+            -H "Authorization: Bearer ${OPENAI_API_KEY}" \
             -H "Content-Type: application/json" \
             -d "$(jq -n --arg prompt "$prompt" '{
-              model: "gpt-4o-mini",
+              model: "google/gemini-2.5-flash",
               messages: [{role: "user", content: $prompt}],
               max_tokens: 300,
               temperature: 0.3


### PR DESCRIPTION
## What

Add automated changelog generation, LLM-powered summary, and Feishu card notification to the desktop nightly build workflow.

## Why

- QA team has no visibility into what changed in each nightly build
- Commit messages are developer-oriented; testers need user-facing descriptions
- No notification channel — testers must manually check GitHub releases

## How

### Changelog generation
- Compares the latest stable release tag (`v*`) to HEAD
- Extracts all merged PR numbers from commit history
- For each PR: fetches title, affected area (from conventional commit prefix + labels), and **closing issues** (via `closingIssuesReferences`)
- Output format shows PR title + linked issue titles so testers see the user-facing bug/feature description

Example:
```
[desktop] fix(desktop): white screen on startup (#597)
  → #598 nightly20260327 version (mac arm) white screen on startup

[models] fix(controller): Kimi K2.5 returns 401 (#540)
  → #555 无法调用kimi k2.5
```

### LLM summary
- Sends the changelog to LiteLLM (`gpt-4o-mini`) for a 3-5 sentence Chinese summary
- Focuses on user-perceivable improvements and bug fixes
- Falls back to a simple count message if LLM is unavailable

### Feishu card notification
- Interactive card with turquoise header
- Sections: LLM summary, version info (version/commit/baseline/PR count), changelog list
- Action buttons: DMG downloads (Apple Silicon + Intel), CI build link, E2E test link, Release page

### Secret added
- `NIGHTLY_FEISHU_WEBHOOK` — Feishu bot webhook URL for nightly notifications

## Affected areas

- [ ] Desktop app (Electron shell)
- [ ] Controller (backend / API)
- [ ] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [x] Build / CI / Tooling

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

## Notes for reviewers

- The `notify` job runs in parallel with `trigger-e2e` (both `needs: build`), so it doesn't add to the total pipeline time
- LLM step has a 30s timeout and graceful fallback — won't block the workflow
- Changelog is capped at 20 entries in the Feishu card to avoid message size limits
- `pull-requests: read` permission added for `closingIssuesReferences` API access