### PR TITLE
chore: split Feishu notify webhooks by GitHub event

### DIFF
--- a/.github/workflows/feishu-discussion-notify.yml
+++ b/.github/workflows/feishu-discussion-notify.yml
@@ -24,7 +24,7 @@ jobs:
           sparse-checkout: scripts
       - name: Send Feishu notification
         env:
-          WEBHOOK_URL: ${{ secrets.ISSUE_SYNC_FEISHU_BOT_WEBHOOK }}
+          WEBHOOK_URL: ${{ secrets.NOTIFY_DISCUSSION_ISSUE_FEISHU_WEBHOOK }}
           EVENT_TYPE: discussion
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}

--- a/.github/workflows/feishu-issue-notify.yml
+++ b/.github/workflows/feishu-issue-notify.yml
@@ -24,7 +24,7 @@ jobs:
           sparse-checkout: scripts
       - name: Send Feishu notification
         env:
-          WEBHOOK_URL: ${{ secrets.ISSUE_SYNC_FEISHU_BOT_WEBHOOK }}
+          WEBHOOK_URL: ${{ secrets.NOTIFY_ISSUE_FEISHU_WEBHOOK }}
           EVENT_TYPE: issue
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}

--- a/.github/workflows/feishu-pr-notify.yml
+++ b/.github/workflows/feishu-pr-notify.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Send Feishu notification
         env:
-          WEBHOOK_URL: ${{ secrets.ISSUE_SYNC_FEISHU_BOT_WEBHOOK }}
+          WEBHOOK_URL: ${{ secrets.NOTIFY_PR_FEISHU_WEBHOOK }}
           EVENT_TYPE: pull_request
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}

--- a/specs/current/nexu-pal.md
+++ b/specs/current/nexu-pal.md
@@ -60,10 +60,10 @@ Current transitions:
 
 Four GitHub Actions send Feishu webhook notifications for GitHub content:
 
-1. **Issue notification** — On `issues: [opened]`, sends the existing issue card to the legacy webhook, but skips notifications when the author is a repository-owner organization member. This suppression remains org-membership-based; the `app/sentry` internal-equivalent triage shortcut does not change the legacy notification rule.
+1. **Issue notification** — On `issues: [opened]`, sends the existing issue card to the issue notification webhook (`NOTIFY_ISSUE_FEISHU_WEBHOOK`), but skips notifications when the author is a repository-owner organization member. This suppression remains org-membership-based; the `app/sentry` internal-equivalent triage shortcut does not change the notification rule.
 2. **Needs-triage issue notification** — On `issues: [labeled]`, when the added label is `needs-triage`, sends a triage card to either the bug or non-bug webhook based on the issue's current labels. The workflow maps GitHub secrets to internal env vars `BUG_WEBHOOK` and `REQ_WEBHOOK`.
-3. **Discussion notification** — On `discussion: [created]`, sends the existing discussion card format using the discussion category in place of labels, but skips notifications when the author is a repository-owner organization member.
-4. **Pull request notification** — On `pull_request: [opened]`, sends the existing card format using pull request labels, but skips notifications when the author is a repository-owner organization member.
+3. **Discussion notification** — On `discussion: [created]`, sends the existing discussion card format using the discussion category in place of labels to the discussion notification webhook (`NOTIFY_DISCUSSION_ISSUE_FEISHU_WEBHOOK`), but skips notifications when the author is a repository-owner organization member.
+4. **Pull request notification** — On `pull_request: [opened]`, sends the existing card format using pull request labels to the pull-request notification webhook (`NOTIFY_PR_FEISHU_WEBHOOK`), but skips notifications when the author is a repository-owner organization member.
 
 The issue/discussion/pull-request workflows run `node scripts/notify/feishu-notify.mjs`. The triage workflow runs `node scripts/notify/feishu-triage-notify.mjs`.
 
@@ -93,7 +93,9 @@ The issue / discussion / pull-request Feishu notification workflows also create 
 | `NEXU_PAL_PRIVATE_KEY_PEM` | GitHub App private key |
 | `OPENAI_BASE_URL` | OpenRouter base URL |
 | `OPENAI_API_KEY` | OpenRouter API key |
-| `ISSUE_SYNC_FEISHU_BOT_WEBHOOK` | Feishu incoming webhook URL for the issue-opened, discussion-created, and pull-request-opened notifications |
+| `NOTIFY_ISSUE_FEISHU_WEBHOOK` | Feishu incoming webhook URL for the issue-opened notifications |
+| `NOTIFY_DISCUSSION_ISSUE_FEISHU_WEBHOOK` | Feishu incoming webhook URL for the discussion-created notifications |
+| `NOTIFY_PR_FEISHU_WEBHOOK` | Feishu incoming webhook URL for the pull-request-opened notifications |
 | `ISSUE_TRIAGE_BUG_FEISHU_WEBHOOK` | Feishu incoming webhook URL for bug triage notifications |
 | `ISSUE_TRIAGE_REQ_FEISHU_WEBHOOK` | Feishu incoming webhook URL for non-bug triage notifications |
 


### PR DESCRIPTION
## What

Route GitHub issue, discussion, and pull request Feishu notifications through separate repository secrets instead of a single shared webhook.

## Why

This lets issue/discussion notifications and PR notifications be configured independently without changing workflow code.

## How

- update the issue workflow to use `NOTIFY_ISSUE_FEISHU_WEBHOOK`
- update the discussion workflow to use `NOTIFY_DISCUSSION_ISSUE_FEISHU_WEBHOOK`
- update the pull request workflow to use `NOTIFY_PR_FEISHU_WEBHOOK`
- refresh `specs/current/nexu-pal.md` to document the new secret mapping

## Affected areas

- [ ] Desktop app (Electron shell)
- [ ] Controller (backend / API)
- [ ] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [x] Build / CI / Tooling

## Checklist

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

## Notes for reviewers

The new repository secrets have already been created in GitHub, and the old `ISSUE_SYNC_FEISHU_BOT_WEBHOOK` secret is no longer referenced by these workflows.