### PR TITLE
release: v0.1.10 (superseded)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexu/desktop",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## 🎉 Highlights

- 🎬 **Seedance 2.0 video generation** — Generate 15-20 second AI videos right from your bot conversations. Star the repo and join the community group to get free credits. (#749, #751) Thanks @alchemistklk and @lefarcen.
- 🔄 **Startup is more resilient** — If the controller fails its initial readiness check, the app now retries automatically instead of getting stuck. (#750) Thanks @mrcfps.

> 📥 **Download now:** [macOS Apple Silicon (.dmg)](https://github.com/nexu-io/nexu/releases/download/v0.1.10/nexu-0.1.10-mac-arm64.dmg) · [macOS Intel (.dmg)](https://github.com/nexu-io/nexu/releases/download/v0.1.10/nexu-0.1.10-mac-x64.dmg)
>
> Requires macOS 13+.

## ✨ What's New

- 🎥 **LibTV Video skill** — A second bundled video generation skill with LibTV as an alternative backend. (#751) Thanks @alchemistklk.
- 📚 **Seedance guide** — New documentation pages walking users through setup and usage. (#748) Thanks @qiongyu1999.

## 🛡️ Stability & Reliability

- Controller startup now retries after readiness failure instead of leaving users on a loading screen forever. (#750) Thanks @mrcfps.
- Promo banner dismiss is session-scoped — it comes back on next launch so users don't permanently miss it. (#756) Thanks @lefarcen.

## 🐛 Bug Fixes

- Fixed promo banner overlapping the hero section — now appears between bot status and channels where it belongs. (#752, #757) Thanks @lefarcen.
- Fixed Sentry automation commits being misattributed as external contributions. (#744) Thanks @nettee.

## 🔨 For Developers

<details>
<summary>Click to expand</summary>

- Seedance promo countdown starts from configurable cycle start with 2-day auto-reset. (#752) Thanks @lefarcen.
- Docs page validation script added. (#748) Thanks @qiongyu1999.
- Internal author detection expanded to cover Sentry bot commits. (#744) Thanks @nettee.

</details>

**Full Changelog:** https://github.com/nexu-io/nexu/compare/v0.1.9...release/v0.1.10