### PR TITLE
chore(ci): purge CDN cache after desktop release upload

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -438,6 +438,45 @@ jobs:
             upload_prefix "${CHANNEL}"
           fi
 
+      - name: Purge Cloudflare CDN cache for latest artifacts
+        if: env.CLOUDFLARE_ZONE_ID != ''
+        env:
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CHANNEL: ${{ steps.artifacts.outputs.channel }}
+          ARCH: ${{ matrix.arch }}
+          LATEST_DMG: ${{ steps.artifacts.outputs.latest_dmg }}
+          LATEST_ZIP: ${{ steps.artifacts.outputs.latest_zip }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          base_url="https://desktop-releases.nexu.io/${CHANNEL}/${ARCH}"
+          urls=(
+            "${base_url}/${LATEST_DMG}"
+            "${base_url}/${LATEST_ZIP}"
+            "${base_url}/latest-mac.yml"
+          )
+
+          if [ "${ARCH}" = "arm64" ]; then
+            legacy_base_url="https://desktop-releases.nexu.io/${CHANNEL}"
+            urls+=(
+              "${legacy_base_url}/${LATEST_DMG}"
+              "${legacy_base_url}/${LATEST_ZIP}"
+              "${legacy_base_url}/latest-mac.yml"
+            )
+          fi
+
+          files_json=$(printf '%s\n' "${urls[@]}" | jq -R . | jq -sc '.')
+          echo "[cf-purge] Purging: ${files_json}"
+
+          curl -sf -X POST \
+            "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \
+            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{\"files\": ${files_json}}" \
+            | jq .
+
   trigger-e2e:
     needs: release
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Add Cloudflare CDN cache purge step to `desktop-release.yml` after R2 upload, matching the existing purge logic in `desktop-build.yml`.

## Why

After a stable release, the `latest-mac.yml` and `nexu-latest-*.dmg/zip` URLs served by Cloudflare CDN were not being cache-invalidated. Users' auto-updater would keep seeing the old version manifest until the CDN cache expired naturally.

`desktop-build.yml` (nightly/beta) already had this purge step, but `desktop-release.yml` (stable) was missing it.

Also added the missing `CLOUDFLARE_ZONE_ID` repo secret — without it the purge condition (`env.CLOUDFLARE_ZONE_ID != ''`) was never satisfied, so even nightly/beta purges were silently skipped.

## How

- Copy the cache purge step from `desktop-build.yml` into `desktop-release.yml`, adapted to use `CHANNEL` from the artifacts step instead of `inputs.update_feed_url`
- Purges: `latest-mac.yml`, latest DMG, latest ZIP — for both `${CHANNEL}/${ARCH}` and legacy `${CHANNEL}/` (arm64 only)

## Affected areas

- [ ] Desktop app (Electron shell)
- [ ] Controller (backend / API)
- [ ] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [x] Build / CI / Tooling

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)