### PR TITLE
chore: track reward task click and completion events

### DIFF
--- a/apps/web/src/pages/rewards.tsx
+++ b/apps/web/src/pages/rewards.tsx
@@ -9,8 +9,10 @@ import {
   completeRewardWithVirtualCheck,
   getRewardCheckingDescriptionKey,
 } from "@/lib/reward-virtual-check";
+import { track } from "@/lib/tracking";
 import { cn } from "@/lib/utils";
 import {
+  type RewardTaskId,
   type RewardTaskStatus,
   rewardTaskRequiresGithubStarSession,
   rewardTaskRequiresUrlProof,
@@ -24,6 +26,23 @@ import { Link } from "react-router-dom";
 import { toast } from "sonner";
 
 const MOBILE_SHARE_QR_URL = "https://github.com/nexu-io/nexu";
+
+// PM-defined tracking type names per reward task. mobile_share is intentionally
+// excluded from click tracking (the click only opens the QR modal, the
+// meaningful signal is the actual screenshot upload tracked via `done`).
+const TASK_CLICK_TRACKING_TYPE: Partial<Record<RewardTaskId, string>> = {
+  github_star: "star_us",
+  x_share: "X",
+  reddit: "Reddit",
+  lingying: "linkedin",
+  facebook: "Facebook",
+  whatsapp: "Whatsapp",
+};
+
+const TASK_DONE_TRACKING_TYPE: Partial<Record<RewardTaskId, string>> = {
+  ...TASK_CLICK_TRACKING_TYPE,
+  mobile_share: "mobile",
+};
 
 const REWARD_GROUPS: Array<{
   key: RewardTaskStatus["group"];
@@ -274,6 +293,11 @@ export function RewardsPage() {
         toast.error(t("rewards.claimFailed"));
       }
       return;
+    }
+
+    const clickTrackingType = TASK_CLICK_TRACKING_TYPE[task.id];
+    if (clickTrackingType) {
+      track("workspace_task_click", { type: clickTrackingType });
     }
 
     if (rewardTaskRequiresGithubStarSession(task.id)) {
@@ -723,6 +747,11 @@ export function RewardsPage() {
                 toast.success(t("rewards.claimAlreadyDone"));
               } else {
                 toast.success(t("rewards.claimSuccess"));
+                const doneTrackingType =
+                  TASK_DONE_TRACKING_TYPE[confirmTask.id];
+                if (doneTrackingType) {
+                  track("workspace_task_done", { type: doneTrackingType });
+                }
               }
               setConfirmPhase("idle");
               setConfirmTaskId(null);


### PR DESCRIPTION
## What

Add two PostHog events to the rewards page so PM can measure click frequency and click→completion conversion for each social/open-source reward task:

- **`workspace_task_click`** — fires when a user clicks a reward task
- **`workspace_task_done`** — fires when a user successfully claims a task in the confirm modal

## Why

PM needs the click → completion funnel per task to decide which reward tasks to expand or retire.

## Event \`type\` values

PM-defined naming:

| Internal task id | \`type\` value | click | done |
|---|---|:-:|:-:|
| \`github_star\` | \`star_us\` | ✅ | ✅ |
| \`x_share\` | \`X\` | ✅ | ✅ |
| \`reddit\` | \`Reddit\` | ✅ | ✅ |
| \`lingying\` | \`linkedin\` | ✅ | ✅ |
| \`facebook\` | \`Facebook\` | ✅ | ✅ |
| \`whatsapp\` | \`Whatsapp\` | ✅ | ✅ |
| \`mobile_share\` | \`mobile\` | ❌ | ✅ |
| \`daily_checkin\` | — | ❌ | ❌ |

## Implementation notes

- Two \`Partial<Record<RewardTaskId, string>>\` tables hold the click/done type mappings
- \`mobile_share\` is intentionally excluded from click tracking — its click only opens the QR modal; the meaningful signal is the screenshot upload, captured via \`done\`
- \`daily_checkin\` goes through a separate inline claim path that doesn't reach the confirm modal, so it's automatically excluded from both events
- The done event only fires when \`!result.alreadyClaimed\`, so re-claiming an already-claimed task doesn't double-count
- Using \`Partial<Record<RewardTaskId, string>>\` instead of an open string dict means **adding a new task id later won't silently emit an unknown \`type\`** — you have to explicitly opt it in

## Affected areas

- [ ] Desktop app (Electron shell)
- [ ] Controller (backend / API)
- [x] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [ ] Build / CI / Tooling

## Checklist

- [x] \`pnpm typecheck\` passes
- [x] \`pnpm lint\` passes
- [x] No credentials or tokens in code or logs
- [x] No \`any\` types introduced