### PR TITLE
fix(desktop): show NexuLoader instead of error card while controller is starting

### DIFF
--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -1327,22 +1327,19 @@ function DesktopShell() {
               version={webSurfaceVersion}
               preload={getWebviewPreloadUrl()}
             />
-          ) : (
+          ) : controllerSurfaceState === "failed" ||
+            controllerSurfaceState === "recovering" ? (
             <section className="runtime-empty-state">
               <span className="runtime-eyebrow">Workspace</span>
               <h2>
                 {controllerSurfaceState === "recovering"
                   ? "Restarting controller..."
-                  : controllerSurfaceState === "failed"
-                    ? "Controller unavailable"
-                    : "Starting controller..."}
+                  : "Controller unavailable"}
               </h2>
               <p>
                 {controllerSurfaceState === "recovering"
                   ? "The local controller stopped cleanly, so desktop is starting it again before mounting the workspace."
-                  : controllerSurfaceState === "failed"
-                    ? "Workspace startup timed out because the local controller did not come back. Retry it here or switch to the control plane."
-                    : "Desktop is waiting for the local controller to report ready before loading the workspace surface."}
+                  : "Workspace startup timed out because the local controller did not come back. Retry it here or switch to the control plane."}
               </p>
               <div className="runtime-actions">
                 <button
@@ -1362,6 +1359,20 @@ function DesktopShell() {
                 </button>
               </div>
             </section>
+          ) : (
+            // Normal polling state: show the brand NexuLoader instead of a
+            // text card with a "Retry controller" button. SurfaceFrame with
+            // src={null} renders its built-in NexuLoader overlay, which is
+            // the same loader used once the webview mounts — producing a
+            // seamless visual transition once the controller is ready.
+            // See issue #876.
+            <SurfaceFrame
+              description="Authenticated workspace surface served by the repo-local web sidecar."
+              src={null}
+              title="nexu Web"
+              version={webSurfaceVersion}
+              preload={getWebviewPreloadUrl()}
+            />
           )}
         </div>
         <div


### PR DESCRIPTION
## What

On desktop app relaunch, replace the "Starting controller... / Retry controller" text card that briefly appeared before the home page with the brand `NexuLoader` animation.

## Why

Issue #876 (P0): after quitting the desktop app and launching it again, users saw a white card with the heading "Starting controller...", body copy "Desktop is waiting for the local controller to report ready before loading the workspace surface.", and two buttons "Retry controller" / "Open control plane" for several seconds before the actual home page appeared. The card looked like an error page, so users reported that the app "lands on the wrong page after loading".

The root cause is in `apps/desktop/src/main.tsx`: during the short window where the controller is booting but not yet ready, `desktopWebUrl` is `null`, so the renderer fell back to a `runtime-empty-state` text card. The same card was shown for both the normal polling state and the genuine `failed` state — only the heading text differed, and both had a "Retry controller" button, making the "still starting" case indistinguishable from "actually broken".

The setup animation only runs on first install / post-update (gated by `needsSetupExtraction`), so on every subsequent relaunch there was no animation to cover the polling window, and the card was exposed.

Closes #876

## How

Split the `activeSurface === "web"` fallback into three branches:

- `desktopWebUrl` ready → `SurfaceFrame` with the webview (unchanged)
- `controllerSurfaceState` is `failed` or `recovering` → the original error card with the Retry button (failure path preserved)
- normal polling → `SurfaceFrame` with `src={null}`, which reuses the built-in `NexuLoader` overlay that `SurfaceFrame` already renders before webview `did-finish-load`

Because the polling loader and the post-mount webview loader are now the same `NexuLoader` component with the same animation parameters, the visual transition from "controller starting" to "home page" is seamless and never exposes any text or buttons that could be mistaken for an error page.

No behavior change in the failure path: once `ensureDesktopControllerReady` times out, `controllerSurfaceState` flips to `failed` and the original error card with Retry is still rendered. First-install setup animation path is untouched (it runs in the setup overlay layer above this branch).

## Affected areas

- [x] Desktop app (Electron shell)
- [ ] Controller (backend / API)
- [ ] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [ ] Build / CI / Tooling

## Checklist

- [x] \`pnpm typecheck\` passes
- [x] \`pnpm lint\` passes
- [x] \`pnpm test\` passes (671 passed / 38 skipped)
- [ ] \`pnpm generate-types\` run (if API routes/schemas changed) — N/A
- [x] No credentials or tokens in code or logs
- [x] No \`any\` types introduced (use \`unknown\` with narrowing)

## Notes for reviewers

- Manually verified on macOS by stopping and relaunching the desktop app in dev mode: the white "Retry controller" card is gone and users now see the `NexuLoader` 4-quadrant animation until the home page appears.
- **Dev-loop gotcha surfaced during testing (not fixed in this PR)**: \`pnpm dev start\` only rebuilds \`dist-electron/\` (main + preload) but does **not** rebuild the renderer bundle in \`apps/desktop/dist/\`. Since \`apps/desktop/main/index.ts:957\` always does \`loadFile("../../dist/index.html")\` regardless of dev / prod, any change to \`apps/desktop/src/*.tsx\` is invisible unless you manually run \`pnpm --filter @nexu/desktop build\` before \`pnpm dev restart desktop\`. Worth tracking as a separate follow-up (either loading the Vite dev server in dev mode, or auto-rebuilding the renderer in \`scripts/dev/src/services/desktop.ts\`).
- Failure path preserved: breaking the ready endpoint URL temporarily showed that after the polling timeout, the original "Controller unavailable" card with the Retry button still renders correctly.