### PR TITLE
fix(web): move promo banner between hero and channels

### DIFF
--- a/apps/web/src/pages/home.tsx
+++ b/apps/web/src/pages/home.tsx
@@ -713,15 +713,15 @@ export function HomePage() {
               </div>
             </div>
           </div>
-        </div>
 
-        {showSeedancePromo ? (
-          <SeedancePromoBanner
-            isDismissed={false}
-            onOpen={() => setSeedancePromoOpen(true)}
-            onDismiss={dismissSeedancePromo}
-          />
-        ) : null}
+          {showSeedancePromo ? (
+            <SeedancePromoBanner
+              isDismissed={false}
+              onOpen={() => setSeedancePromoOpen(true)}
+              onDismiss={dismissSeedancePromo}
+            />
+          ) : null}
+        </div>
 
         {modalChannel && (
           <ChannelConnectModal


### PR DESCRIPTION
## What

Move Seedance promo banner position in the connected-channels view (Scene B) from below channels to between the hero section and the channels card.

## Why

The banner should appear right after the bot status/model info area, above the channels — not buried below them.

## How

Moved the `SeedancePromoBanner` render from after the channels `</div>` to before `{/* ═══ MIDDLE: Channels panel ═══ */}`.

## Affected areas

- [x] Web dashboard (React UI)

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes
- [x] No `any` types introduced