### PR TITLE
fix: repair plugin bundle dependency closure for qqbot

### DIFF
--- a/apps/controller/scripts/bundle-runtime-plugins.mjs
+++ b/apps/controller/scripts/bundle-runtime-plugins.mjs
@@ -46,6 +46,16 @@ function getVirtualStoreNodeModules(realPkgPath) {
   return null;
 }
 
+function getPackageNodeModules(packageRoot) {
+  const candidate = path.join(packageRoot, "node_modules");
+  try {
+    readdirSync(candidate);
+    return candidate;
+  } catch {
+    return null;
+  }
+}
+
 function listPackages(nodeModulesDir) {
   const result = [];
 
@@ -166,8 +176,10 @@ async function bundlePlugin({ id, npmName }) {
   });
   await maybeFixPluginManifest(outputDir);
 
-  const rootVirtualNodeModules = getVirtualStoreNodeModules(sourcePackageRoot);
-  if (!rootVirtualNodeModules) {
+  const rootDependencyNodeModules =
+    getPackageNodeModules(sourcePackageRoot) ??
+    getVirtualStoreNodeModules(sourcePackageRoot);
+  if (!rootDependencyNodeModules) {
     throw new Error(`Unable to resolve node_modules for ${npmName}`);
   }
 
@@ -178,7 +190,7 @@ async function bundlePlugin({ id, npmName }) {
     ...Object.keys(packageJson.peerDependencies ?? {}),
   ]);
   const collected = new Map();
-  const queue = [{ nodeModulesDir: rootVirtualNodeModules, skipPkg: npmName }];
+  const queue = [{ nodeModulesDir: rootDependencyNodeModules, skipPkg: npmName }];
 
   while (queue.length > 0) {
     const { nodeModulesDir, skipPkg } = queue.shift();

--- a/apps/controller/scripts/bundle-runtime-plugins.mjs
+++ b/apps/controller/scripts/bundle-runtime-plugins.mjs
@@ -190,7 +190,9 @@ async function bundlePlugin({ id, npmName }) {
     ...Object.keys(packageJson.peerDependencies ?? {}),
   ]);
   const collected = new Map();
-  const queue = [{ nodeModulesDir: rootDependencyNodeModules, skipPkg: npmName }];
+  const queue = [
+    { nodeModulesDir: rootDependencyNodeModules, skipPkg: npmName },
+  ];
 
   while (queue.length > 0) {
     const { nodeModulesDir, skipPkg } = queue.shift();

--- a/apps/controller/tests/openclaw-runtime-plugin-writer.test.ts
+++ b/apps/controller/tests/openclaw-runtime-plugin-writer.test.ts
@@ -189,6 +189,41 @@ describe("OpenClawRuntimePluginWriter", () => {
     ).toBe("bundled\n");
   });
 
