### PR TITLE
fix(desktop): use consistent 1280×720 window size

### DIFF
--- a/apps/desktop/main/index.ts
+++ b/apps/desktop/main/index.ts
@@ -765,18 +765,11 @@ app.on("second-instance", () => {
 function createMainWindow(): BrowserWindow {
   logLaunchTimeline("main window creation requested");
   const isMacOS = process.platform === "darwin";
-  // During setup animation, use 16:9 dimensions matching the video (1920×1080)
-  // to avoid non-uniform scaling / edge cropping. Restored to normal size
-  // when setup:animation-complete IPC fires.
-  const setupWidth = 1280;
-  const setupHeight = 720;
-  const normalWidth = 1400;
-  const normalHeight = 920;
   const window = new BrowserWindow({
-    width: needsSetupExtraction ? setupWidth : normalWidth,
-    height: needsSetupExtraction ? setupHeight : normalHeight,
-    minWidth: needsSetupExtraction ? setupWidth : 1120,
-    minHeight: needsSetupExtraction ? setupHeight : 760,
+    width: 1280,
+    height: 720,
+    minWidth: needsSetupExtraction ? 1280 : 1120,
+    minHeight: 720,
     backgroundColor: isMacOS ? "#00000000" : "#0B1020",
     title: "nexu",
     titleBarStyle: "hiddenInset",

--- a/apps/desktop/main/ipc.ts
+++ b/apps/desktop/main/ipc.ts
@@ -496,13 +496,11 @@ export function registerIpcHandlers(
         }
 
         case "setup:animation-complete": {
-          // Restore normal window size and vibrancy now that the
-          // white-background animation overlay has been removed.
+          // Restore vibrancy now that the white-background animation
+          // overlay has been removed.
           const win = BrowserWindow.getAllWindows()[0];
           if (win) {
-            win.setMinimumSize(1120, 760);
-            win.setSize(1400, 920, true);
-            win.center();
+            win.setMinimumSize(1120, 720);
             if (process.platform === "darwin") {
               win.setBackgroundColor("#00000000");
               win.setVibrancy("sidebar");


### PR DESCRIPTION
## What

Use a fixed 1280×720 window size for all launches, removing the post-animation resize to 1400×920.

## Why

The setup animation plays at 1280×720, then the window abruptly resizes to 1400×920 after completion — the jump feels jarring and inconsistent.

## How

- `index.ts`: Always create the window at 1280×720 instead of conditionally using 1400×920 for non-setup launches.
- `ipc.ts`: On `setup:animation-complete`, only restore vibrancy and relax `minWidth` — no longer call `setSize` / `center`.

## Affected areas

- [x] Desktop app (Electron shell)

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)