### PR TITLE
fix: route minimax oauth browser launch through shell openExternal

### DIFF
--- a/apps/web/src/pages/models.tsx
+++ b/apps/web/src/pages/models.tsx
@@ -6,7 +6,11 @@ import {
   useDesktopCloudStatus,
 } from "@/hooks/use-desktop-cloud-status";
 import { useGitHubStars } from "@/hooks/use-github-stars";
-import { openLocalFolderUrl, pathToFileUrl } from "@/lib/desktop-links";
+import {
+  openExternalUrl,
+  openLocalFolderUrl,
+  pathToFileUrl,
+} from "@/lib/desktop-links";
 import { track } from "@/lib/tracking";
 import { cn } from "@/lib/utils";
 import { selectPreferredModel } from "@nexu/shared";
@@ -1698,13 +1702,13 @@ function ByokProviderDetail({
       }
       return data;
     },
-    onSuccess: (result) => {
+    onSuccess: async (result) => {
       const browserUrl =
         "browserUrl" in result && typeof result.browserUrl === "string"
           ? result.browserUrl
           : null;
       if (browserUrl) {
-        window.open(browserUrl, "_blank", "noopener,noreferrer");
+        await openExternalUrl(browserUrl);
       }
       queryClient.invalidateQueries({ queryKey: ["minimax-oauth-status"] });
     },


### PR DESCRIPTION
## What

Route MiniMax OAuth browser launch through the shared desktop `shell:open-external` path instead of calling `window.open()` directly from the models page.

## Why

MiniMax OAuth was using a different browser-launch path from the other stable desktop entry points. That made the browser handoff more fragile in Electron and could prevent MiniMax login from opening the system browser even though other flows still worked.

## How

Reuse `openExternalUrl()` in the MiniMax OAuth success path so desktop builds always delegate browser opening to the Electron main process via `shell.openExternal()`.

## Affected areas

- [ ] Desktop app (Electron shell)
- [ ] Controller (backend / API)
- [x] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [ ] Build / CI / Tooling

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

## Notes for reviewers

This change does not alter the MiniMax OAuth protocol flow, token polling, or credential persistence. It only switches the browser-launch call site to the existing desktop-safe external-open helper.
