### PR TITLE
fix(desktop): make electronDist override opt-in to unbreak nightly codesign

### DIFF
--- a/apps/desktop/scripts/dist-mac.mjs
+++ b/apps/desktop/scripts/dist-mac.mjs
@@ -116,17 +116,19 @@ async function ensureExistingRuntimeInstall() {
   ]);
 }
 
+// Only honor an explicitly provided electron dist override (used by e2e
+// coverage tooling). When unset, return null so electron-builder falls back
+// to its default electron resolution. Pointing electron-builder directly at
+// the pnpm-stored Electron.app caused codesign to fail with "bundle format is
+// ambiguous" because the framework symlink layout did not survive the copy
+// from the pnpm content-addressable store (regression from #698).
 async function resolveElectronDistPath() {
-  if (process.env.NEXU_DESKTOP_ELECTRON_DIST_PATH) {
-    return process.env.NEXU_DESKTOP_ELECTRON_DIST_PATH;
+  const override = process.env.NEXU_DESKTOP_ELECTRON_DIST_PATH;
+  if (!override) {
+    return null;
   }
-
-  const electronPackageJsonPath = require.resolve("electron/package.json", {
-    paths: [electronRoot, repoRoot],
-  });
-  const electronDistPath = resolve(dirname(electronPackageJsonPath), "dist");
-  await ensureExistingPath(electronDistPath, "electron dist");
-  return electronDistPath;
+  await ensureExistingPath(override, "electron dist override");
+  return override;
 }
 
 async function timedStep(stepName, fn, timings) {
@@ -805,7 +807,9 @@ async function main() {
         "--publish",
         "never",
         `--config.electronVersion=${electronVersion}`,
-        `--config.electronDist=${electronDistPath}`,
+        ...(electronDistPath
+          ? [`--config.electronDist=${electronDistPath}`]
+          : []),
         `--config.buildVersion=${buildVersion}`,
         `--config.directories.output=${releaseRoot}`,
         ...(isFastCiMode


### PR DESCRIPTION
## What

Stop unconditionally passing `--config.electronDist` to electron-builder. Only forward it when `NEXU_DESKTOP_ELECTRON_DIST_PATH` is explicitly set.

## Why

The 04-07 Desktop Nightly run ([24058395128](https://github.com/nexu-io/nexu/actions/runs/24058395128)) failed during codesign on macOS arm64:

```
Electron Framework: bundle format is ambiguous (could be app or framework)
```

`codesign` hung for ~6 minutes before exiting. The 04-06 nightly succeeded, and the only desktop-build-related change between the two was #698, which added:

```js
`--config.electronDist=${electronDistPath}`,
```

where `electronDistPath` was resolved via `require.resolve("electron/package.json")` — i.e. it pointed directly into the pnpm content-addressable store at `node_modules/.pnpm/electron@37.10.3/node_modules/electron/dist`.

When electron-builder copies `Electron.app` out of that path, the framework versioning symlinks (`Electron Framework.framework/Versions/Current → A`, top-level `Electron Framework → Versions/Current/Electron Framework`, etc.) do not survive the copy out of the pnpm store. The resulting framework bundle ends up with both top-level files and a `Versions/` directory present, which is exactly the layout that makes `codesign` report `bundle format is ambiguous`.

Letting electron-builder resolve electron via its default pnpm-aware path (the pre-#698 behavior) preserves framework symlinks correctly, which is why every nightly before 04-07 was green.

## How

- `resolveElectronDistPath()` now returns `null` unless `NEXU_DESKTOP_ELECTRON_DIST_PATH` is set, and validates the override path when present.
- `--config.electronDist=...` is only appended to the electron-builder argv when the helper returns a non-null value.
- The e2e coverage tooling that originally needed to inject a custom electron dist can still do so via the env var — that opt-in escape hatch is preserved.
- Added an inline comment documenting why we avoid pointing electron-builder at the pnpm store directly, so this regression doesn't get reintroduced.

## Affected areas

- [x] Desktop app (Electron shell)
- [x] Build / CI / Tooling

## Checklist

- [ ] `pnpm typecheck` passes — N/A (build script, not in tsc graph)
- [ ] `pnpm lint` passes — not run locally (worktree without node_modules); change is a 14-line edit to a build script and follows existing patterns
- [ ] `pnpm test` passes — N/A
- [ ] `pnpm generate-types` run (if API routes/schemas changed) — N/A
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced

## Notes for reviewers

- Verification path: re-run the Desktop Nightly workflow on this branch (or trigger `dist:mac` manually) and confirm the macOS arm64 codesign step completes successfully.
- If the e2e coverage workflow relies on a custom electron dist, it must now set `NEXU_DESKTOP_ELECTRON_DIST_PATH` explicitly. Worth a quick grep in the e2e workflow to confirm whether anything depended on the implicit auto-resolution behavior introduced in #698.