### PR TITLE
fix(desktop): pass gateway token to OpenClaw launchd plist

### DIFF
--- a/apps/desktop/main/services/plist-generator.ts
+++ b/apps/desktop/main/services/plist-generator.ts
@@ -250,7 +250,13 @@ function generateOpenclawPlist(label: string, env: PlistEnv): string {
         <key>OPENCLAW_SERVICE_MARKER</key>
         <string>launchd</string>
         <key>OPENCLAW_IMAGE_BACKEND</key>
-        <string>sips</string>
+        <string>sips</string>${
+          env.gatewayToken
+            ? `
+        <key>OPENCLAW_GATEWAY_TOKEN</key>
+        <string>${escapeXml(env.gatewayToken)}</string>`
+            : ""
+        }
         <key>HOME</key>
         <string>${escapeXml(os.homedir())}</string>${renderProxyEnvEntries(
           env.proxyEnv,

--- a/tests/desktop/plist-env-parity.test.ts
+++ b/tests/desktop/plist-env-parity.test.ts
@@ -176,6 +176,29 @@ describe("controller plist env var parity with manifests", () => {
         `<key>${key}</key>`,
       );
     }
+
+    // Gateway token must be in openclaw plist when provided
+    if (mockEnv.gatewayToken) {
+      expect(
+        plist,
+        "openclaw plist must include OPENCLAW_GATEWAY_TOKEN when gatewayToken is set",
+      ).toContain("<key>OPENCLAW_GATEWAY_TOKEN</key>");
+    }
+  });
+
+  it("gateway token is present in BOTH controller and openclaw plists", async () => {
+    const { generatePlist } = await import(
+      "../../apps/desktop/main/services/plist-generator"
+    );
+
+    const envWithToken = { ...mockEnv, gatewayToken: "parity-test-token" };
+    const controllerPlist = generatePlist("controller", envWithToken);
+    const openclawPlist = generatePlist("openclaw", envWithToken);
+
+    expect(controllerPlist).toContain("<key>OPENCLAW_GATEWAY_TOKEN</key>");
+    expect(controllerPlist).toContain("<string>parity-test-token</string>");
+    expect(openclawPlist).toContain("<key>OPENCLAW_GATEWAY_TOKEN</key>");
+    expect(openclawPlist).toContain("<string>parity-test-token</string>");
   });
 
   it("dev mode sets NODE_ENV=development and adds --auth none to openclaw", async () => {


### PR DESCRIPTION
## What

Add `OPENCLAW_GATEWAY_TOKEN` to the OpenClaw launchd plist environment variables.

## Why

Fresh installs of the packaged app (v0.1.8) have **all channels permanently stuck in "connecting"**. The controller's WebSocket connection to OpenClaw is rejected every time:

```
openclaw_ws_connect_failed: unauthorized: gateway token mismatch
```

**Root cause**: `generateOpenclawPlist()` never included `OPENCLAW_GATEWAY_TOKEN`. The controller plist had it (since commit 20b1fef4), but the openclaw plist was missing it.

**Why upgrade users weren't affected**: They already had `openclaw.json` on disk from a previous session with `gateway.auth.token` embedded. OpenClaw read the token from the config file. Fresh installs don't have this file yet, so OpenClaw starts with no token → mismatch.

## How

- Added `OPENCLAW_GATEWAY_TOKEN` to the openclaw plist env vars (same pattern as controller plist)
- Added parity regression test: verifies BOTH controller AND openclaw plists contain the gateway token

## Affected areas

- [x] Desktop app (Electron shell)

## Checklist

- [x] `pnpm typecheck` passes
- [x] Plist parity tests pass (7/7)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced