### PR TITLE
fix: remove agent-browser from curated skills list

### DIFF
--- a/apps/controller/src/services/skillhub/curated-skills.ts
+++ b/apps/controller/src/services/skillhub/curated-skills.ts
@@ -28,8 +28,6 @@ export const CURATED_SKILL_SLUGS: readonly string[] = [
   "session-logs",
   // Skill management
   "skill-creator",
-  // Browser & web
-  "agent-browser",
   // Skill discovery
   "find-skill",
   // Search & content (ClawHub)


### PR DESCRIPTION
## What

Remove `agent-browser` from `CURATED_SKILL_SLUGS` — it's no longer available on ClawHub.

## Why

Users reported that switching to the Skills tab kept showing the toast `"agent-browser" 在 ClawHub 上不可用，可能已被移除或重命名。`

Root cause chain:

1. `agent-browser` is hard-coded in `CURATED_SKILL_SLUGS` (`apps/controller/src/services/skillhub/curated-skills.ts:32`).
2. On every cold start, `SkillhubService.initialize()` (`apps/controller/src/services/skillhub-service.ts:155-174`) asks `catalogManager.getCuratedSlugsToEnqueue()` for missing curated slugs and enqueues them into `InstallQueue`.
3. `getCuratedSlugsToEnqueue` (`catalog-manager.ts:333-336`) only filters against slugs that already exist in the ledger DB. Failed installs are never persisted — `InstallQueue` only calls `onComplete` on success (`install-queue.ts:238-253`), so the ledger never learns about the failure.
4. `executeInstall` shells out to `clawhub install agent-browser`, which returns `Skill not found`, classified as `errorCode: "skill_not_found"` (`install-queue.ts:285-294`).
5. The Skills page polls `/queue`, sees the failed item, and fires `toast.error(t("skills.skillNotFound", ...))` (`apps/web/src/pages/skills.tsx:366-379`).
6. The toast de-dup `Set` lives in a `useRef`, so every time the user navigates away from the Skills tab and back, the component remounts, the `Set` resets, and the same failed item (still in the 30s cleanup window) re-fires the toast.

Net effect: the error loops on every cold start and re-fires on every tab remount.

## How

Drop `agent-browser` from `CURATED_SKILL_SLUGS`. This stops the loop for end users immediately. Deeper structural fixes (persisting failures to the ledger, hoisting the toast de-dup out of `useRef`) are out of scope for this hotfix and tracked separately.

## Affected areas

- [x] Controller (backend / API)

## Checklist

- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced

## Notes for reviewers

Pre-existing `pnpm typecheck` failure in `apps/controller/src/app/create-app.ts` (Hono middleware type inference) also reproduces on `main` without this change — not introduced here.