### PR TITLE
chore(controller): rename session_start event and add chat skill source

### DIFF
--- a/apps/controller/src/services/analytics-service.ts
+++ b/apps/controller/src/services/analytics-service.ts
@@ -14,7 +14,7 @@ type AnalyticsChannel =
   | "discord"
   | "telegram"
   | "whatsapp";
-type AnalyticsSkillSource = "builtin" | "explore" | "custom";
+type AnalyticsSkillSource = "builtin" | "explore" | "custom" | "chat";
 type InternalSkillSource = "curated" | "managed" | "custom";
 
 type AnalyticsState = {
@@ -249,7 +249,7 @@ export class AnalyticsService {
     if (!this.state.sessionStartSent && firstSessionCandidate?.providerName) {
       await this.sendEvent(
         profile.id,
-        "session_start",
+        "nexu_first_conversation_start",
         {
           channel: firstSessionCandidate.channel,
           model_provider: firstSessionCandidate.providerName,


### PR DESCRIPTION
## What

- Rename `session_start` → `nexu_first_conversation_start` to match product analytics spec
- Add `"chat"` to `AnalyticsSkillSource` type for skills created via conversation

## Why

Product spec requires `nexu_first_conversation_start` as the event name. Also adds `"chat"` skill source type for future use when OpenClaw supports identifying conversation-created skills.

## Affected areas

- [ ] Desktop app (Electron shell)
- [x] Controller (backend / API)
- [ ] Web dashboard (React UI)
- [ ] Build / CI / Tooling

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced