### PR TITLE
fix(desktop): auto-clear launchd disabled override on bootstrap

### DIFF
--- a/apps/desktop/main/services/launchd-manager.ts
+++ b/apps/desktop/main/services/launchd-manager.ts
@@ -26,12 +26,14 @@ export class LaunchdManager {
   private readonly plistDir: string;
   private readonly uid: number;
   private readonly domain: string;
+  private readonly log: (message: string) => void;
 
-  constructor(opts?: { plistDir?: string }) {
+  constructor(opts?: { plistDir?: string; log?: (message: string) => void }) {
     this.plistDir =
       opts?.plistDir ?? path.join(os.homedir(), "Library/LaunchAgents");
     this.uid = os.userInfo().uid;
     this.domain = `gui/${this.uid}`;
+    this.log = opts?.log ?? console.log;
   }
 
   /**
@@ -72,6 +74,16 @@ export class LaunchdManager {
 
     await fs.writeFile(plistPath, plistContent, "utf8");
 
+    // Clear any persistent "disabled" override left by legacy `launchctl unload -w`.
+    // Without this, bootstrap fails with error 5 (Input/output error).
+    const disabled = await this.isServiceDisabled(label);
+    if (disabled) {
+      this.log(
+        `installService: ${label} has disabled override, clearing with launchctl enable`,
+      );
+      await this.enableService(label);
+    }
+
     // Bootstrap with retry: "Input/output error" (code 5) means launchd
     // has stale state for this label. Bootout to clear it, then retry.
     for (let attempt = 0; attempt < 2; attempt++) {
@@ -95,6 +107,8 @@ export class LaunchdManager {
           } catch {
             // may already be unregistered
           }
+          // Also clear disabled override in case that's the cause
+          await this.enableService(label).catch(() => {});
           await new Promise((r) => setTimeout(r, 1000));
           continue;
         }
@@ -265,6 +279,45 @@ export class LaunchdManager {
       }
     }
     return env;
+  }
+
+  /**
+   * Check if a service has a persistent "disabled" override in launchd's database.
+   * This happens when someone runs `launchctl unload -w` which writes a sticky
+   * disabled flag, causing all subsequent `launchctl bootstrap` calls to fail
+   * with error 5 (Input/output error).
+   */
+  async isServiceDisabled(label: string): Promise<boolean> {
+    try {
+      const { stdout } = await execFileAsync("launchctl", [
+        "print-disabled",
+        this.domain,
+      ]);
+      // Output format: "io.nexu.controller" => true
+      const pattern = new RegExp(
+        `"${label.replace(/\./g, "\\.")}"\\s*=>\\s*true`,
+      );
+      return pattern.test(stdout);
+    } catch {
+      // Command failed or label not found — assume not disabled
+      return false;
+    }
+  }
+
+  /**
+   * Clear a persistent "disabled" override for a service.
+   * Runs `launchctl enable gui/<uid>/<label>` so that subsequent bootstrap
+   * calls succeed. Tolerates errors (the label may not be in the disabled database).
+   */
+  async enableService(label: string): Promise<void> {
+    try {
+      await execFileAsync("launchctl", ["enable", `${this.domain}/${label}`]);
+      this.log(`enableService: cleared disabled override for ${label}`);
+    } catch (err) {
+      this.log(
+        `enableService: failed to clear disabled override for ${label}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
## What

Auto-detect and clear persistent `launchctl unload -w` disabled overrides before launchd bootstrap.

## Why

Closes #780

Two users previously ran `launchctl unload -w` to clean up zombie OpenClaw processes. This command writes a persistent "disabled" flag in launchd's database, causing all subsequent `launchctl bootstrap` calls to fail with error 5 (Input/output error) — even when the plist and all referenced paths are valid. The result is controller/openclaw never starting, leading to a white screen on launch.

## How

Added two methods to `LaunchdManager`:

- `isServiceDisabled(label)` — parses `launchctl print-disabled gui/<uid>` output to detect if a label is marked as disabled
- `enableService(label)` — runs `launchctl enable gui/<uid>/<label>` to clear the disabled override

Called in `installService()` at two points:
1. **Pre-bootstrap** (normal path): proactively checks and clears the disabled flag before the first bootstrap attempt
2. **Error 5 retry** (defensive path): clears the flag after bootout and before the retry attempt

Also added `log` callback support to `LaunchdManager` (aligned with #792) so disabled-detection logs are written to the structured cold-start.log.

## Affected areas

- [x] Desktop app (Electron shell)

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

## Notes for reviewers

This PR has a minor conflict with #792 (logging improvements) — both modify the `LaunchdManager` constructor. Resolve by keeping the `log` callback from whichever merges second. Core logic changes are limited to `installService()` and the two new methods; no impact on existing startup flow.