### PR TITLE
fix(web): persist banner dismiss per session only

### DIFF
--- a/apps/web/src/pages/home.tsx
+++ b/apps/web/src/pages/home.tsx
@@ -278,7 +278,7 @@ export function HomePage() {
   const [seedancePromoOpen, setSeedancePromoOpen] = useState(false);
   const [showSeedancePromo, setShowSeedancePromo] = useState(() => {
     try {
-      return localStorage.getItem(SEEDANCE_PROMO_DISMISS_KEY) !== "1";
+      return sessionStorage.getItem(SEEDANCE_PROMO_DISMISS_KEY) !== "1";
     } catch {
       return true;
     }
@@ -511,7 +511,7 @@ export function HomePage() {
   const dismissSeedancePromo = useCallback(() => {
     setShowSeedancePromo(false);
     try {
-      localStorage.setItem(SEEDANCE_PROMO_DISMISS_KEY, "1");
+      sessionStorage.setItem(SEEDANCE_PROMO_DISMISS_KEY, "1");
     } catch {
       // noop
     }


### PR DESCRIPTION
## What

Switch Seedance promo banner dismiss state from `localStorage` to `sessionStorage`.

## Why

When user dismisses the banner, it should only stay hidden for the current session. Next time they open the app, the banner should reappear.

## How

`localStorage` → `sessionStorage` for the dismiss key read/write. `sessionStorage` is cleared when the window/tab closes.

## Affected areas

- [x] Web dashboard (React UI)

## Checklist

- [x] `pnpm typecheck` passes
- [x] No `any` types introduced