### PR TITLE
chore: treat sentry automation as internal author

### DIFF
--- a/scripts/nexu-pal/lib/internal-equivalent-author.mjs
+++ b/scripts/nexu-pal/lib/internal-equivalent-author.mjs
@@ -1,0 +1,22 @@
+function normalizeLogin(login) {
+  if (typeof login !== "string") {
+    return "";
+  }
+
+  return login.trim().toLowerCase();
+}
+
+export function isSentryAutomationAuthor(login) {
+  return normalizeLogin(login) === "sentry[bot]";
+}
+
+export function isInternalEquivalentAuthor({
+  isInternalAuthor,
+  issueAuthorLogin,
+}) {
+  if (isInternalAuthor === true) {
+    return true;
+  }
+
+  return isSentryAutomationAuthor(issueAuthorLogin);
+}

--- a/scripts/nexu-pal/lib/triage-opened-engine.mjs
+++ b/scripts/nexu-pal/lib/triage-opened-engine.mjs
@@ -1,3 +1,7 @@
+import {
+  isInternalEquivalentAuthor,
+  isSentryAutomationAuthor,
+} from "./internal-equivalent-author.mjs";
 import { detectDuplicate } from "./signals/duplicate-detector.mjs";
 import { matchRoadmap } from "./signals/roadmap-matcher.mjs";
 
@@ -9,14 +13,6 @@ export function createTriagePlan() {
     closeIssue: false,
     diagnostics: [],
   };
