### PR TITLE
chore: add structured logging to channel connect/disconnect flows

### DIFF
--- a/apps/controller/src/lib/channel-binding-compiler.ts
+++ b/apps/controller/src/lib/channel-binding-compiler.ts
@@ -9,6 +9,7 @@ import type {
   WhatsappAccountConfig,
 } from "@nexu/shared";
 import type { BotResponse, ChannelResponse } from "@nexu/shared";
+import { logger } from "./logger.js";
 
 /** Prefix for all internal placeholder account IDs that must never be persisted to runtime state. */
 export const NEXU_INTERNAL_ACCOUNT_PREFIX = "__nexu_internal_";
@@ -105,8 +106,16 @@ export function compileChannelsConfig(params: {
   const useSlackSocketMode =
     typeof socketAppToken === "string" && socketAppToken.length > 0;
 
+  const skippedChannels: Array<{ id: string; type: string; reason: string }> =
+    [];
+
   for (const channel of params.channels) {
     if (channel.status !== "connected" && channel.channelType !== "feishu") {
+      skippedChannels.push({
+        id: channel.id,
+        type: channel.channelType,
+        reason: `status=${channel.status}`,
+      });
       continue;
     }
 
@@ -253,6 +262,32 @@ export function compileChannelsConfig(params: {
     // gateway restart (~20-45s → ~500ms).
     wechatAccounts[INTERNAL_WECHAT_PREWARM_ACCOUNT_ID] = { enabled: false };
   }
+
+  const compiled: Record<string, number> = {};
+  if (Object.keys(slackAccounts).length > 0)
+    compiled.slack = Object.keys(slackAccounts).length;
+  if (Object.keys(discordAccounts).length > 0)
+    compiled.discord = Object.keys(discordAccounts).length;
+  if (Object.keys(telegramAccounts).length > 0)
+    compiled.telegram = Object.keys(telegramAccounts).length;
+  if (Object.keys(feishuAccounts).length > 0)
+    compiled.feishu = Object.keys(feishuAccounts).length;
+  if (Object.keys(whatsappAccounts).length > 0)
+    compiled.whatsapp = Object.keys(whatsappAccounts).length;
+  if (Object.keys(wechatAccounts).length > 0)
+    compiled.wechat = Object.keys(wechatAccounts).length;
+  if (dingtalkChannel) compiled.dingtalk = 1;
+  if (wecomChannel) compiled.wecom = 1;
+  if (qqbotChannel) compiled.qqbot = 1;
+
+  logger.info(
+    {
+      inputCount: params.channels.length,
+      compiled,
+      skipped: skippedChannels.length > 0 ? skippedChannels : undefined,
+    },
+    "compile_channels_summary",
+  );
 
   return {
     ...(Object.keys(slackAccounts).length > 0

--- a/apps/controller/src/routes/channel-routes.ts
+++ b/apps/controller/src/routes/channel-routes.ts
@@ -23,6 +23,7 @@ import {
   whatsappQrWaitResponseSchema,
 } from "@nexu/shared";
 import type { ControllerContainer } from "../app/container.js";
+import { logger } from "../lib/logger.js";
 import type { ControllerBindings } from "../types.js";
 
 const channelIdParamSchema = z.object({ channelId: z.string() });
@@ -128,6 +129,10 @@ export function registerChannelRoutes(
           200,
         );
       } catch (error) {
+        logger.error(
+          { error: error instanceof Error ? error.message : String(error) },
+          "channel_connect_error_slack",
+        );
         return c.json(
           {
             message:
@@ -167,6 +172,10 @@ export function registerChannelRoutes(
           200,
         );
       } catch (error) {
+        logger.error(
+          { error: error instanceof Error ? error.message : String(error) },
+          "channel_connect_error_discord",
+        );
         return c.json(
           {
             message:
@@ -206,6 +215,10 @@ export function registerChannelRoutes(
           200,
         );
       } catch (error) {
+        logger.error(
+          { error: error instanceof Error ? error.message : String(error) },
+          "channel_connect_error_feishu",
+        );
         return c.json(
           {
             message:
@@ -246,6 +259,10 @@ export function registerChannelRoutes(
           200,
         );
       } catch (error) {
+        logger.error(
+          { error: error instanceof Error ? error.message : String(error) },
+          "channel_connect_error_telegram",
+        );
         return c.json(
           {
             message:
@@ -287,6 +304,10 @@ export function registerChannelRoutes(
           200,
         );
       } catch (error) {
+        logger.error(
+          { error: error instanceof Error ? error.message : String(error) },
+          "channel_connect_error_dingtalk",
+        );
         return c.json(
           {
             message:
@@ -373,6 +394,10 @@ export function registerChannelRoutes(
           200,
         );
       } catch (error) {
+        logger.error(
+          { error: error instanceof Error ? error.message : String(error) },
+          "channel_connect_error_qqbot",
+        );
         return c.json(
           {
             message:
@@ -455,6 +480,10 @@ export function registerChannelRoutes(
           200,
         );
       } catch (error) {
+        logger.error(
+          { error: error instanceof Error ? error.message : String(error) },
+          "channel_connect_error_wecom",
+        );
         return c.json(
           {
             message:

--- a/apps/controller/src/services/channel-service.ts
+++ b/apps/controller/src/services/channel-service.ts
@@ -751,6 +751,7 @@ export class ChannelService {
   }
 
   async connectSlack(input: ConnectSlackInput) {
+    logger.info({}, "slack_connect_start");
     const authResp = await proxyFetch("https://slack.com/api/auth.test", {
       headers: { Authorization: `Bearer ${input.botToken}` },
       timeoutMs: 5000,
@@ -764,6 +765,10 @@ export class ChannelService {
       error?: string;
     };
     if (!authData.ok || !authData.team_id) {
+      logger.error(
+        { slackError: authData.error },
+        "slack_connect_verify_failed",
+      );
       throw new Error(
         `Invalid Slack bot token: ${authData.error ?? "auth.test failed"}`,
       );
@@ -797,15 +802,24 @@ export class ChannelService {
       botUserId: authData.user_id ?? null,
     });
     await this.syncService.syncAll();
+    logger.info(
+      { channelId: channel.id, teamName: authData.team },
+      "slack_connect_success",
+    );
     return channel;
   }
 
   async connectDiscord(input: ConnectDiscordInput) {
+    logger.info({ appId: input.appId }, "discord_connect_start");
     const userResp = await proxyFetch("https://discord.com/api/v10/users/@me", {
       headers: { Authorization: `Bot ${input.botToken}` },
       timeoutMs: 5000,
     });
     if (!userResp.ok) {
+      logger.error(
+        { appId: input.appId, status: userResp.status },
+        "discord_connect_verify_failed",
+      );
       throw new Error(
         userResp.status === 401
           ? "Invalid Discord bot token"
@@ -825,6 +839,10 @@ export class ChannelService {
     if (appResp.ok) {
       const appData = (await appResp.json()) as { id: string };
       if (appData.id !== input.appId) {
+        logger.error(
+          { expected: input.appId, actual: appData.id },
+          "discord_connect_app_id_mismatch",
+        );
         throw new Error(
           `Application ID mismatch: token belongs to ${appData.id}, but ${input.appId} was provided`,
         );
@@ -836,6 +854,10 @@ export class ChannelService {
       botUserId: userData.id ?? null,
     });
     await this.syncService.syncAll();
+    logger.info(
+      { channelId: channel.id, botUserId: userData.id },
+      "discord_connect_success",
+    );
     return channel;
   }
 
@@ -964,6 +986,7 @@ export class ChannelService {
   }
 
   async connectTelegram(input: ConnectTelegramInput) {
+    logger.info({}, "telegram_connect_start");
     const response = await proxyFetch(
       `https://api.telegram.org/bot${encodeURIComponent(input.botToken)}/getMe`,
       {
@@ -971,6 +994,10 @@ export class ChannelService {
       },
     );
     if (!response.ok) {
+      logger.error(
+        { status: response.status },
+        "telegram_connect_verify_failed",
+      );
       throw new Error(
         response.status === 401
           ? "Invalid Telegram bot token"
@@ -980,6 +1007,10 @@ export class ChannelService {
 
     const payload = (await response.json()) as TelegramGetMeResponse;
     if (!payload.ok || !payload.result?.id) {
+      logger.error(
+        { description: payload.description },
+        "telegram_connect_payload_invalid",
+      );
       throw new Error(payload.description ?? "Invalid Telegram bot token");
     }
 
@@ -993,10 +1024,15 @@ export class ChannelService {
         null,
     });
     await this.syncService.syncAll();
+    logger.info(
+      { channelId: channel.id, botUsername: payload.result.username },
+      "telegram_connect_success",
+    );
     return channel;
   }
 
   async connectQqbot(input: ConnectQqbotInput) {
+    logger.info({}, "qqbot_connect_start");
     this.ensureQqbotPluginInstalled();
     const { appId, appSecret } = await this.verifyQqbotCredentials(input);
 
@@ -1005,10 +1041,12 @@ export class ChannelService {
       appSecret,
     });
     await this.syncService.syncAll();
+    logger.info({ channelId: channel.id, appId }, "qqbot_connect_success");
     return channel;
   }
 
   async connectDingtalk(input: ConnectDingtalkInput) {
+    logger.info({}, "dingtalk_connect_start");
     this.ensureDingtalkPluginInstalled();
     const { clientId, clientSecret } =
       await this.verifyDingtalkCredentials(input);
@@ -1018,6 +1056,10 @@ export class ChannelService {
       clientSecret,
     });
     await this.syncService.syncAll();
+    logger.info(
+      { channelId: channel.id, clientId },
+      "dingtalk_connect_success",
+    );
     return channel;
   }
 
@@ -1040,6 +1082,7 @@ export class ChannelService {
   }
 
   async connectWecom(input: ConnectWecomInput) {
+    logger.info({}, "wecom_connect_start");
     this.ensureWecomPluginInstalled();
     const { botId, secret } = this.verifyWecomCredentials(input);
 
@@ -1048,6 +1091,7 @@ export class ChannelService {
       secret,
     });
     await this.syncService.syncAll();
+    logger.info({ channelId: channel.id, botId }, "wecom_connect_success");
     return channel;
   }
 
@@ -1283,6 +1327,7 @@ export class ChannelService {
   }
 
   async connectFeishu(input: ConnectFeishuInput) {
+    logger.info({ appId: input.appId }, "feishu_connect_start");
     const response = await proxyFetch(
       "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal",
       {
@@ -1297,6 +1342,15 @@ export class ChannelService {
     );
     const payload = (await response.json()) as { code?: number; msg?: string };
     if (!response.ok || payload.code !== 0) {
+      logger.error(
+        {
+          appId: input.appId,
+          status: response.status,
+          code: payload.code,
+          feishuMsg: payload.msg,
+        },
+        "feishu_connect_verify_failed",
+      );
       throw new Error(
         `Invalid Feishu credentials: ${payload.msg ?? `HTTP ${response.status}`}`,
       );
@@ -1304,6 +1358,10 @@ export class ChannelService {
 
     const channel = await this.configStore.connectFeishu(input);
     await this.syncService.syncAll();
+    logger.info(
+      { channelId: channel.id, appId: input.appId },
+      "feishu_connect_success",
+    );
     return channel;
   }
 
@@ -1317,6 +1375,10 @@ export class ChannelService {
         ? this.configStore.getChannel.bind(this.configStore)
         : null;
     const channel = getChannel ? await getChannel(channelId) : null;
+    logger.info(
+      { channelId, channelType: channel?.channelType ?? "unknown" },
+      "channel_disconnect_start",
+    );
     const removed = await this.configStore.disconnectChannel(channelId);
     if (removed) {
       // syncAll triggers the authoritative index writer which removes
@@ -1327,6 +1389,12 @@ export class ChannelService {
       if (channel?.channelType === "whatsapp") {
         await this.restartOpenClawForWhatsappLifecycle("whatsapp-disconnect");
       }
+      logger.info(
+        { channelId, channelType: channel?.channelType ?? "unknown" },
+        "channel_disconnect_success",
+      );
+    } else {
+      logger.warn({ channelId }, "channel_disconnect_not_found");
     }
     return removed;
   }


### PR DESCRIPTION
## What

Add structured logging to all channel connect/disconnect operations across the controller.

## Why

Channel connect failures (especially Telegram/Discord) were completely silent — `proxyFetch` timeouts or API errors were caught and returned as 409 JSON responses with zero controller log entries. This made it impossible to diagnose "channel won't connect" from user diagnostics exports.

Discovered while debugging a user report where Telegram/Discord appeared unconfigured despite the user claiming they had set them up.

## How

Three files changed:

**`channel-service.ts`** — start/success/failure logs for all `connect*()` methods + `disconnectChannel`:
- `{slack,discord,telegram,feishu,qqbot,dingtalk,wecom}_connect_{start,success}`
- `{slack,discord,telegram,feishu}_connect_verify_failed`
- `channel_disconnect_{start,success,not_found}`

**`channel-routes.ts`** — `channel_connect_error_<type>` in all route catch blocks (covers `proxyFetch` network errors that throw before service-level logging).

**`channel-binding-compiler.ts`** — `compile_channels_summary` log showing input count, compiled channel types with account counts, and skipped channels with skip reasons.

## Affected areas

- Controller channel service (all channel types)
- Controller channel routes
- Channel binding compiler

## Checklist

- [x] Logging only, no behavior change
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] No credentials logged (bot tokens redacted)