### PR TITLE
fix: restore packaged Nexu home and welcome redirect

### DIFF
--- a/apps/desktop/main/bootstrap.ts
+++ b/apps/desktop/main/bootstrap.ts
@@ -3,6 +3,10 @@ import { join, resolve } from "node:path";
 import { app } from "electron";
 import { getDesktopNexuHomeDir } from "../shared/desktop-paths";
 import { resolveRuntimePlatform } from "./platforms/platform-resolver";
+import {
+  getLegacyPackagedNexuHomeDir,
+  migrateNexuHomeFromUserData,
+} from "./services/nexu-home-migration";
 
 function safeWrite(stream: NodeJS.WriteStream, message: string): void {
   if (stream.destroyed || !stream.writable) {
@@ -145,11 +149,27 @@ function configurePackagedPaths(): void {
   const sessionDataPath = join(effectiveUserDataPath, "session");
   const logsPath = join(effectiveUserDataPath, "logs");
   const nexuHomePath = getDesktopNexuHomeDir(effectiveUserDataPath);
+  const legacyPackagedNexuHomePath = getLegacyPackagedNexuHomeDir(
+    effectiveUserDataPath,
+  );
 
   mkdirSync(effectiveUserDataPath, { recursive: true });
   mkdirSync(sessionDataPath, { recursive: true });
   mkdirSync(logsPath, { recursive: true });
   mkdirSync(nexuHomePath, { recursive: true });
+
+  if (legacyPackagedNexuHomePath !== nexuHomePath) {
+    migrateNexuHomeFromUserData({
+      targetNexuHome: nexuHomePath,
+      sourceNexuHome: legacyPackagedNexuHomePath,
+      log: (message) => {
+        safeWrite(
+          process.stdout,
+          `[desktop:paths] nexu-home-migration: ${message}\n`,
+        );
+      },
+    });
+  }
 
   process.env.NEXU_HOME = nexuHomePath;
 

--- a/apps/desktop/main/services/nexu-home-migration.ts
+++ b/apps/desktop/main/services/nexu-home-migration.ts
@@ -1,0 +1,222 @@
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { resolve } from "node:path";
+
+const MIGRATION_STAMP = ".desktop-userdata-home-migration-v1";
+
+const COPYABLE_FILES = [
+  "cloud-profiles.json",
+  "compiled-openclaw.json",
+  "skill-ledger.json",
+  "analytics-state.json",
+] as const;
+
+const COPYABLE_DIRS = [
+  "artifacts",
+  "skillhub-cache",
+  "logs",
+  "runtime",
+] as const;
+
+type JsonRecord = Record<string, unknown>;
+
+export interface NexuHomeMigrationOpts {
+  targetNexuHome: string;
+  sourceNexuHome: string;
+  log: (message: string) => void;
+}
+
+function safeReadJson(filePath: string): JsonRecord | null {
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, "utf8")) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed as JsonRecord;
+  } catch {
+    return null;
+  }
+}
+
+function mergeRecords(
+  target: JsonRecord | undefined,
+  source: JsonRecord | undefined,
+): JsonRecord {
+  return {
+    ...(target ?? {}),
+    ...(source ?? {}),
+  };
+}
+
+function mergeConfigArrays(
+  target: unknown,
+  source: unknown,
+): Array<Record<string, unknown>> | undefined {
+  const targetItems = Array.isArray(target) ? target : [];
+  const sourceItems = Array.isArray(source) ? source : [];
+  if (targetItems.length === 0 && sourceItems.length === 0) {
+    return undefined;
+  }
+
+  const merged = new Map<string, Record<string, unknown>>();
+  const anon: Array<Record<string, unknown>> = [];
+  for (const item of targetItems) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+    const record = item as Record<string, unknown>;
+    const id = typeof record.id === "string" ? record.id : null;
+    if (id) {
+      merged.set(id, record);
+    } else {
+      anon.push(record);
+    }
+  }
+
+  for (const item of sourceItems) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+    const record = item as Record<string, unknown>;
+    const id = typeof record.id === "string" ? record.id : null;
+    if (id) {
+      merged.set(id, {
+        ...(merged.get(id) ?? {}),
+        ...record,
+      });
+    } else {
+      anon.push(record);
+    }
+  }
+
+  return [...merged.values(), ...anon];
+}
+
+function mergeNexuConfig(
+  target: JsonRecord | null,
+  source: JsonRecord | null,
+): JsonRecord | null {
+  if (!target && !source) return null;
+  if (!target) return source;
+  if (!source) return target;
+
+  return {
+    ...target,
+    ...source,
+    app: mergeRecords(
+      target.app as JsonRecord | undefined,
+      source.app as JsonRecord | undefined,
+    ),
+    runtime: mergeRecords(
+      target.runtime as JsonRecord | undefined,
+      source.runtime as JsonRecord | undefined,
+    ),
+    desktop: mergeRecords(
+      target.desktop as JsonRecord | undefined,
+      source.desktop as JsonRecord | undefined,
+    ),
+    secrets: mergeRecords(
+      target.secrets as JsonRecord | undefined,
+      source.secrets as JsonRecord | undefined,
+    ),
+    templates: mergeRecords(
+      target.templates as JsonRecord | undefined,
+      source.templates as JsonRecord | undefined,
+    ),
+    bots: mergeConfigArrays(target.bots, source.bots) ?? [],
+    providers: mergeConfigArrays(target.providers, source.providers) ?? [],
+    integrations:
+      mergeConfigArrays(target.integrations, source.integrations) ?? [],
+    channels: mergeConfigArrays(target.channels, source.channels) ?? [],
+  };
+}
+
+function copyDirIfMissing(
+  sourceDir: string,
+  targetDir: string,
+  log: (message: string) => void,
+): number {
+  if (!existsSync(sourceDir) || existsSync(targetDir)) {
+    return 0;
+  }
+  cpSync(sourceDir, targetDir, { recursive: true });
+  log(`copied dir ${targetDir}`);
+  return 1;
+}
+
+function copyFileIfMissing(
+  sourceFile: string,
+  targetFile: string,
+  log: (message: string) => void,
+): number {
+  if (!existsSync(sourceFile) || existsSync(targetFile)) {
+    return 0;
+  }
+  cpSync(sourceFile, targetFile);
+  log(`copied file ${targetFile}`);
+  return 1;
+}
+
+function writeStamp(stampPath: string): void {
+  writeFileSync(stampPath, new Date().toISOString(), "utf8");
+}
+
+export function getLegacyPackagedNexuHomeDir(userDataPath: string): string {
+  return resolve(userDataPath, ".nexu");
+}
+
+export function migrateNexuHomeFromUserData(opts: NexuHomeMigrationOpts): void {
+  const { targetNexuHome, sourceNexuHome, log } = opts;
+  const stampPath = resolve(targetNexuHome, MIGRATION_STAMP);
+
+  if (existsSync(stampPath)) {
+    log("nexu-home migration already completed, skipping");
+    return;
+  }
+
+  mkdirSync(targetNexuHome, { recursive: true });
+
+  if (!existsSync(sourceNexuHome)) {
+    log(`legacy nexu-home not found: ${sourceNexuHome}, nothing to migrate`);
+    writeStamp(stampPath);
+    return;
+  }
+
+  let migrated = 0;
+
+  const sourceConfigPath = resolve(sourceNexuHome, "config.json");
+  const targetConfigPath = resolve(targetNexuHome, "config.json");
+  const mergedConfig = mergeNexuConfig(
+    safeReadJson(targetConfigPath),
+    safeReadJson(sourceConfigPath),
+  );
+  if (mergedConfig) {
+    writeFileSync(
+      targetConfigPath,
+      `${JSON.stringify(mergedConfig, null, 2)}\n`,
+      "utf8",
+    );
+    log(`merged config ${targetConfigPath}`);
+    migrated++;
+  }
+
+  for (const file of COPYABLE_FILES) {
+    migrated += copyFileIfMissing(
+      resolve(sourceNexuHome, file),
+      resolve(targetNexuHome, file),
+      log,
+    );
+  }
+
+  for (const dir of COPYABLE_DIRS) {
+    migrated += copyDirIfMissing(
+      resolve(sourceNexuHome, dir),
+      resolve(targetNexuHome, dir),
+      log,
+    );
+  }
+
+  writeStamp(stampPath);
+  log(`nexu-home migration complete: ${migrated} items migrated`);
+}

