### PR TITLE
fix(desktop): restore dev loadURL via NEXU_DESKTOP_DEV_SERVER_URL

### DIFF
--- a/apps/desktop/main/index.ts
+++ b/apps/desktop/main/index.ts
@@ -940,14 +940,26 @@ function createMainWindow(): BrowserWindow {
     focusMainWindow();
   }
 
-  void window.loadFile(resolve(__dirname, "../../dist/index.html"));
-  diagnosticsReporter?.recordStartupProbe({
-    source: "main",
-    stage: "main:window-load-dispatched",
-    status: "ok",
-    detail: resolve(__dirname, "../../dist/index.html"),
-  });
-  logLaunchTimeline("main window loadFile dispatched");
+  const devServerUrl = process.env.NEXU_DESKTOP_DEV_SERVER_URL;
+  if (devServerUrl) {
+    void window.loadURL(devServerUrl);
+    diagnosticsReporter?.recordStartupProbe({
+      source: "main",
+      stage: "main:window-load-dispatched",
+      status: "ok",
+      detail: devServerUrl,
+    });
+    logLaunchTimeline(`main window loadURL dispatched url=${devServerUrl}`);
+  } else {
+    void window.loadFile(resolve(__dirname, "../../dist/index.html"));
+    diagnosticsReporter?.recordStartupProbe({
+      source: "main",
+      stage: "main:window-load-dispatched",
+      status: "ok",
+      detail: resolve(__dirname, "../../dist/index.html"),
+    });
+    logLaunchTimeline("main window loadFile dispatched");
+  }
   mainWindow = window;
   return window;
 }


### PR DESCRIPTION
Commit 9ca4ca20 removed the dev server URL check and hardcoded loadFile, which broke dev mode because dist/index.html does not exist in dev. Restore the check using NEXU_DESKTOP_DEV_SERVER_URL (injected by the dev scripts) so Electron loads from the Vite dev server in dev mode and falls back to loadFile only in packaged mode.

## What

<!-- One-liner: what does this PR do? -->

## Why

<!-- Motivation: what problem does it solve or what feature does it enable? Link related issues with "Closes #123". -->

## How

<!-- Implementation approach: key design decisions, trade-offs, or anything reviewers should know. -->

## Affected areas

<!-- Check all that apply -->

- [ ] Desktop app (Electron shell)
- [ ] Controller (backend / API)
- [ ] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [ ] Build / CI / Tooling

## Checklist

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [ ] No credentials or tokens in code or logs
- [ ] No `any` types introduced (use `unknown` with narrowing)

## Screenshots / recordings

<!-- If applicable, add screenshots or recordings to help explain the change. Delete this section if not needed. -->

## Notes for reviewers

<!-- Anything specific reviewers should focus on, test manually, or be aware of. Delete this section if not needed. -->
