### PR TITLE
docs: add wechat article formatting and x article publisher skills

### DIFF
--- a/skills/localdev/wechat-article/SKILL.md
+++ b/skills/localdev/wechat-article/SKILL.md
@@ -1,0 +1,361 @@
+# Skill: Nexu 公众号文章排版与发布
+
+> 基于 2026 年 4 月最新已发布文章（蒸馏 CEO + Claude 封号指南）提取的标准化排版流程。
+
+## 触发词
+
+公众号、微信文章、排版、排公众号、发布公众号、md 转公众号、公众号 HTML
+
+---
+
+## 一、排版流水线（三步走）
+
+所有公众号文章统一使用以下流水线，不再手写 HTML。
+
+### 第一步：Markdown → HTML
+
+使用 `baoyu-markdown-to-html` 的 **grace 主题 + black 配色**：
+
+```bash
+bun ~/.claude/skills/baoyu-markdown-to-html/scripts/main.ts <input.md> --theme grace --color black
+```
+
+首次使用先装依赖：
+
+```bash
+cd ~/.claude/skills/baoyu-markdown-to-html/scripts && bun install
+```
+
+**注意：不要** 加 `--keep-title`，正文不含 H1 标题。标题通过发布参数传入。
+
+### 第二步：颜色后处理
+
+转换完成后，用 StrReplace（`replace_all: true`）做两轮全局替换：
+
+| 原始值 | 替换为 | 用途 |
+|--------|--------|------|
+| `color: #3f3f3f` | `color: #888888` | 正文灰色（阅读舒适） |
+| `color: #333333` | `color: #1a1a1a` | 加粗近黑（强调清晰） |
+
+### 第三步：删除正文封面图
+
+如果 Markdown 中第一张图是封面图，转换后会出现在 HTML 开头。**发布前必须删除 `<p><img ...></p>` 封面图标签**，封面图通过 `--thumb` 参数单独上传。
+
+---
+
+## 二、排版设计令牌（从已发布 HTML 逐属性提取）
+
+以下所有 CSS 值均从已发布文章（`distill-skill-guide-publish.html` + `claude-ban-survival-guide-publish.html`）的内联 `style=""` 中逐属性抄录，作为排版效果的 ground truth。
+
+### 2.1 容器
+
+```css
+/* <body> */
+body {
+  padding: 24px;
+  background: #ffffff;
+  max-width: 860px;
+  margin: 0 auto;
+  font-family: -apple-system-font, BlinkMacSystemFont, Helvetica Neue,
+               PingFang SC, Hiragino Sans GB, Microsoft YaHei UI,
+               Microsoft YaHei, Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.75;
+  text-align: left;
+}
+
+/* <section class="container"> — 继承 body */
+section.container {
+  font-family: /* 同 body */;
+  font-size: 16px;
+  line-height: 1.75;
+  text-align: left;
+}
+```
+
+### 2.2 段落 `<p>`
+
+```css
+p {
+  margin: 1.5em 8px;
+  letter-spacing: 0.1em;
+  color: #888888;
+}
+```
+
+### 2.3 加粗 `<strong>`
+
+```css
+strong {
+  color: #1a1a1a;
+  font-weight: bold;
+  font-size: inherit;
+}
+```
+
+视觉效果：在 `#888888` 灰色正文中，`#1a1a1a` 近黑加粗跳出来形成对比。
+
+### 2.4 引用块 `<blockquote>`
+
+```css
+blockquote {
+  margin-top: 0;
+  margin-right: 0;
+  margin-left: 0;
+  background: #f7f7f7;
+  font-style: italic;
+  padding: 1em 1em 1em 2em;
+  border-left: 4px solid #333333;
+  border-radius: 6px;
+  color: rgba(0, 0, 0, 0.6);
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
+  margin-bottom: 1em;
+}
+
+/* 引用块内的段落 */
+blockquote p {
+  display: block;
+  font-size: 1em;
+  letter-spacing: 0.1em;
+  color: #888888;
+  margin: 0;
+}
+```
+
+### 2.5 分隔线 `<hr>`
+
+```css
+hr {
+  border-style: solid;
+  border-width: 2px 0 0;
+  border-color: rgba(0, 0, 0, 0.1);
+  -webkit-transform-origin: 0 0;
+  -webkit-transform: scale(1, 0.5);
+  transform-origin: 0 0;
+  transform: scale(1, 0.5);
+  height: 1px;
+  border: none;
+  margin: 2em 0;
+  background: linear-gradient(to right,
+    rgba(0, 0, 0, 0),
+    rgba(0, 0, 0, 0.1),
+    rgba(0, 0, 0, 0));
+}
+```
+
+### 2.6 无序列表 `<ul>` / `<li>`
+
+```css
+ul {
+  margin-left: 0;
+  color: #888888;
+  list-style: none;
+  padding-left: 1.5em;
+}
+
+li {
+  display: block;
+  color: #888888;
+  margin: 0.5em 8px;
+}
+```
+
+列表项以手动 `•` 字符作为文本前缀，不使用 CSS `list-style`。加粗的列表项内 `<strong>` 仍为 `color: #1a1a1a`。
+
+### 2.7 图片 `<img>`
+
+```css
+img {
+  display: block;
+  width: 100%;
+  margin: 1.5em auto;
+}
+```
+
+图片总是包裹在 `<p>` 中：`<p class="p" style="..."><img ...></p>`。
+
+### 2.8 行内代码 `<code>`
+
+```css
+code {
+  font-size: 90%;
+  color: #d14;
+  background: rgba(27, 31, 35, 0.05);
+  padding: 3px 5px;
+  border-radius: 4px;
+}
+```
+
+### 2.9 颜色速查表
+
+| 用途 | 色值 | 来源 |
+|------|------|------|
+| 正文文字 | `#888888` | 后处理（原 `#3f3f3f`） |
+| 加粗文字 | `#1a1a1a` | 后处理（原 `#333333`） |
+| 列表文字 | `#888888` | 后处理 |
+| 引用块边框 | `#333333` | grace 主题原生 |
+| 引用块背景 | `#f7f7f7` | grace 主题原生 |
+| 引用块文字 | `rgba(0, 0, 0, 0.6)` | grace 主题原生 |
+| 引用块内段落 | `#888888` | 后处理 |
+| 行内代码文字 | `#d14` | grace 主题原生 |
+| 行内代码背景 | `rgba(27, 31, 35, 0.05)` | grace 主题原生 |
+| 页面背景 | `#ffffff` | grace 主题原生 |
+
+---
+
+## 三、标准内容结构
+
+从已发布文章提取的统一结构模式：
+
+### 3.1 开头：Star 引导引用块
+
+每篇文章正文第一个元素是一个 `<blockquote>`，引导读者 Star：
+
+```
+> nexu 是一个可以一键安装的 OpenClaw 桌面客户端，让你在本地用 AI 操控一切。
+> GitHub：https://github.com/nexu-io/nexu ，觉得有用的话帮忙点个 Star 支持一下 🌟
+```
+
+### 3.2 正文：分节图 + 分隔线节奏
+
+文章按章节组织，章节之间用 **`<hr>` 分隔线 + 分节横幅图** 的组合来过渡：
+
+```
+段落正文...
+
+---                          ← hr 分隔线
+![](imgs-xxx/02-section.png) ← 分节横幅图
+段落正文...
+
+---
+![](imgs-xxx/03-section.png)
+段落正文...
+```
+
+分节横幅图编号从 `02-section.png` 开始（`01` 留给封面图），通常 4-6 张。
+
+### 3.3 结尾：CTA + 二维码
+
+```
+---
+
+**nexu** 是一个可以一键安装的 OpenClaw 桌面客户端...
+
+**GitHub：https://github.com/nexu-io/nexu**
+
+进群还能领 **Seedance 2.0 视频生成免费额度**，名额有限，先到先得。
+
+扫码加入龙虾社区，一起交流 AI Agent 和本地开发工作流：
+
+![](imgs-xxx/qr-both-groups.png)
+```
+
+---
+
+## 四、发布到公众号草稿箱
+
+**重要：先用 `open` 命令在浏览器打开本地 HTML 预览，等用户确认后再推送。不要自动推送。**
+
+```bash
+node skills/nexubot/wechat-mp-draft/scripts/publish-html-draft.mjs \
+  <publish.html> \
+  --thumb <cover.png> \
+  --title "文章标题" \
+  --digest "一句话摘要（手动撰写，不超过 64 字）"
+```
+
+### 发布参数说明
+
+| 参数 | 必填 | 说明 |
+|------|------|------|
+| `<HTML文件路径>` | 是 | 本地公众号 HTML 文件 |
+| `--thumb <路径>` | 推荐 | 封面图路径（省略时取正文第一张图） |
+| `--title <标题>` | 推荐 | 文章标题（正文中不含 H1） |
+| `--digest <摘要>` | 推荐 | 一句话摘要，口语化有行动感 |
+
+### 环境变量
+
+`.env` 文件位于 `skills/nexubot/wechat-mp-draft/scripts/.env`：
+
+```
+WECHAT_APP_ID=<your_app_id>
+WECHAT_APP_SECRET=<your_app_secret>
+WECHAT_ARTICLE_AUTHOR=Next to you 的 nexu
+```
+
+---
+
+## 五、发布规范（强制）
+
+### A. 标题不进正文
+
+正文 HTML 不含 `<h1>`。标题通过 `--title` 参数传入。
+
+### B. 摘要手动指定
+
+每篇文章用 `--digest` 传入一句话摘要（≤64 汉字），不依赖自动截取。
+
+### C. 封面图单独指定
+
+封面图通过 `--thumb` 参数指定，不放入正文 HTML。建议尺寸 900×383 或 900×500。
+
+### D. 微信链接处理
+
+微信公众号正文不支持超链接跳转。所有外部链接写成完整文本 URL，不使用 `<a>` 标签。
+
+### E. 社群二维码
+
+文章末尾统一使用最新二维码文件：
+- 源文件：`/Users/joey/.cursor/projects/Users-joey-Desktop-nexu/assets/_____-38e21ace-929c-4f23-9637-a4a34f0115c9.png`
+- 复制到文章 `imgs-*` 目录下，命名为 `qr-both-groups.png`
+
+---
+
+## 六、文章目录结构
+
+每篇文章在 `skills/localdev/wechat-article/` 下组织：
+
+```
+skills/localdev/wechat-article/
+├── SKILL.md                              ← 本文件（排版规范）
+├── <slug>.md                             ← Markdown 源文件
+├── <slug>-publish.html                   ← 公众号发布用 HTML（grace+black+后处理）
+├── <slug>.html                           ← 本地预览 HTML（可选）
+└── imgs-<slug>/                          ← 配图子目录
+    ├── 01-cover.png                      ← 封面图
+    ├── 02-section.png ~ 06-section.png   ← 分节图
+    ├── <content-images>.png              ← 内容截图
+    └── qr-both-groups.png                ← 社群二维码
+```
+
+### 命名约定
+
+- Markdown / HTML 用 kebab-case 命名
+- 封面图以 `01-cover` 开头
+- 分节横幅图以 `0X-section` 编号
+- 二维码固定命名 `qr-both-groups.png`
+
+---
+
+## 七、合规风控检查（发布前必过）
+
+| 检查项 | ❌ 禁止 | ✅ 替代方案 |
+|--------|---------|------------|
+| 绝对化 | 免费无限量、最好用、全网第一 | 以官网公示为准 |
+| 替官方背书 | 微信官方推荐、不会封号 | 以微信官方说明为准 |
+| 敏感词 | 翻墙、VPN、破解 | 在常用网络环境下即可使用 |
+| 标题红线 | ChatGPT / OpenAI 作标题主体 | 可正文提及，不做标题重点 |
+| 外链密度 | 重复出现同一链接 5+ 次 | 精简到 2-3 次自然出现 |
+
+---
+
+## 八、已发布文章索引
+
+| 文章 | 主题 | Markdown | 发布 HTML | 配图目录 |
+|------|------|----------|-----------|----------|
+| 蒸馏 CEO | grace+black ✅ | `distill-skill-guide.md` | `distill-skill-guide-publish.html` | `imgs-distill/` |
+| Claude 封号指南 | grace+black ✅ | — | `claude-ban-survival-guide-publish.html` | `imgs-claude-ban/` |
+| Seedance 2.0 | 旧蓝色 ⚠️ | `nexu-seedance2-article.md` | `nexu-seedance2-article.html` | `imgs/` |
+| v0.2.0 更新 | 手写 ⚠️ | `nexu-v0.2.0-release-wechat.md` | `nexu-v0.2.0-release-wechat.html` | — |
+
+**⚠️ 标记**：Seedance 那篇使用旧蓝色主题（`#0F4C81` 强调色，白底蓝标题），v0.2.0 那篇是手写 HTML 预览。新文章一律使用 grace+black+颜色后处理流程。

