### PR TITLE
chore: reserve windows workflow lanes

### DIFF
--- a/.github/workflows/desktop-beta.yml
+++ b/.github/workflows/desktop-beta.yml
@@ -27,3 +27,14 @@ jobs:
       release_name: "Nexu Desktop Beta"
       channel: "beta"
     secrets: inherit
+
+  package-windows:
+    name: Windows (placeholder)
+    runs-on: windows-latest
+    steps:
+      - name: Reserve Windows lane
+        shell: pwsh
+        run: |
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "## Windows placeholder"
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- Channel: beta"
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- Status: reserved only; no Windows artifacts are published by this workflow yet"

--- a/.github/workflows/desktop-nightly.yml
+++ b/.github/workflows/desktop-nightly.yml
@@ -29,8 +29,19 @@ jobs:
       channel: "nightly"
     secrets: inherit
 
+  package-windows:
+    name: Windows (placeholder)
+    runs-on: windows-latest
+    steps:
+      - name: Reserve Windows lane
+        shell: pwsh
+        run: |
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "## Windows placeholder"
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- Channel: nightly"
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- Status: reserved only; no Windows artifacts are published by this workflow yet"
+
   trigger-e2e:
-    needs: build
+    needs: [build, package-windows]
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Desktop E2E (async)
@@ -46,7 +57,7 @@ jobs:
             });
 
   notify:
-    needs: build
+    needs: [build, package-windows]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -549,3 +549,14 @@ jobs:
               ref: context.ref || 'main',
               inputs: { mode: 'model', channel: '${{ steps.channel.outputs.channel }}' },
             });
+
+  package-windows:
+    name: Windows (placeholder)
+    runs-on: windows-latest
+    steps:
+      - name: Reserve Windows lane
+        shell: pwsh
+        run: |
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "## Windows placeholder"
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- Channel: release"
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- Status: reserved only; no Windows artifacts are published by this workflow yet"


### PR DESCRIPTION
## What

Add a minimal `package-windows` placeholder job to the desktop nightly, beta, and release workflows.

## Why

The current desktop release workflows do not consistently surface a Windows lane from `main`, which makes it harder to observe and evolve the Windows delivery path uniformly across channels.

## How

- add a no-op Windows placeholder job to `desktop-nightly.yml`
- add a no-op Windows placeholder job to `desktop-beta.yml`
- add a no-op Windows placeholder job to `desktop-release.yml`
- make nightly follow-up jobs wait for the placeholder lane so the graph reflects the intended multi-platform shape

## Affected areas

- [ ] Desktop app (Electron shell)
- [ ] Controller (backend / API)
- [ ] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [x] Build / CI / Tooling

## Checklist

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

## Notes for reviewers

This is intentionally a placeholder-only PR: it reserves the Windows lane in the workflow graph without publishing Windows artifacts yet.