### PR TITLE
fix(ci): switch R2 upload from wrangler to AWS S3 CLI

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -417,8 +417,10 @@ jobs:
       - name: Upload to Cloudflare R2
         if: inputs.update_feed_url != ''
         env:
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_ENDPOINT_URL: https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          AWS_REGION: auto
           UPDATE_FEED_URL: ${{ inputs.update_feed_url }}
           CHANNEL: ${{ inputs.channel }}
           ARCH: ${{ matrix.arch }}
@@ -430,30 +432,28 @@ jobs:
         run: |
           set -euo pipefail
 
+          R2_BUCKET="s3://nexu-desktop-releases"
+
+          upload_file() {
+            local src="$1" dst="$2"
+            echo "Uploading $(basename "$src") → ${dst}"
+            aws s3 cp "$src" "${R2_BUCKET}/${dst}" --no-progress
+          }
+
           upload_prefix() {
             local prefix="$1"
 
             echo "[r2] uploading to prefix: ${prefix}/"
 
             if [ -f "apps/desktop/release/latest-mac.yml" ]; then
-              echo "Uploading latest-mac.yml → ${prefix}/latest-mac.yml"
-              npx wrangler r2 object put "nexu-desktop-releases/${prefix}/latest-mac.yml" --file "apps/desktop/release/latest-mac.yml" --remote
+              upload_file "apps/desktop/release/latest-mac.yml" "${prefix}/latest-mac.yml"
             fi
 
-            echo "Uploading ${VERSIONED_DMG} → ${prefix}/${VERSIONED_DMG}"
-            npx wrangler r2 object put "nexu-desktop-releases/${prefix}/${VERSIONED_DMG}" --file "apps/desktop/channel-artifacts/${VERSIONED_DMG}" --remote
-
-            echo "Uploading ${VERSIONED_ZIP} → ${prefix}/${VERSIONED_ZIP}"
-            npx wrangler r2 object put "nexu-desktop-releases/${prefix}/${VERSIONED_ZIP}" --file "apps/desktop/channel-artifacts/${VERSIONED_ZIP}" --remote
-
-            echo "Uploading ${LATEST_DMG} → ${prefix}/${LATEST_DMG}"
-            npx wrangler r2 object put "nexu-desktop-releases/${prefix}/${LATEST_DMG}" --file "apps/desktop/channel-artifacts/${LATEST_DMG}" --remote
-
-            echo "Uploading ${LATEST_ZIP} → ${prefix}/${LATEST_ZIP}"
-            npx wrangler r2 object put "nexu-desktop-releases/${prefix}/${LATEST_ZIP}" --file "apps/desktop/channel-artifacts/${LATEST_ZIP}" --remote
-
-            echo "Uploading ${{ steps.artifacts.outputs.checksum_file }} → ${prefix}/${{ steps.artifacts.outputs.checksum_file }}"
-            npx wrangler r2 object put "nexu-desktop-releases/${prefix}/${{ steps.artifacts.outputs.checksum_file }}" --file "apps/desktop/channel-artifacts/${{ steps.artifacts.outputs.checksum_file }}" --remote
+            upload_file "apps/desktop/channel-artifacts/${VERSIONED_DMG}" "${prefix}/${VERSIONED_DMG}"
+            upload_file "apps/desktop/channel-artifacts/${VERSIONED_ZIP}" "${prefix}/${VERSIONED_ZIP}"
+            upload_file "apps/desktop/channel-artifacts/${LATEST_DMG}" "${prefix}/${LATEST_DMG}"
+            upload_file "apps/desktop/channel-artifacts/${LATEST_ZIP}" "${prefix}/${LATEST_ZIP}"
+            upload_file "apps/desktop/channel-artifacts/${{ steps.artifacts.outputs.checksum_file }}" "${prefix}/${{ steps.artifacts.outputs.checksum_file }}"
           }
 
           # Extract R2 prefix from feed URL path (e.g. https://desktop-releases.nexu.io/nightly → nightly)

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -394,8 +394,10 @@ jobs:
 
       - name: Upload to Cloudflare R2
         env:
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_ENDPOINT_URL: https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          AWS_REGION: auto
           CHANNEL: ${{ steps.artifacts.outputs.channel }}
           ARCH: ${{ matrix.arch }}
           VERSIONED_DMG: ${{ steps.artifacts.outputs.versioned_dmg }}
@@ -405,30 +407,28 @@ jobs:
         run: |
           set -euo pipefail
 
