### PR TITLE
fix: make daily check-in readonly in rewards

### DIFF
--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -408,6 +408,8 @@ const en = {
   "rewards.action.open": "Open",
   "reward.daily_checkin.name": "Daily check-in",
   "reward.daily_checkin.desc": "Once per day",
+  "reward.daily_checkin.autoGrantedDesc":
+    "Daily reward is granted automatically. No manual claim needed.",
   "reward.github_star.name": "Star us",
   "reward.github_star.desc": "One-time reward",
   "reward.x_share.name": "Share on X",

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -389,6 +389,7 @@ const zhCN = {
   "rewards.action.open": "打开",
   "reward.daily_checkin.name": "每日打卡",
   "reward.daily_checkin.desc": "每天可领一次",
+  "reward.daily_checkin.autoGrantedDesc": "每日奖励自动发放，无需手动领取",
   "reward.github_star.name": "Star us",
   "reward.github_star.desc": "仅限一次",
   "reward.x_share.name": "分享到 X",

--- a/apps/web/src/pages/rewards.tsx
+++ b/apps/web/src/pages/rewards.tsx
@@ -65,7 +65,17 @@ function getRewardsModelHintState(input: {
   if ((input.cloudBalance?.totalBalance ?? 0) <= 0) return "none";
   return "switch-back";
 }
+function isReadonlyRewardTask(task: RewardTaskStatus): boolean {
+  return task.id === "daily_checkin";
+}
 
+function getRewardTaskDescriptionKey(task: RewardTaskStatus): string {
+  if (task.id === "daily_checkin") {
+    return "reward.daily_checkin.autoGrantedDesc";
+  }
+
+  return `reward.${task.id}.desc`;
+}
 function RewardConfirmModal({
   task,
   phase,
@@ -287,7 +297,7 @@ export function RewardsPage() {
   });
 
   const handleTaskAction = async (task: RewardTaskStatus) => {
-    if (task.isClaimed) {
+    if (task.isClaimed || isReadonlyRewardTask(task)) {
       return;
     }
 
@@ -446,22 +456,24 @@ export function RewardsPage() {
                     const isGithubStar = rewardTaskRequiresGithubStarSession(
                       task.id,
                     );
+                    const isReadonlyTask = isReadonlyRewardTask(task);
                     const isPreparingThisTask =
                       isGithubStar && isPreparingGithubStarSession;
-                    const actionLabel = task.isClaimed
-                      ? t("budget.cta.done").replace(
-                          "${n}",
-                          formatRewardAmount(task.reward),
-                        )
-                      : loading
-                        ? "..."
-                        : task.repeatMode === "daily"
-                          ? t("budget.cta.checkin")
-                          : task.shareMode === "image"
-                            ? t("budget.cta.download")
-                            : task.shareMode === "tweet"
-                              ? t("budget.cta.share")
-                              : t("budget.cta.go");
+                    const actionLabel =
+                      task.isClaimed || isReadonlyTask
+                        ? t("budget.cta.done").replace(
+                            "${n}",
+                            formatRewardAmount(task.reward),
+                          )
+                        : loading
+                          ? "..."
+                          : task.repeatMode === "daily"
+                            ? t("budget.cta.checkin")
+                            : task.shareMode === "image"
+                              ? t("budget.cta.download")
+                              : task.shareMode === "tweet"
+                                ? t("budget.cta.share")
+                                : t("budget.cta.go");
 
                     return (
                       <div
@@ -474,7 +486,7 @@ export function RewardsPage() {
                         <div
                           className={cn(
                             "flex h-8 w-8 shrink-0 items-center justify-center rounded-[10px] border transition-colors",
-                            task.isClaimed
+                            task.isClaimed || isReadonlyTask
                               ? "border-border/50 bg-surface-2 opacity-50"
                               : "border-border bg-white",
                           )}
@@ -487,7 +499,7 @@ export function RewardsPage() {
                             <span
                               className={cn(
                                 "text-[13px] font-medium leading-tight",
-                                task.isClaimed
+                                task.isClaimed || isReadonlyTask
                                   ? "text-text-muted"
                                   : "text-text-primary",
                               )}
@@ -502,12 +514,12 @@ export function RewardsPage() {
                           <div
                             className={cn(
                               "mt-0.5 text-[11px]",
-                              task.isClaimed
+                              task.isClaimed || isReadonlyTask
                                 ? "text-text-muted/60"
                                 : "text-text-muted",
                             )}
                           >
-                            {t(`reward.${task.id}.desc`)}
+                            {t(getRewardTaskDescriptionKey(task))}
                           </div>
                         </div>
 
@@ -516,13 +528,14 @@ export function RewardsPage() {
                           disabled={
                             loading ||
                             task.isClaimed ||
+                            isReadonlyTask ||
                             isPreparingThisTask ||
                             claimingTaskId === task.id
                           }
                           onClick={() => void handleTaskAction(task)}
                           className={cn(
                             "inline-flex h-[26px] shrink-0 items-center justify-center gap-2 rounded-full px-3 text-[11px] font-medium leading-none transition-all",
-                            task.isClaimed
+                            task.isClaimed || isReadonlyTask
                               ? "bg-surface-2 text-text-muted"
                               : "border border-[var(--color-brand-primary)]/30 text-[var(--color-brand-primary)] hover:bg-[var(--color-brand-primary)]/5",
                           )}

--- a/apps/web/tests/rewards-page-daily-checkin.test.tsx
+++ b/apps/web/tests/rewards-page-daily-checkin.test.tsx
@@ -1,0 +1,98 @@
+import { rewardTasks } from "@nexu/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import zhCN from "../src/i18n/locales/zh-CN";
+import { RewardsPage } from "../src/pages/rewards";
+
+vi.mock("@/lib/api", () => ({}));
+vi.mock("@nexu/shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@nexu/shared")>();
+  return {
+    ...actual,
+    rewardTaskRequiresGithubStarSession: (taskId: string) =>
+      taskId === "github_star",
+    rewardTaskRequiresUrlProof: (taskId: string) =>
+      ["x_share", "reddit", "lingying", "facebook", "whatsapp"].includes(
+        taskId,
+      ),
+    validateRewardProofUrl: () => true,
+  };
+});
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: {
+      language: "zh-CN",
+    },
+  }),
+}));
+vi.mock("../src/lib/api", () => ({
+  client: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+function renderRewardsPage(): string {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  queryClient.setQueryData(["desktop-rewards"], {
+    viewer: {
+      cloudConnected: true,
+      activeModelId: "link/gemini",
+      activeModelProviderId: "link",
+      usingManagedModel: true,
+    },
+    progress: {
+      claimedCount: 0,
+      totalCount: rewardTasks.length,
+      earnedCredits: 0,
+      availableCredits: rewardTasks.reduce((sum, task) => sum + task.reward, 0),
+    },
+    cloudBalance: {
+      totalBalance: 100,
+      totalRecharged: 100,
+      totalConsumed: 0,
+    },
+    tasks: rewardTasks.map((task) => ({
+      ...task,
+      isClaimed: false,
+      lastClaimedAt: null,
+      claimCount: 0,
+    })),
+  });
+
+  return renderToStaticMarkup(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <RewardsPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("RewardsPage daily check-in", () => {
+  it("renders the daily check-in task as readonly completed UI", () => {
+    const markup = renderRewardsPage();
+
+    expect(markup).toContain("reward.daily_checkin.name");
+    expect(markup).toContain("reward.daily_checkin.autoGrantedDesc");
+    expect(markup).toContain("budget.cta.done");
+    expect(markup).not.toContain("budget.cta.checkin");
+    expect(markup).toContain("disabled");
+  });
+
+  it("defines the Chinese auto-grant subtitle copy", () => {
+    expect(zhCN["reward.daily_checkin.autoGrantedDesc"]).toBe(
+      "每日奖励自动发放，无需手动领取",
+    );
+  });
+});


### PR DESCRIPTION
## What

Make the daily check-in task render as a readonly completed item in the rewards page instead of a manual-claim action.

## Why

Closes #900.

The current UI still exposes a clickable daily check-in entry, which makes the task look manually claimable and contributed to repeated-claim confusion. This change removes that interaction surface and shows the task as already handled.

## How

- Treat `daily_checkin` as a readonly task in the rewards page UI
- Reuse the completed-state visual treatment and disable the CTA permanently for that task
- Add dedicated i18n copy that explains the reward is auto-granted and needs no manual claim
- Add a focused web regression test covering the readonly completed state and subtitle copy

## Affected areas

- [ ] Desktop app (Electron shell)
- [ ] Controller (backend / API)
- [x] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [ ] Build / CI / Tooling

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

## Notes for reviewers

This PR intentionally does not change auto-grant behavior or reward accounting. It only removes the manual claim entry point for `daily_checkin` and updates the UI copy to match that product behavior.