--- a/skills/localdev/x-article-publisher/SKILL.md
+++ b/skills/localdev/x-article-publisher/SKILL.md
@@ -1,0 +1,243 @@
+# Skill: X (Twitter) 长文发布到草稿箱
+
+> 将 Markdown 文章自动发布到 X Articles 草稿箱，保留富文本格式、自动插入图片和分割线。
+
+## 触发词
+
+发布推特长文、X 长文、Twitter Article、推特文章、发到 X 草稿箱、publish to X article
+
+---
+
+## 前置条件
+
+- Playwright MCP 已启用（浏览器自动化）
+- 用户已在 Chrome 登录 X，且有 Premium Plus 订阅（长文功能）
+- Python 3.9+，已安装：`pip install Pillow pyobjc-framework-Cocoa`（macOS）
+- 脚本目录：`~/.codex/skills/x-article-publisher/scripts/`
+
+---
+
+## 一、核心流水线
+
+### 策略：先文后图后分割线
+
+所有文章统一按此顺序操作：先粘贴全文文本 → 再插入内容图片 → 最后插入分割线。
+
+### 1.1 解析 Markdown
+
+```bash
+# 获取结构化 JSON（标题、封面、内容图片位置、分割线位置、HTML）
+python ~/.codex/skills/x-article-publisher/scripts/parse_markdown.py /path/to/article.md
+
+# 单独导出 HTML（用于剪贴板粘贴）
+python ~/.codex/skills/x-article-publisher/scripts/parse_markdown.py /path/to/article.md --html-only > /tmp/article_html.html
+```
+
+JSON 输出关键字段：
+
+```json
+{
+  "title": "文章标题",
+  "cover_image": "/path/to/cover.png",
+  "content_images": [
+    {
+      "path": "/path/to/img.png",
+      "block_index": 5,
+      "after_text": "前一段末尾文字..."
+    }
+  ],
+  "dividers": [
+    { "block_index": 10 }
+  ],
+  "total_blocks": 45
+}
+```
+
+### 1.2 打开编辑器
+
+```
+browser_navigate → https://x.com/compose/articles
+browser_snapshot → 找到 create 按钮
+browser_click → 点击 create 进入编辑器
+```
+
+### 1.3 上传封面图
+
+```
+browser_click → "添加照片或视频" 按钮
+browser_file_upload → 选择 cover_image 路径
+```
+
+封面图使用 `browser_file_upload`（有专门上传按钮），不走剪贴板。
+
+### 1.4 填写标题
+
+```
+browser_click → "添加标题" 输入框
+browser_type → 输入 title
+```
+
+### 1.5 粘贴正文（剪贴板富文本）
+
+```bash
+python ~/.codex/skills/x-article-publisher/scripts/copy_to_clipboard.py html --file /tmp/article_html.html
+```
+
+```
+browser_click → 编辑器正文区域
+browser_press_key → Meta+v
+```
+
+保留所有富文本格式：H2、加粗、链接、列表、引用。
+
+### 1.6 插入内容图片（从大到小）
+
+按 `block_index` **从大到小**逐张插入，避免位置偏移：
+
+```bash
+# 1. 复制图片到剪贴板
+python ~/.codex/skills/x-article-publisher/scripts/copy_to_clipboard.py image /path/to/img.png --quality 85
+```
+
+```
+# 2. 定位到目标段落
+browser_snapshot → 找到包含 after_text 的段落
+browser_click → 点击该段落
+
+# 3. 【关键】按 End 移到行尾（避免误触链接）
+browser_press_key → End
+
+# 4. 按 Enter 换行 + 粘贴图片
+browser_press_key → Enter
+browser_press_key → Meta+v
+
+# 5. 等待上传完成
+browser_wait_for textGone="正在上传媒体"
+```
+
+### 1.7 插入分割线（从大到小）
+
+分割线无法通过 HTML `<hr>` 粘贴，必须走 X 编辑器菜单：
+
+```
+# 1. 点击目标位置的段落
+browser_click → block_index 对应的段落
+
+# 2. 打开 Insert 菜单
+browser_click → "Insert" / "添加媒体" 按钮
+
+# 3. 选择 Divider
+browser_click → "Divider" / "分割线" 菜单项
+```
+
+同样按 block_index 从大到小。
+
+### 1.8 保存草稿
+
+草稿自动保存。操作完成后：
+- 点击"预览"验证格式
+- 报告"Draft saved. Review and publish manually."
+- **绝不自动发布**
+
+---
+
+## 二、脚本参考
+
+| 脚本 | 用途 |
+|------|------|
+| `parse_markdown.py` | 解析 Markdown → JSON + HTML |
+| `copy_to_clipboard.py` | 复制图片/HTML 到系统剪贴板 |
+| `table_to_image.py` | 将 Markdown 表格转换为 PNG 图片 |
+
+所有脚本位于 `~/.codex/skills/x-article-publisher/scripts/`。
+
+### copy_to_clipboard.py 用法
+
+```bash
+# 复制图片（带压缩）
+python copy_to_clipboard.py image /path/to/image.jpg --quality 85
+
+# 复制 HTML（富文本粘贴）
+python copy_to_clipboard.py html --file /path/to/content.html
+```
+
+### table_to_image.py 用法
+
+```bash
+# 表格转图片（X Articles 不支持原生表格）
+python table_to_image.py input.md output.png --scale 2
+```
+
+---
+
+## 三、格式支持表
+
+| Markdown 元素 | X Articles 支持 | 处理方式 |
+|---------------|-----------------|----------|
+| `##` H2 标题 | 原生 | 直接粘贴 |
+| `**加粗**` | 原生 | 直接粘贴 |
+| `*斜体*` | 原生 | 直接粘贴 |
+| `[链接](url)` | 原生 | 直接粘贴 |
+| 有序列表 `1.` | 原生 | 直接粘贴 |
+| 无序列表 `-` | 原生 | 直接粘贴 |
+| 引用 `>` | 原生 | 直接粘贴 |
+| 代码块 | 转换 | → 引用块 |
+| 表格 | 转换 | → PNG 图片（`table_to_image.py`） |
+| Mermaid | 转换 | → PNG 图片（`mmdc`） |
+| 分割线 `---` | 菜单插入 | Insert > Divider |
+
+---
+
+## 四、效率原则
+
+### 避免多余的 browser_snapshot
+
+每次 browser_click / browser_press_key 返回结果中已包含页面状态，直接使用即可。
+
+```
+❌ browser_click → browser_snapshot → 分析 → browser_click
+✅ browser_click → 从返回结果中获取状态 → browser_click
+```
+
+### 准备工作前置
+
+在开始浏览器操作之前，先完成所有准备：
+1. 解析 Markdown → JSON
+2. 生成 HTML 到 /tmp/
+3. 记录 title、cover_image、content_images 列表
+
+浏览器操作阶段连续执行，不中途停下来处理数据。
+
+### 等待策略
+
+Playwright `browser_wait_for` 的行为：先等 `time` 秒 → 再检查条件。
+
+```
+✅ 只用 textGone，不设 time → 自动轮询等待条件满足
+❌ 同时用 textGone + time → 先傻等 time 秒再检查，浪费时间
+```
+
+---
+
+## 五、故障排除
+
+| 问题 | 原因 | 解决方案 |
+|------|------|----------|
+| `Browser is already in use` | Chrome 被锁定 | `browser_close` 后重新 `browser_navigate` |
+| 图片位置偏移 | 点击段落时误触链接 | 点击后**必须按 End**移到行尾 |
+| `正在上传媒体` 卡住 | 图片文件过大 | 用 `--quality 85` 压缩 |
+| 图片路径找不到 | 相对路径解析失败 | `parse_markdown.py` 自动搜索 `~/Downloads` `~/Desktop` |
+| Playwright MCP 不可用 | 连接断开 | 执行 `/mcp` → 选 playwright → Restart |
+| 粘贴后格式丢失 | 未用 HTML 剪贴板 | 确认用了 `copy_to_clipboard.py html` |
+
+---
+
+## 六、关键规则
+
+1. **绝不自动发布** — 只保存草稿
+2. **第一张图 = 封面图** — 用 `browser_file_upload` 上传
+3. **内容图用剪贴板** — `copy_to_clipboard.py image` + `Meta+v`，比菜单快
+4. **反向插入** — 图片和分割线都按 `block_index` 从大到小
+5. **必须按 End** — 点击段落后按 End 避免链接干扰
+6. **分割线走菜单** — `<hr>` 标签会被 X 忽略，必须用 Insert > Divider
+7. **H1 只做标题** — H1 不进正文，只填入标题栏


### PR DESCRIPTION
## Summary
- 从已发布公众号文章（蒸馏 CEO + Claude 封号指南）逐属性提取 CSS 设计令牌，建立标准化排版 skill (`skills/localdev/wechat-article/SKILL.md`)
- 提取 X Articles 长文自动发布流程为独立 skill (`skills/localdev/x-article-publisher/SKILL.md`)，覆盖 Playwright 自动化、剪贴板粘贴、图片/分割线插入等完整工作流

## Test plan
- [ ] 确认 SKILL.md 中的 CSS 值与已发布 HTML 一致
- [ ] 下次排版公众号文章时验证流水线可用
- [ ] 下次发布 X 长文时验证流程可用

Made with [Cursor](https://cursor.com)