### PR TITLE
fix(desktop): recreate window on second-instance relaunch

### DIFF
--- a/apps/desktop/main/index.ts
+++ b/apps/desktop/main/index.ts
@@ -740,6 +740,11 @@ function focusMainWindow(): void {
 }
 
 app.on("second-instance", () => {
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    createMainWindow();
+    return;
+  }
+
   focusMainWindow();
 });
 

--- a/tests/desktop/dev-toolchain-invariants.test.ts
+++ b/tests/desktop/dev-toolchain-invariants.test.ts
@@ -321,7 +321,25 @@ describe("Shutdown safety", () => {
   });
 
   // -----------------------------------------------------------------------
-  // 18. dev-launchd.sh stop sends SIGTERM before SIGKILL
+  // 18. second-instance recreates the main window when none exists
+  // -----------------------------------------------------------------------
+  it("index.ts recreates the main window on second-instance when none exists", () => {
+    const indexTs = readFile("apps/desktop/main/index.ts");
+    const secondInstanceStart = indexTs.indexOf('app.on("second-instance"');
+    const secondInstanceBlock = indexTs.slice(
+      secondInstanceStart,
+      secondInstanceStart + 300,
+    );
+
+    expect(secondInstanceBlock).toContain(
+      "!mainWindow || mainWindow.isDestroyed()",
+    );
+    expect(secondInstanceBlock).toContain("createMainWindow()");
+    expect(secondInstanceBlock).toContain("focusMainWindow()");
+  });
+
+  // -----------------------------------------------------------------------
+  // 19. dev-launchd.sh stop sends SIGTERM before SIGKILL
   // -----------------------------------------------------------------------
   it("dev-launchd.sh stop_services sends SIGTERM before SIGKILL", () => {
     const devLaunchdSh = readFile("scripts/dev-launchd.sh");


### PR DESCRIPTION
## What

Recreate the desktop main window when a second app launch arrives after the original window has already been destroyed.

## Why

Packaged Nexu can keep running as a background UIElement app with no remaining windows. In that state, clicking the app again triggers `second-instance`, but the existing handler only tried to focus an in-memory window reference and could not recover the UI.

## How

- add a `second-instance` fallback that calls `createMainWindow()` when `mainWindow` is missing or destroyed
- keep the existing focus path for the normal already-open case
- add a regression invariant test covering the no-window relaunch path

## Affected areas

- [x] Desktop app (Electron shell)
- [ ] Controller (backend / API)
- [ ] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [ ] Build / CI / Tooling

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

## Notes for reviewers

This only changes the second-instance recovery path. It does not change the packaged `LSUIElement` behavior.