### PR TITLE
fix(ci): use PAT for auto-tag to trigger downstream release build

### DIFF
--- a/.github/workflows/desktop-auto-tag.yml
+++ b/.github/workflows/desktop-auto-tag.yml
@@ -7,6 +7,11 @@ name: Desktop Auto-Tag on Release PR Merge
 #
 # This bridges the gap between "merge Release PR" and "desktop-release.yml"
 # which triggers on tag push to build + sign + publish artifacts.
+#
+# IMPORTANT: Uses RELEASE_PAT (Personal Access Token) instead of GITHUB_TOKEN
+# for git push. Tags pushed by GITHUB_TOKEN don't trigger downstream workflows
+# (GitHub's anti-recursion safeguard), so we need a PAT to ensure
+# desktop-release.yml fires on the tag push event.
 
 on:
   pull_request:
@@ -28,6 +33,8 @@ jobs:
       - name: Checkout merged commit
         uses: actions/checkout@v4
         with:
+          # Use PAT for checkout so git push triggers downstream workflows
+          token: ${{ secrets.RELEASE_PAT }}
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
 
@@ -64,7 +71,7 @@ jobs:
       - name: Create GitHub Release with PR body as release notes
         if: steps.check.outputs.exists == 'false'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## What

Switch `desktop-auto-tag.yml` from `GITHUB_TOKEN` to `RELEASE_PAT` for checkout and tag push.

## Why

Tags pushed by `GITHUB_TOKEN` don't trigger `on: push: tags` workflows — this is GitHub's anti-recursion safeguard. As a result, merging the Release PR auto-tagged correctly but the `desktop-release.yml` build never fired. Had to manually dispatch for v0.1.8.

## How

- Checkout uses `token: ${{ secrets.RELEASE_PAT }}` so `git push` authenticates with PAT
- `gh release create` also uses `RELEASE_PAT` for consistency
- Added comments explaining why PAT is needed

## Setup required

Add repo secret `RELEASE_PAT`: a Personal Access Token with `contents:write` scope.

## Checklist
- [x] No code changes, workflow-only
- [x] Tested: v0.1.8 auto-tag worked, but build didn't trigger (this fixes that)