+  it("keeps bundled qqbot runtime dependencies when materializing extensions", async () => {
+    const bundledPluginDir = path.join(
+      env.bundledRuntimePluginsDir,
+      "openclaw-qqbot",
+    );
+    const bundledSilkWasmDir = path.join(
+      bundledPluginDir,
+      "node_modules",
+      "silk-wasm",
+    );
+
+    await mkdir(bundledSilkWasmDir, { recursive: true });
+    await writeFile(
+      path.join(bundledSilkWasmDir, "package.json"),
+      '{ "name": "silk-wasm" }\n',
+      "utf8",
+    );
+
+    const writer = new OpenClawRuntimePluginWriter(env);
+    await writer.ensurePlugins();
+
+    expect(
+      await readFile(
+        path.join(
+          env.openclawExtensionsDir,
+          "openclaw-qqbot",
+          "node_modules",
+          "silk-wasm",
+          "package.json",
+        ),
+        "utf8",
+      ),
+    ).toContain('"name": "silk-wasm"');
+  });
+
   it("prefers bundled wecom over the legacy runtime plugin source", async () => {
     const bundledPluginDir = path.join(env.bundledRuntimePluginsDir, "wecom");
     const legacyPluginDir = path.join(env.runtimePluginTemplatesDir, "wecom");

--- a/apps/desktop/scripts/dist-mac.mjs
+++ b/apps/desktop/scripts/dist-mac.mjs
@@ -80,6 +80,15 @@ async function ensureExistingPath(path, label) {
   }
 }
 
+async function pathExists(targetPath) {
+  try {
+    await lstat(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 async function ensureExistingBuildArtifacts() {
   await Promise.all([
     ensureExistingPath(
@@ -463,6 +472,52 @@ async function stapleNotarizedAppBundles() {
   }
 }
 
+async function validatePackagedQqbotDependencies(releaseRoot) {
+  const appBundleDirs = await readdir(releaseRoot, { withFileTypes: true });
+  const packagedMacBundles = appBundleDirs.filter(
+    (entry) =>
+      entry.isDirectory() &&
+      (entry.name === "mac" || entry.name.startsWith("mac-")),
+  );
+
+  if (packagedMacBundles.length === 0) {
+    throw new Error(
+      `[dist:mac] expected packaged macOS app bundles under ${releaseRoot}, but none were found.`,
+    );
+  }
+
+  for (const entry of packagedMacBundles) {
+    const appRoot = resolve(releaseRoot, entry.name, "Nexu.app");
+    const qqbotPluginRoot = resolve(
+      appRoot,
+      "Contents",
+      "Resources",
+      "runtime",
+      "controller",
+      "plugins",
+      "openclaw-qqbot",
+    );
+    const silkWasmPackagePath = resolve(
+      qqbotPluginRoot,
+      "node_modules",
+      "silk-wasm",
+      "package.json",
+    );
+
+    if (!(await pathExists(qqbotPluginRoot))) {
+      throw new Error(
+        `[dist:mac] packaged app is missing openclaw-qqbot: ${qqbotPluginRoot}`,
+      );
+    }
+
+    if (!(await pathExists(silkWasmPackagePath))) {
+      throw new Error(
+        `[dist:mac] packaged app is missing openclaw-qqbot dependency silk-wasm: ${silkWasmPackagePath}`,
+      );
+    }
+  }
+}
+
 async function ensureBuildConfig() {
   const configPath = resolve(electronRoot, "build-config.json");
   const isCi =
@@ -838,6 +893,11 @@ async function main() {
           : notarizeEnv,
       });
     },
+    timings,
+  );
+  await timedStep(
+    "validate packaged qqbot dependencies",
+    async () => validatePackagedQqbotDependencies(releaseRoot),
     timings,
   );
   await timedStep(

--- a/apps/desktop/scripts/dist-win-stage.mjs
+++ b/apps/desktop/scripts/dist-win-stage.mjs
@@ -457,6 +457,36 @@ async function validateWinUnpackedReuse(releaseRoot) {
   }
 }
 
+async function validatePackagedQqbotDependencies(releaseRoot) {
+  const winUnpackedRoot = resolve(releaseRoot, "win-unpacked");
+  const qqbotPluginRoot = resolve(
+    winUnpackedRoot,
+    "resources",
+    "runtime",
+    "controller",
+    "plugins",
+    "openclaw-qqbot",
+  );
+  const silkWasmPackagePath = resolve(
+    qqbotPluginRoot,
+    "node_modules",
+    "silk-wasm",
+    "package.json",
+  );
+
+  if (!(await pathExists(qqbotPluginRoot))) {
+    throw new Error(
+      `[dist:win] packaged app is missing openclaw-qqbot: ${qqbotPluginRoot}`,
+    );
+  }
+
+  if (!(await pathExists(silkWasmPackagePath))) {
+    throw new Error(
+      `[dist:win] packaged app is missing openclaw-qqbot dependency silk-wasm: ${silkWasmPackagePath}`,
+    );
+  }
+}
+
 async function ensureExistingBuildArtifacts() {
   await Promise.all([
     ensureExistingPath(
@@ -1279,6 +1309,11 @@ async function main() {
       });
       await writeWinUnpackedManifest(releaseRoot);
     },
+    timings,
+  );
+  await timedStep(
+    "validate packaged qqbot dependencies",
+    async () => validatePackagedQqbotDependencies(releaseRoot),
     timings,
   );
 

--- a/apps/desktop/scripts/prepare-controller-sidecar.mjs
+++ b/apps/desktop/scripts/prepare-controller-sidecar.mjs
@@ -1,5 +1,5 @@
 import { cp, readFile, writeFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import { join, resolve } from "node:path";
 import {
   copyRuntimeDependencyClosure,
   getSidecarRoot,
@@ -31,9 +31,39 @@ const sidecarPackageJsonPath = resolve(sidecarRoot, "package.json");
 const diagnosticsEnabled =
   process.env.NEXU_DESKTOP_DIST_DIAGNOSTICS === "1" ||
   process.env.NEXU_DESKTOP_DIST_DIAGNOSTICS?.toLowerCase() === "true";
+const qqbotPluginRelativeRoot = "openclaw-qqbot";
+const qqbotSilkWasmPackageRelativePath = join(
+  qqbotPluginRelativeRoot,
+  "node_modules",
+  "silk-wasm",
+  "package.json",
+);
 
 function formatDurationMs(durationMs) {
   return `${(durationMs / 1000).toFixed(3)}s`;
+}
+
+async function ensureQqbotPluginDependencyTree(rootDir, label) {
+  const pluginDir = resolve(rootDir, qqbotPluginRelativeRoot);
+  const silkWasmPackagePath = resolve(
+    rootDir,
+    qqbotSilkWasmPackageRelativePath,
+  );
+  const missing = [];
+
+  if (!(await pathExists(pluginDir))) {
+    missing.push(pluginDir);
+  }
+
+  if (!(await pathExists(silkWasmPackagePath))) {
+    missing.push(silkWasmPackagePath);
+  }
+
+  if (missing.length > 0) {
+    throw new Error(
+      `[controller-sidecar] ${label} is missing bundled QQ plugin dependencies: ${missing.join(", ")}`,
+    );
+  }
 }
 
 async function ensureBuildArtifacts() {
@@ -78,10 +108,18 @@ async function prepareControllerSidecar() {
   }
 
   if (await pathExists(controllerBundledPluginsRoot)) {
+    await ensureQqbotPluginDependencyTree(
+      controllerBundledPluginsRoot,
+      "controller bundled plugins",
+    );
     await cp(controllerBundledPluginsRoot, sidecarPluginsRoot, {
       recursive: true,
       dereference: true,
     });
+    await ensureQqbotPluginDependencyTree(
+      sidecarPluginsRoot,
+      "controller sidecar plugins",
+    );
   }
 
   const controllerPackageJson = JSON.parse(


### PR DESCRIPTION
## What

Repair the qqbot bundled plugin dependency closure so packaged desktop builds include `silk-wasm`, and fail packaging early if the qqbot plugin is incomplete.

## Why

Upgraded packaged installs could keep an incomplete `openclaw-qqbot` runtime plugin, leaving QQ stuck in a restarting/starting state with `Cannot find module 'silk-wasm'` during plugin preload.

## How

- Start qqbot bundled dependency collection from the plugin's own `node_modules` before falling back to the pnpm virtual-store parent.
- Add a regression test covering qqbot bundled runtime dependencies during extension materialization.
- Add controller sidecar packaging checks for `openclaw-qqbot/node_modules/silk-wasm/package.json`.
- Add mac packaged-app validation to ensure the final `.app` includes the qqbot `silk-wasm` dependency.

## Affected areas

- [x] Desktop app (Electron shell)
- [x] Controller (backend / API)
- [ ] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [x] Build / CI / Tooling

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

## Notes for reviewers

- I ran the targeted regression test: `pnpm --filter @nexu/controller exec vitest run tests/openclaw-runtime-plugin-writer.test.ts`.
- I also built an Apple Silicon unsigned zip and verified the packaged app contains `runtime/controller/plugins/openclaw-qqbot/node_modules/silk-wasm/package.json`.
- I did not mark full `pnpm test` as passing because the current `main` branch already has unrelated failing tests.