--- a/apps/desktop/shared/desktop-paths.ts
+++ b/apps/desktop/shared/desktop-paths.ts
@@ -1,7 +1,8 @@
+import { homedir } from "node:os";
 import { resolve } from "node:path";
 
-export function getDesktopNexuHomeDir(userDataPath: string): string {
-  return resolve(userDataPath, ".nexu");
+export function getDesktopNexuHomeDir(_userDataPath: string): string {
+  return resolve(homedir(), ".nexu");
 }
 
 export function getOpenclawSkillsDir(userDataPath: string): string {

--- a/apps/web/src/pages/welcome.tsx
+++ b/apps/web/src/pages/welcome.tsx
@@ -21,6 +21,7 @@ import { LanguageSwitcher } from "../components/language-switcher";
 import { ProviderLogo } from "../components/provider-logo";
 import { useLocale } from "../hooks/use-locale";
 import { usePageTitle } from "../hooks/use-page-title";
+import { authClient } from "../lib/auth-client";
 import { track } from "../lib/tracking";
 
 const SETUP_COMPLETE_KEY = "nexu_setup_complete";
@@ -104,11 +105,8 @@ export function WelcomePage() {
   const { t } = useLocale();
   usePageTitle(t("welcome.pageTitle"));
   const navigate = useNavigate();
-
-  // If already set up, skip welcome
-  if (isSetupComplete()) {
-    return <Navigate to="/workspace" replace />;
-  }
+  const { data: session, isPending: authPending } = authClient.useSession();
+  const setupComplete = isSetupComplete();
 
   const [mode, setMode] = useState<Mode>("choose");
 
@@ -123,6 +121,14 @@ export function WelcomePage() {
     connected: false,
     polling: false,
   });
+
+  if (setupComplete && authPending) {
+    return <div className="min-h-screen bg-[#0b0b0d]" />;
+  }
+
+  if (setupComplete && session?.user) {
+    return <Navigate to="/workspace" replace />;
+  }
 
   useEffect(() => {
     let cancelled = false;

--- a/tests/desktop/nexu-home-migration.test.ts
+++ b/tests/desktop/nexu-home-migration.test.ts
@@ -1,0 +1,166 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  getLegacyPackagedNexuHomeDir,
+  migrateNexuHomeFromUserData,
+} from "../../apps/desktop/main/services/nexu-home-migration";
+import { getDesktopNexuHomeDir } from "../../apps/desktop/shared/desktop-paths";
+
+let tempDir: string;
+let sourceDir: string;
+let targetDir: string;
+const logMessages: string[] = [];
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "nexu-home-migration-"));
+  sourceDir = join(tempDir, "userData", ".nexu");
+  targetDir = join(tempDir, "home", ".nexu");
+  mkdirSync(sourceDir, { recursive: true });
+  mkdirSync(targetDir, { recursive: true });
+  logMessages.length = 0;
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("desktop nexu home paths", () => {
+  it("resolves packaged nexu home to ~/.nexu instead of userData/.nexu", () => {
+    const userDataPath = join(
+      tempDir,
+      "Library",
+      "Application Support",
+      "@nexu",
+      "desktop",
+    );
+    expect(getDesktopNexuHomeDir(userDataPath)).toBe(
+      join(process.env.HOME ?? "", ".nexu"),
+    );
+    expect(getDesktopNexuHomeDir(userDataPath)).not.toBe(
+      join(userDataPath, ".nexu"),
+    );
+  });
+
+  it("resolves the legacy packaged nexu home under userData", () => {
+    const userDataPath = join(
+      tempDir,
+      "Library",
+      "Application Support",
+      "@nexu",
+      "desktop",
+    );
+    expect(getLegacyPackagedNexuHomeDir(userDataPath)).toBe(
+      join(userDataPath, ".nexu"),
+    );
+  });
+});
+
+describe("migrateNexuHomeFromUserData", () => {
+  it("merges config.json from legacy userData home into ~/.nexu", () => {
+    writeFileSync(
+      join(sourceDir, "config.json"),
+      JSON.stringify({
+        channels: [{ id: "qq", botId: "bot-1", channelType: "qqbot" }],
+        bots: [{ id: "bot-1", name: "QQ Bot" }],
+        templates: { foo: { id: "foo", name: "foo" } },
+      }),
+      "utf8",
+    );
+    writeFileSync(
+      join(targetDir, "config.json"),
+      JSON.stringify({
+        channels: [{ id: "feishu", botId: "bot-2", channelType: "feishu" }],
+        bots: [{ id: "bot-2", name: "Feishu Bot" }],
+      }),
+      "utf8",
+    );
+
+    migrateNexuHomeFromUserData({
+      sourceNexuHome: sourceDir,
+      targetNexuHome: targetDir,
+      log: (message) => logMessages.push(message),
+    });
+
+    const merged = JSON.parse(
+      readFileSync(join(targetDir, "config.json"), "utf8"),
+    ) as {
+      channels: Array<{ id: string }>;
+      bots: Array<{ id: string }>;
+      templates: Record<string, unknown>;
+    };
+    expect(merged.channels.map((channel) => channel.id).sort()).toEqual([
+      "feishu",
+      "qq",
+    ]);
+    expect(merged.bots.map((bot) => bot.id).sort()).toEqual(["bot-1", "bot-2"]);
+    expect(Object.keys(merged.templates)).toContain("foo");
+  });
+
+  it("copies legacy metadata files and directories when missing", () => {
+    writeFileSync(
+      join(sourceDir, "compiled-openclaw.json"),
+      JSON.stringify({ channels: { qqbot: {} } }),
+      "utf8",
+    );
+    mkdirSync(join(sourceDir, "skillhub-cache"), { recursive: true });
+    writeFileSync(
+      join(sourceDir, "skillhub-cache", "index.json"),
+      "{}",
+      "utf8",
+    );
+
+    migrateNexuHomeFromUserData({
+      sourceNexuHome: sourceDir,
+      targetNexuHome: targetDir,
+      log: (message) => logMessages.push(message),
+    });
+
+    expect(existsSync(join(targetDir, "compiled-openclaw.json"))).toBe(true);
+    expect(existsSync(join(targetDir, "skillhub-cache", "index.json"))).toBe(
+      true,
+    );
+  });
+
+  it("writes a stamp and skips repeated migrations", () => {
+    writeFileSync(
+      join(sourceDir, "config.json"),
+      JSON.stringify({ channels: [{ id: "qq" }] }),
+      "utf8",
+    );
+
+    migrateNexuHomeFromUserData({
+      sourceNexuHome: sourceDir,
+      targetNexuHome: targetDir,
+      log: (message) => logMessages.push(message),
+    });
+
+    writeFileSync(
+      join(sourceDir, "config.json"),
+      JSON.stringify({ channels: [{ id: "updated-after-stamp" }] }),
+      "utf8",
+    );
+
+    migrateNexuHomeFromUserData({
+      sourceNexuHome: sourceDir,
+      targetNexuHome: targetDir,
+      log: (message) => logMessages.push(message),
+    });
+
+    const merged = JSON.parse(
+      readFileSync(join(targetDir, "config.json"), "utf8"),
+    ) as { channels: Array<{ id: string }> };
+    expect(merged.channels.map((channel) => channel.id)).toEqual(["qq"]);
+    expect(
+      logMessages.some((message) => message.includes("already completed")),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Restore packaged desktop `NEXU_HOME` back to `~/.nexu`, add a one-time migration for configs previously written under `userData/.nexu`, and keep the welcome page redirect gated on a ready auth session.

## Why

Recent packaged builds started binding `NEXU_HOME` to `userData/.nexu` instead of the persistent `~/.nexu` home. After upgrading, the controller could read a fresh empty config root and all channels appeared missing until users recreated them manually.

## How

- stop deriving packaged `NEXU_HOME` from `userData`
- resolve packaged desktop home back to `~/.nexu`
- add a one-time migration that merges legacy `userData/.nexu` config and metadata into the stable home
- add regression coverage for the new home path and migration behavior
- keep the existing welcome-page auth-session redirect fix in this branch

## Affected areas

- [x] Desktop app (Electron shell)
- [ ] Controller (backend / API)
- [x] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [ ] Build / CI / Tooling

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

## Notes for reviewers

I also built a local unsigned Apple Silicon package to verify the packaged desktop flow after the path fix.
