### PR TITLE
fix(web): prevent locale bootstrap from overriding user selection (#759)

### DIFF
--- a/apps/web/src/hooks/use-locale.tsx
+++ b/apps/web/src/hooks/use-locale.tsx
@@ -43,6 +43,10 @@ const LocaleContext = createContext<LocaleCtx>({
 export function LocaleProvider({ children }: { children: ReactNode }) {
   const [locale, setLocaleState] = useState<Locale>(detectDefault);
   const didBootstrapRef = useRef(false);
+  // Tracks whether the user has manually changed the locale during this
+  // session. The async bootstrap fetch must NOT override a user-made
+  // selection that landed while the fetch was in flight (see #759).
+  const userInteractedRef = useRef(false);
 
   useEffect(() => {
     i18n.changeLanguage(locale);
@@ -53,10 +57,11 @@ export function LocaleProvider({ children }: { children: ReactNode }) {
       return;
     }
     didBootstrapRef.current = true;
-    void bootstrapLocale(setLocaleState);
+    void bootstrapLocale(setLocaleState, userInteractedRef);
   }, []);
 
   const setLocale = useCallback((l: Locale) => {
+    userInteractedRef.current = true;
     setLocaleState(l);
     try {
       localStorage.setItem(STORAGE_KEY, l);
@@ -97,11 +102,20 @@ async function syncDesktopLocale(locale: Locale): Promise<void> {
 
 async function bootstrapLocale(
   setLocaleState: (locale: Locale) => void,
+  userInteractedRef: { current: boolean },
 ): Promise<void> {
   const localCandidate = detectDefault();
 
   const response = await getApiInternalDesktopPreferences().catch(() => null);
   const storedLocale = response?.data?.locale ?? null;
+
+  // If the user already manually picked a locale while the GET above was in
+  // flight, their selection is the source of truth — don't overwrite it.
+  // Issue #759: on Windows zh-CN systems, the bootstrap was reverting a
+  // user-selected English back to Chinese on the welcome screen.
+  if (userInteractedRef.current) {
+    return;
+  }
 
   if (storedLocale === "en" || storedLocale === "zh-CN") {
     const nextLocale = storedLocale === "zh-CN" ? "zh" : "en";
@@ -114,7 +128,12 @@ async function bootstrapLocale(
     return;
   }
 
-  setLocaleState(localCandidate);
+  // Server has no stored locale yet. The useState initializer already set
+  // the React state to `localCandidate`, so we deliberately do NOT call
+  // setLocaleState here — calling it would race with any in-flight user
+  // click and could revert their selection. We still persist the detected
+  // default to localStorage and push it to the controller so the
+  // credit-guard plugin and other locale-aware code see a consistent value.
   try {
     localStorage.setItem(STORAGE_KEY, localCandidate);
   } catch {


### PR DESCRIPTION
## What

Fix the welcome-screen language switcher being unable to switch from Chinese to English on a fresh Windows install (issue #759).

## Why

`LocaleProvider` (apps/web/src/hooks/use-locale.tsx) runs an async bootstrap on mount that:

1. Synchronously seeds React state via `useState(detectDefault)` — on a Windows zh-CN system this returns `"zh"`.
2. Fires an async GET to the controller's desktop preferences endpoint.
3. After the GET resolves, calls `setLocaleState(...)` with either the server-stored locale (if present) or the locally detected default (if not).

On a fresh install the controller has no stored locale yet, so step 3 takes the second branch and unconditionally calls `setLocaleState(localCandidate)` — i.e. `setLocaleState("zh")`. If the user clicks **English** in the welcome screen language switcher *before* the GET resolves:

- `setLocale("en")` updates React state → UI briefly switches to English
- The in-flight GET resolves
- `bootstrapLocale` calls `setLocaleState("zh")` → React state reverts to Chinese
- The user perceives "the language switcher does nothing"

The bug is Windows-specific in practice because Windows users overwhelmingly run zh-CN system locale. macOS users on en-US never see it: `localCandidate` is `"en"`, so the bootstrap override is effectively `"en" → "en"` and is invisible.

## How

Two changes in `apps/web/src/hooks/use-locale.tsx`:

1. **Track manual interaction.** New `userInteractedRef` is flipped to `true` inside `setLocale` *before* any state update. `bootstrapLocale` now takes this ref as a parameter and bails out early if the user has already interacted while the GET was in flight.

2. **Don't call `setLocaleState` in the \"server has no stored locale\" branch.** The `useState` initializer has already seeded React state to `localCandidate` synchronously on first render, so calling `setLocaleState(localCandidate)` here was redundant in the non-racy path and only ever existed to fight the race window. Removing it eliminates the override entirely. We still persist to `localStorage` and POST to the controller so the credit-guard plugin and other locale-aware code see a consistent value.

The existing \"server has a stored value\" branch is unchanged: when the controller already has a locale, it continues to win on bootstrap (the typical \"sync from server on app open\" behavior), gated by the user-interaction check.

## Affected areas

- [x] Web dashboard (React UI)

## Checklist

- [ ] `pnpm typecheck` passes — not run locally (worktree without node_modules); change is type-stable: only adds a `useRef<boolean>` and a parameter of the same shape (`{ current: boolean }`)
- [ ] `pnpm lint` passes — not run locally for the same reason
- [ ] `pnpm test` passes — N/A, no tests cover this path today
- [ ] `pnpm generate-types` run (if API routes/schemas changed) — N/A
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced

## Notes for reviewers

- Verification path: fresh Windows 11 install with system locale zh-CN. Launch Nexu for the first time, click \"English\" on the welcome screen, confirm UI switches and stays in English. Restart the app to confirm the choice is persisted via the controller round-trip.
- Edge cases I traced through:
  - Existing user with both localStorage and server set: server still wins on bootstrap (unchanged).
  - Existing user, GET fails (network error): no `setLocaleState` call — same behavior as before for the `response === null` case.
  - StrictMode double-mount: `didBootstrapRef` still ensures bootstrap runs once.
  - User clicks AFTER bootstrap completes (server-null branch): `setLocale` runs normally, no race because bootstrap already returned.
- This fix is based on code analysis; I was unable to verify on a Windows machine. The PR author will validate on their Windows hardware.

Closes #759