### PR TITLE
chore: harden desktop release cache purge

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -49,7 +49,7 @@ on:
     secrets:
       CLOUDFLARE_ZONE_ID:
         required: false
-      CLOUDFLARE_API_TOKEN:
+      CLOUDFLARE_PURGE_API_TOKEN:
         required: false
 
 permissions:
@@ -471,7 +471,7 @@ jobs:
         if: inputs.update_feed_url != '' && env.CLOUDFLARE_ZONE_ID != ''
         env:
           CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_PURGE_API_TOKEN: ${{ secrets.CLOUDFLARE_PURGE_API_TOKEN }}
           UPDATE_FEED_URL: ${{ inputs.update_feed_url }}
           LATEST_DMG: ${{ steps.artifacts.outputs.latest_dmg }}
           LATEST_ZIP: ${{ steps.artifacts.outputs.latest_zip }}
@@ -497,14 +497,60 @@ jobs:
           fi
 
           files_json=$(printf '%s\n' "${urls[@]}" | jq -R . | jq -sc '.')
+          payload=$(jq -cn --argjson files "$files_json" '{ files: $files }')
+          api_url="https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache"
+          max_attempts=5
+          purge_succeeded=0
+
           echo "[cf-purge] Purging: ${files_json}"
 
-          curl -sf -X POST \
-            "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \
-            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-            -H "Content-Type: application/json" \
-            -d "{\"files\": ${files_json}}" \
-            | jq .
+          for attempt in $(seq 1 "$max_attempts"); do
+            response_file=$(mktemp)
+            http_code="$({
+              curl \
+                --http1.1 \
+                --silent \
+                --show-error \
+                --location \
+                --retry 3 \
+                --retry-delay 2 \
+                --retry-all-errors \
+                --connect-timeout 15 \
+                --max-time 120 \
+                --output "$response_file" \
+                --write-out '%{http_code}' \
+                -X POST \
+                "$api_url" \
+                -H "Authorization: Bearer ${CLOUDFLARE_PURGE_API_TOKEN}" \
+                -H "Content-Type: application/json" \
+                --data "$payload"
+            } || true)"
+
+            echo "[cf-purge] attempt ${attempt}/${max_attempts} http=${http_code:-curl-failed}"
+
+            if [ -s "$response_file" ]; then
+              jq . "$response_file" || true
+            else
+              echo "[cf-purge] empty response body"
+            fi
+
+            if [ "$http_code" = "200" ] && jq -e '.success == true' "$response_file" >/dev/null 2>&1; then
+              purge_succeeded=1
+              rm -f "$response_file"
+              break
+            fi
+
+            rm -f "$response_file"
+
+            if [ "$attempt" -lt "$max_attempts" ]; then
+              sleep $((attempt * 2))
+            fi
+          done
+
+          if [ "$purge_succeeded" -ne 1 ]; then
+            echo "[cf-purge] failed after ${max_attempts} attempts" >&2
+            exit 1
+          fi
 
       - name: Publish Cloudflare download links
         if: inputs.update_feed_url != ''

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -442,7 +442,7 @@ jobs:
         if: env.CLOUDFLARE_ZONE_ID != ''
         env:
           CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_PURGE_API_TOKEN: ${{ secrets.CLOUDFLARE_PURGE_API_TOKEN }}
           CHANNEL: ${{ steps.artifacts.outputs.channel }}
           ARCH: ${{ matrix.arch }}
           LATEST_DMG: ${{ steps.artifacts.outputs.latest_dmg }}
@@ -468,14 +468,60 @@ jobs:
           fi
 
           files_json=$(printf '%s\n' "${urls[@]}" | jq -R . | jq -sc '.')
+          payload=$(jq -cn --argjson files "$files_json" '{ files: $files }')
+          api_url="https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache"
+          max_attempts=5
+          purge_succeeded=0
+
           echo "[cf-purge] Purging: ${files_json}"
 
-          curl -sf -X POST \
-            "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \
-            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-            -H "Content-Type: application/json" \
-            -d "{\"files\": ${files_json}}" \
-            | jq .
+          for attempt in $(seq 1 "$max_attempts"); do
+            response_file=$(mktemp)
+            http_code="$({
+              curl \
+                --http1.1 \
+                --silent \
+                --show-error \
+                --location \
+                --retry 3 \
+                --retry-delay 2 \
+                --retry-all-errors \
+                --connect-timeout 15 \
+                --max-time 120 \
+                --output "$response_file" \
+                --write-out '%{http_code}' \
+                -X POST \
+                "$api_url" \
+                -H "Authorization: Bearer ${CLOUDFLARE_PURGE_API_TOKEN}" \
+                -H "Content-Type: application/json" \
+                --data "$payload"
+            } || true)"
+
+            echo "[cf-purge] attempt ${attempt}/${max_attempts} http=${http_code:-curl-failed}"
+
+            if [ -s "$response_file" ]; then
+              jq . "$response_file" || true
+            else
+              echo "[cf-purge] empty response body"
+            fi
+
+            if [ "$http_code" = "200" ] && jq -e '.success == true' "$response_file" >/dev/null 2>&1; then
+              purge_succeeded=1
+              rm -f "$response_file"
+              break
+            fi
+
+            rm -f "$response_file"
+
+            if [ "$attempt" -lt "$max_attempts" ]; then
+              sleep $((attempt * 2))
+            fi
+          done
+
+          if [ "$purge_succeeded" -ne 1 ]; then
+            echo "[cf-purge] failed after ${max_attempts} attempts" >&2
+            exit 1
+          fi
 
   trigger-e2e:
     needs: release


### PR DESCRIPTION
## What

Improve the desktop release Cloudflare cache purge steps and switch them to a dedicated purge token secret.

## Why

The nightly desktop build failed after publishing artifacts because the final Cloudflare purge call was brittle and the existing token setup was not scoped for cache purge. This keeps release publication reliable while avoiding reuse of unrelated Cloudflare credentials.

## How

- switch desktop build/release workflows to `CLOUDFLARE_PURGE_API_TOKEN`
- add retry, backoff, HTTP status capture, and response-body logging around the purge request
- fail only when all purge attempts are exhausted or Cloudflare returns a non-success response
- locally validate the updated logic with a retrying mock server and a real Cloudflare purge request against the nightly latest artifacts

## Affected areas

- [ ] Desktop app (Electron shell)
- [ ] Controller (backend / API)
- [ ] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [x] Build / CI / Tooling

## Checklist

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

## Notes for reviewers

- Added repo secret: `CLOUDFLARE_PURGE_API_TOKEN`
- Verified the new token with a real purge call for nightly latest artifacts before opening this PR