### PR TITLE
fix(desktop): pass gateway token to OpenClaw launchd plist

### DIFF
--- a/apps/desktop/main/services/plist-generator.ts
+++ b/apps/desktop/main/services/plist-generator.ts
@@ -248,7 +248,13 @@ function generateOpenclawPlist(label: string, env: PlistEnv): string {
         <key>OPENCLAW_LAUNCHD_LABEL</key>
         <string>${label}</string>
         <key>OPENCLAW_SERVICE_MARKER</key>
-        <string>launchd</string>
+        <string>launchd</string>${
+          env.gatewayToken
+            ? `
+        <key>OPENCLAW_GATEWAY_TOKEN</key>
+        <string>${escapeXml(env.gatewayToken)}</string>`
+            : ""
+        }
         <key>HOME</key>
         <string>${escapeXml(os.homedir())}</string>${renderProxyEnvEntries(
           env.proxyEnv,

--- a/tests/desktop/plist-env-parity.test.ts
+++ b/tests/desktop/plist-env-parity.test.ts
@@ -176,6 +176,28 @@ describe("controller plist env var parity with manifests", () => {
         `<key>${key}</key>`,
       );
     }
+
+    if (mockEnv.gatewayToken) {
+      expect(
+        plist,
+        "openclaw plist must include OPENCLAW_GATEWAY_TOKEN when gatewayToken is set",
+      ).toContain("<key>OPENCLAW_GATEWAY_TOKEN</key>");
+    }
+  });
+
+  it("gateway token is present in BOTH controller and openclaw plists", async () => {
+    const { generatePlist } = await import(
+      "../../apps/desktop/main/services/plist-generator"
+    );
+
+    const envWithToken = { ...mockEnv, gatewayToken: "parity-test-token" };
+    const controllerPlist = generatePlist("controller", envWithToken);
+    const openclawPlist = generatePlist("openclaw", envWithToken);
+
+    expect(controllerPlist).toContain("<key>OPENCLAW_GATEWAY_TOKEN</key>");
+    expect(controllerPlist).toContain("<string>parity-test-token</string>");
+    expect(openclawPlist).toContain("<key>OPENCLAW_GATEWAY_TOKEN</key>");
+    expect(openclawPlist).toContain("<string>parity-test-token</string>");
   });
 
   it("dev mode sets NODE_ENV=development and adds --auth none to openclaw", async () => {


### PR DESCRIPTION
## What

Add `OPENCLAW_GATEWAY_TOKEN` to the OpenClaw launchd plist.

## Why

Fresh installs of v0.1.8 have all channels stuck in "connecting" — controller WS rejected with `gateway token mismatch`. The openclaw plist was missing the token env var.

## How

- Added `OPENCLAW_GATEWAY_TOKEN` to openclaw plist env vars
- Added parity regression test for both plists

## Checklist

- [x] `pnpm typecheck` passes
- [x] Plist parity tests pass