-}
-
-function isInternalEquivalentAuthor({ isInternalAuthor, issueAuthorLogin }) {
-  if (isInternalAuthor === true) {
-    return true;
-  }
-
-  return issueAuthorLogin === "app/sentry";
 }
 
 function buildTranslationComment({ translatedTitle, translatedSections }) {
@@ -415,9 +411,9 @@ export async function buildOpenedIssueTriagePlan({
     `organization membership: ${isInternalAuthor === true ? "member" : "non-member"}`,
   );
 
-  if (issueAuthorLogin === "app/sentry") {
+  if (isSentryAutomationAuthor(issueAuthorLogin)) {
     plan.diagnostics.push(
-      "author is app/sentry; treated as internal-equivalent automation for triage short-circuit",
+      "author is sentry[bot]; treated as internal-equivalent automation for triage short-circuit",
     );
   }
 

--- a/scripts/notify/feishu-notify.mjs
+++ b/scripts/notify/feishu-notify.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { checkOrganizationMembership } from "../nexu-pal/lib/github-client.mjs";
+import { isSentryAutomationAuthor } from "../nexu-pal/lib/internal-equivalent-author.mjs";
 
 /**
  * Send a Feishu interactive card notification via incoming webhook.
@@ -36,10 +37,20 @@ if (!webhookUrl) {
   process.exit(1);
 }
 
-if (!ghToken || !repositoryOwner || !author) {
-  console.error(
-    "GITHUB_TOKEN, GITHUB_REPOSITORY_OWNER, and AUTHOR are required",
+if (!author) {
+  console.error("AUTHOR is required");
+  process.exit(1);
+}
+
+if (isSentryAutomationAuthor(author)) {
+  console.log(
+    `Skipping Feishu notification for internal-equivalent author: ${author}`,
   );
+  process.exit(0);
+}
+
+if (!ghToken || !repositoryOwner) {
+  console.error("GITHUB_TOKEN and GITHUB_REPOSITORY_OWNER are required");
   process.exit(1);
 }
 

--- a/specs/current/nexu-pal.md
+++ b/specs/current/nexu-pal.md
@@ -23,7 +23,7 @@ Runs in order:
 
 3. **Intent classification** — Sends the normalized English title and body to the LLM and assigns only the `bug` label when the issue clearly describes broken behavior.
 
-4. **Internal-member short-circuit** — The workflow checks whether `issue.user.login` belongs to the repository owner's GitHub organization via the org-membership API. If the author is an org member, the opened-issue flow stops after translation + bug classification. The same short-circuit also applies to the repository-managed `app/sentry` issue source. These internal-equivalent issues skip known-issue matching, completeness checks, and `needs-triage` labeling.
+4. **Internal-member short-circuit** — The workflow checks whether `issue.user.login` belongs to the repository owner's GitHub organization via the org-membership API. If the author is an org member, the opened-issue flow stops after translation + bug classification. The same short-circuit also applies to Sentry automation issues authored by `sentry[bot]` (GitHub App actor). These internal-equivalent issues skip known-issue matching, completeness checks, and `needs-triage` labeling.
 
 5. **Completeness check** — For authors that are not internal or internal-equivalent, uses the LLM to decide whether the issue is too incomplete to continue triage. If so, adds `needs-information`, posts a follow-up comment, and pauses there.
 
@@ -60,10 +60,10 @@ Current transitions:
 
 Four GitHub Actions send Feishu webhook notifications for GitHub content:
 
-1. **Issue notification** — On `issues: [opened]`, sends the existing issue card to the issue notification webhook (`NOTIFY_ISSUE_FEISHU_WEBHOOK`), but skips notifications when the author is a repository-owner organization member. This suppression remains org-membership-based; the `app/sentry` internal-equivalent triage shortcut does not change the notification rule.
+1. **Issue notification** — On `issues: [opened]`, sends the existing issue card to the issue notification webhook (`NOTIFY_ISSUE_FEISHU_WEBHOOK`), but skips notifications when the author is a repository-owner organization member or `sentry[bot]`.
 2. **Needs-triage issue notification** — On `issues: [labeled]`, when the added label is `needs-triage`, sends a triage card to either the bug or non-bug webhook based on the issue's current labels. The workflow maps GitHub secrets to internal env vars `BUG_WEBHOOK` and `REQ_WEBHOOK`.
-3. **Discussion notification** — On `discussion: [created]`, sends the existing discussion card format using the discussion category in place of labels to the discussion notification webhook (`NOTIFY_DISCUSSION_ISSUE_FEISHU_WEBHOOK`), but skips notifications when the author is a repository-owner organization member.
-4. **Pull request notification** — On `pull_request: [opened]`, sends the existing card format using pull request labels to the pull-request notification webhook (`NOTIFY_PR_FEISHU_WEBHOOK`), but skips notifications when the author is a repository-owner organization member.
+3. **Discussion notification** — On `discussion: [created]`, sends the existing discussion card format using the discussion category in place of labels to the discussion notification webhook (`NOTIFY_DISCUSSION_ISSUE_FEISHU_WEBHOOK`), but skips notifications when the author is a repository-owner organization member or `sentry[bot]`.
+4. **Pull request notification** — On `pull_request: [opened]`, sends the existing card format using pull request labels to the pull-request notification webhook (`NOTIFY_PR_FEISHU_WEBHOOK`), but skips notifications when the author is a repository-owner organization member or `sentry[bot]`.
 
 The issue/discussion/pull-request workflows run `node scripts/notify/feishu-notify.mjs`. The triage workflow runs `node scripts/notify/feishu-triage-notify.mjs`.
 
@@ -83,7 +83,7 @@ The issue/discussion/pull-request workflows run `node scripts/notify/feishu-noti
 
 The three **nexu-pal** workflows create a short-lived token via `actions/create-github-app-token@v1` using secrets `NEXU_PAL_APP_ID` and `NEXU_PAL_PRIVATE_KEY_PEM`. All GitHub API calls and the first-interaction action use this App token.
 
-The issue / discussion / pull-request Feishu notification workflows also create a short-lived GitHub App token so they can reuse the org-membership check and suppress notifications for organization-member internal authors. The `needs-triage` Feishu workflow continues to use GitHub Actions event data plus Feishu incoming-webhook secrets.
+The issue / discussion / pull-request Feishu notification workflows also create a short-lived GitHub App token so they can reuse the org-membership check and suppress notifications for organization-member internal authors; they also suppress `sentry[bot]` as internal-equivalent automation. The `needs-triage` Feishu workflow continues to use GitHub Actions event data plus Feishu incoming-webhook secrets.
 
 ## Secrets
 

--- a/tests/nexu-pal/internal-equivalent-author.test.ts
+++ b/tests/nexu-pal/internal-equivalent-author.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  isInternalEquivalentAuthor,
+  isSentryAutomationAuthor,
+} from "../../scripts/nexu-pal/lib/internal-equivalent-author.mjs";
+
+describe("isSentryAutomationAuthor", () => {
+  it("matches the real sentry bot login", () => {
+    expect(isSentryAutomationAuthor("sentry[bot]")).toBe(true);
+    expect(isSentryAutomationAuthor("SENTRY[BOT]")).toBe(true);
+    expect(isSentryAutomationAuthor("app/sentry")).toBe(false);
+  });
+});
+
+describe("isInternalEquivalentAuthor", () => {
+  it("treats org members as internal-equivalent", () => {
+    expect(
+      isInternalEquivalentAuthor({
+        isInternalAuthor: true,
+        issueAuthorLogin: "someone",
+      }),
+    ).toBe(true);
+  });
+
+  it("treats sentry[bot] as internal-equivalent", () => {
+    expect(
+      isInternalEquivalentAuthor({
+        isInternalAuthor: false,
+        issueAuthorLogin: "sentry[bot]",
+      }),
+    ).toBe(true);
+  });
+});

--- a/tests/nexu-pal/triage-opened-engine.test.ts
+++ b/tests/nexu-pal/triage-opened-engine.test.ts
@@ -253,7 +253,7 @@ describe("buildOpenedIssueTriagePlan", () => {
     );
   });
 
-  it("treats app/sentry as internal-equivalent and skips needs-information or needs-triage", async () => {
+  it("treats sentry[bot] as internal-equivalent and skips needs-information or needs-triage", async () => {
     const chat = vi
       .fn()
       .mockResolvedValueOnce(
@@ -276,7 +276,7 @@ describe("buildOpenedIssueTriagePlan", () => {
       issueTitle:
         "Error: Cannot write headers after they are sent to the client",
       issueBody: "Sentry issue body",
-      issueAuthorLogin: "app/sentry",
+      issueAuthorLogin: "sentry[bot]",
       isInternalAuthor: false,
       chat,
     });
@@ -287,7 +287,7 @@ describe("buildOpenedIssueTriagePlan", () => {
     expect(plan.diagnostics).toEqual(
       expect.arrayContaining([
         "organization membership: non-member",
-        "author is app/sentry; treated as internal-equivalent automation for triage short-circuit",
+        "author is sentry[bot]; treated as internal-equivalent automation for triage short-circuit",
         "internal-equivalent author detected; skipped roadmap/duplicate/completeness/needs-triage checks",
       ]),
     );


### PR DESCRIPTION
## What

Treat Sentry-authored GitHub content as internal-equivalent across nexu-pal workflows, and fix the actor match to use the real GitHub login `sentry[bot]`.

## Why

Recent Sentry issues were still receiving `needs-information` and Feishu notifications because the automation matched `app/sentry`, while the real GitHub actor is `sentry[bot]`. Sentry content should be handled like internal authors everywhere.

## How

- add a shared helper for internal-equivalent author detection
- switch nexu-pal triage to detect `sentry[bot]` instead of `app/sentry`
- skip Feishu notifications for Sentry-authored issues/discussions/PRs the same way we skip internal authors
- update tests and nexu-pal spec notes to reflect the real actor and behavior

## Affected areas

- [ ] Desktop app (Electron shell)
- [ ] Controller (backend / API)
- [ ] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [x] Build / CI / Tooling

## Checklist

- [x] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

## Notes for reviewers

Repo-wide checks still have pre-existing unrelated failures/warnings:
- `pnpm lint` reports existing warnings in `tests/desktop/launchd-startup-scenarios.test.ts`
- `pnpm test` still has an existing failure in `tests/desktop/skill-dir-watcher-workspace.test.ts`