+          R2_BUCKET="s3://nexu-desktop-releases"
+
+          upload_file() {
+            local src="$1" dst="$2"
+            echo "Uploading $(basename "$src") → ${dst}"
+            aws s3 cp "$src" "${R2_BUCKET}/${dst}" --no-progress
+          }
+
           upload_prefix() {
             local prefix="$1"
 
             echo "[r2] uploading to prefix: ${prefix}/"
 
             if [ -f "apps/desktop/release/latest-mac.yml" ]; then
-              echo "Uploading latest-mac.yml → ${prefix}/latest-mac.yml"
-              npx wrangler r2 object put "nexu-desktop-releases/${prefix}/latest-mac.yml" --file "apps/desktop/release/latest-mac.yml" --remote
+              upload_file "apps/desktop/release/latest-mac.yml" "${prefix}/latest-mac.yml"
             fi
 
-            echo "Uploading ${VERSIONED_DMG} → ${prefix}/${VERSIONED_DMG}"
-            npx wrangler r2 object put "nexu-desktop-releases/${prefix}/${VERSIONED_DMG}" --file "apps/desktop/release-artifacts/${VERSIONED_DMG}" --remote
-
-            echo "Uploading ${VERSIONED_ZIP} → ${prefix}/${VERSIONED_ZIP}"
-            npx wrangler r2 object put "nexu-desktop-releases/${prefix}/${VERSIONED_ZIP}" --file "apps/desktop/release-artifacts/${VERSIONED_ZIP}" --remote
-
-            echo "Uploading ${LATEST_DMG} → ${prefix}/${LATEST_DMG}"
-            npx wrangler r2 object put "nexu-desktop-releases/${prefix}/${LATEST_DMG}" --file "apps/desktop/release-artifacts/${LATEST_DMG}" --remote
-
-            echo "Uploading ${LATEST_ZIP} → ${prefix}/${LATEST_ZIP}"
-            npx wrangler r2 object put "nexu-desktop-releases/${prefix}/${LATEST_ZIP}" --file "apps/desktop/release-artifacts/${LATEST_ZIP}" --remote
-
-            echo "Uploading ${{ steps.artifacts.outputs.checksum_file }} → ${prefix}/${{ steps.artifacts.outputs.checksum_file }}"
-            npx wrangler r2 object put "nexu-desktop-releases/${prefix}/${{ steps.artifacts.outputs.checksum_file }}" --file "apps/desktop/release-artifacts/${{ steps.artifacts.outputs.checksum_file }}" --remote
+            upload_file "apps/desktop/release-artifacts/${VERSIONED_DMG}" "${prefix}/${VERSIONED_DMG}"
+            upload_file "apps/desktop/release-artifacts/${VERSIONED_ZIP}" "${prefix}/${VERSIONED_ZIP}"
+            upload_file "apps/desktop/release-artifacts/${LATEST_DMG}" "${prefix}/${LATEST_DMG}"
+            upload_file "apps/desktop/release-artifacts/${LATEST_ZIP}" "${prefix}/${LATEST_ZIP}"
+            upload_file "apps/desktop/release-artifacts/${{ steps.artifacts.outputs.checksum_file }}" "${prefix}/${{ steps.artifacts.outputs.checksum_file }}"
           }
 
           upload_prefix "${CHANNEL}/${ARCH}"


### PR DESCRIPTION
## What

Replace `npx wrangler r2 object put` with `aws s3 cp` for uploading desktop build artifacts to Cloudflare R2.

## Why

The Intel x64 DMG has grown to 303 MiB, exceeding wrangler's hard 300 MiB single-object upload limit. This broke the nightly Intel build ([run #23826267155](https://github.com/nexu-io/nexu/actions/runs/23826267155)). ARM64 DMG is at 281 MiB and will hit the same wall soon.

## How

- Switch from `npx wrangler r2 object put` to `aws s3 cp` in both `desktop-build.yml` and `desktop-release.yml`
- R2 natively supports the S3 API; `aws s3 cp` automatically uses multipart upload for large files — no size limit
- `aws` CLI is pre-installed on GitHub macOS runners, no extra setup needed
- Also eliminates the ~30s `npx wrangler@4.79.0` download overhead per upload call

**Requires new GitHub Secrets:**
- `R2_ACCESS_KEY_ID` — from Cloudflare R2 API Token (S3 Auth)
- `R2_SECRET_ACCESS_KEY` — from Cloudflare R2 API Token (S3 Auth)

`CLOUDFLARE_ACCOUNT_ID` is reused for the endpoint URL. The existing `CLOUDFLARE_API_TOKEN` is still used by the CDN cache purge step (unchanged).

## Affected areas

- [x] Build / CI / Tooling

## Checklist

- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced

## Notes for reviewers

Before merging, add `R2_ACCESS_KEY_ID` and `R2_SECRET_ACCESS_KEY` to GitHub repo secrets. Create them in Cloudflare Dashboard → R2 → Manage R2 API Tokens → Create API Token (Object Read & Write, bucket: `nexu-desktop-releases`).