### PR TITLE
release: v0.1.10

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexu/desktop",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## 🎉 Highlights

- 🎬 **Seedance 2.0 video generation** — Generate 15-20 second AI videos right from your bot conversations. Star the repo and join the community group to get free credits. (#749, #751, #764) Thanks @alchemistklk and @lefarcen.
- 🔄 **Startup is more resilient** — If the controller fails its initial readiness check, the app now retries automatically instead of getting stuck on a loading screen. (#750) Thanks @mrcfps.

> 📥 **Download now:** [macOS Apple Silicon (.dmg)](https://github.com/nexu-io/nexu/releases/download/v0.1.10/nexu-0.1.10-mac-arm64.dmg) · [macOS Intel (.dmg)](https://github.com/nexu-io/nexu/releases/download/v0.1.10/nexu-0.1.10-mac-x64.dmg)
>
> Requires macOS 13+.

## ✨ What's New

- 🎥 **Two video skills bundled** — Medeo Video and LibTV Video ship out of the box, with Seedance 2.0, Kling 3.0, and more models available. (#751, #764) Thanks @alchemistklk.
- 📚 **Seedance guide** — New documentation pages in Chinese, English, and Japanese walking users through setup and usage. (#748, #761) Thanks @qiongyu1999.
- 📊 **Better analytics** — First-conversation events and skill source tracking for understanding how users discover features. (#766) Thanks @lefarcen.

## 🛡️ Stability & Reliability

- Controller startup retries after readiness failure instead of hanging forever. (#750) Thanks @mrcfps.
- Amplitude API key now correctly passed to the controller in launchd mode — analytics no longer silently broken in packaged builds. (#763) Thanks @lefarcen.
- Promo banner dismiss is session-scoped — comes back on next launch so users don't permanently miss it. (#756) Thanks @lefarcen.

## 🐛 Bug Fixes

- Fixed promo banner appearing above bot status — now sits between the hero section and channels. (#752, #757) Thanks @lefarcen.
- Fixed NoneType crash in LibTV video skill when API returns unexpected data. (#764) Thanks @alchemistklk.
- Fixed Sentry automation commits being misattributed as external contributions. (#744) Thanks @nettee.

## 🔨 For Developers

<details>
<summary>Click to expand</summary>

- Seedance promo countdown starts from configurable cycle start with 2-day auto-reset. (#752) Thanks @lefarcen.
- Docs page validation script added. (#748) Thanks @qiongyu1999.
- Internal author detection expanded to cover Sentry bot commits. (#744) Thanks @nettee.
- Renamed `session_start` analytics event to `nexu_first_conversation_start` for clarity. (#766) Thanks @lefarcen.

</details>

**Full Changelog:** https://github.com/nexu-io/nexu/compare/v0.1.9...release/v0.1.10