### PR TITLE
chore: add Vaunt contributor achievement configuration

### DIFF
--- a/.vaunt/config.yml
+++ b/.vaunt/config.yml
@@ -1,235 +1,217 @@
+version: 0.0.1
 achievements:
   # ── WELCOME ──────────────────────────────────────────────────────────────────
 
-  - name: Stargazer
-    body: >
-      You starred the Nexu repository. Thanks for the support — every star
-      helps the project grow.
-    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/2b50.png
-    trigger:
-      type: star
+  - achievement:
+      name: Stargazer
+      icon: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/2b50.png
+      description: Starred the Nexu repository. Thanks for the support — every star helps the project grow.
+      triggers:
+        - trigger:
+            actor: author
+            action: star
+            condition: starred = true
 
-  - name: First Report
-    body: >
-      Opened your first issue. Whether it's a bug, a feature idea, or an
-      improvement — you're helping shape Nexu.
-    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f4dd.png
-    trigger:
-      type: issue
-      count: 1
+  - achievement:
+      name: First Report
+      icon: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f4dd.png
+      description: Opened your first issue. Whether it's a bug, a feature idea, or an improvement — you're helping shape Nexu.
+      triggers:
+        - trigger:
+            actor: author
+            action: issue
+            condition: count() >= 1
 
-  - name: Lift Off
-    body: >
-      First pull request merged into Nexu. You're officially a contributor.
-      Welcome aboard.
-    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f680.png
-    trigger:
-      type: pull_request
-      merged: true
-      count: 1
+  - achievement:
+      name: Lift Off
+      icon: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f680.png
+      description: First pull request merged into Nexu. You're officially a contributor. Welcome aboard.
+      triggers:
+        - trigger:
+            actor: author
+            action: pull_request
+            condition: merged = true & count() >= 1
 
   # ── BUG HUNTING ──────────────────────────────────────────────────────────────
 
-  - name: Bug Spotter
-    body: >
-      Reported a confirmed bug in Nexu. Good eyes — finding bugs is half the
-      battle.
-    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f41b.png
-    trigger:
-      type: issue
-      count: 1
-      labels:
-        - bug
+  - achievement:
+      name: Bug Spotter
+      icon: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f41b.png
+      description: Reported a confirmed bug in Nexu. Good eyes — finding bugs is half the battle.
+      triggers:
+        - trigger:
+            actor: author
+            action: issue
+            condition: labels in ['bug'] & count() >= 1
 
-  - name: Bug Crusher
-    body: >
-      Merged your first bug-fix PR. You didn't just spot it — you squashed it.
-    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f527.png
-    trigger:
-      type: pull_request
-      merged: true
-      count: 1
-      labels:
-        - bug
+  - achievement:
+      name: Bug Crusher
+      icon: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f527.png
+      description: Merged your first bug-fix PR. You didn't just spot it — you squashed it.
+      triggers:
+        - trigger:
+            actor: author
+            action: pull_request
+            condition: merged = true & labels in ['bug'] & count() >= 1
 
-  - name: Exterminator
-    body: >
-      Five bug-fix PRs merged. The codebase is measurably better because of you.
-    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/26a1.png
-    trigger:
-      type: pull_request
-      merged: true
-      count: 5
-      labels:
-        - bug
+  - achievement:
+      name: Exterminator
+      icon: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/26a1.png
+      description: Five bug-fix PRs merged. The codebase is measurably better because of you.
+      triggers:
+        - trigger:
+            actor: author
+            action: pull_request
+            condition: merged = true & labels in ['bug'] & count() >= 5
 
   # ── FEATURE BUILDING ─────────────────────────────────────────────────────────
 
-  - name: Spark
-    body: >
-      Shipped your first enhancement to Nexu. You're not just using it —
-      you're making it better.
-    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/2728.png
-    trigger:
-      type: pull_request
-      merged: true
-      count: 1
-      labels:
-        - enhancement
+  - achievement:
+      name: Spark
+      icon: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/2728.png
+      description: Shipped your first enhancement to Nexu. You're not just using it — you're making it better.
+      triggers:
+        - trigger:
+            actor: author
+            action: pull_request
+            condition: merged = true & labels in ['enhancement'] & count() >= 1
 
-  - name: Feature Architect
-    body: >
-      Five enhancement PRs merged. You're actively shaping what Nexu becomes.
-    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f4a1.png
-    trigger:
-      type: pull_request
-      merged: true
-      count: 5
-      labels:
-        - enhancement
+  - achievement:
+      name: Feature Architect
+      icon: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f4a1.png
+      description: Five enhancement PRs merged. You're actively shaping what Nexu becomes.
+      triggers:
+        - trigger:
+            actor: author
+            action: pull_request
+            condition: merged = true & labels in ['enhancement'] & count() >= 5
 
   # ── IMPROVEMENT ──────────────────────────────────────────────────────────────
 
-  - name: Polish Pro
-    body: >
-      Merged your first improvement PR. Refactoring, performance, DX — the
-      unglamorous work that makes a codebase solid.
-    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f528.png
-    trigger:
-      type: pull_request
-      merged: true
-      count: 1
-      labels:
-        - improvement
+  - achievement:
+      name: Polish Pro
+      icon: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f528.png
+      description: Merged your first improvement PR. Refactoring, performance, DX — the unglamorous work that makes a codebase solid.
+      triggers:
+        - trigger:
+            actor: author
+            action: pull_request
+            condition: merged = true & labels in ['improvement'] & count() >= 1
 
-  - name: Craftsmanship
-    body: >
-      Five improvement PRs merged. You care about the quality of the craft,
-      not just the feature count.
-    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f3c5.png
-    trigger:
-      type: pull_request
-      merged: true
-      count: 5
-      labels:
-        - improvement
+  - achievement:
+      name: Craftsmanship
+      icon: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f3c5.png
+      description: Five improvement PRs merged. You care about the quality of the craft, not just the feature count.
+      triggers:
+        - trigger:
+            actor: author
+            action: pull_request
+            condition: merged = true & labels in ['improvement'] & count() >= 5
 
   # ── DOMAIN EXPERTS ───────────────────────────────────────────────────────────
 
-  - name: Desktop Wizard
-    body: >
-      Shipped a change to Nexu's Electron desktop layer. You understand the
-      packaged app, launchd services, or the Electron shell.
-    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f5a5-fe0f.png
-    trigger:
-      type: pull_request
-      merged: true
-      count: 1
-      labels:
-        - desktop
+  - achievement:
+      name: Desktop Wizard
+      icon: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f5a5-fe0f.png
+      description: Shipped a change to Nexu's Electron desktop layer. You understand the packaged app, launchd services, or the Electron shell.
+      triggers:
+        - trigger:
+            actor: author
+            action: pull_request
+            condition: merged = true & labels in ['desktop'] & count() >= 1
 
-  - name: Skill Crafter
-    body: >
-      Contributed to Nexu's OpenClaw skill ecosystem. Building skills is how
-      Nexu's AI agents gain superpowers.
-    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f99e.png
-    trigger:
-      type: pull_request
-      merged: true
-      count: 1
-      labels:
-        - skills
+  - achievement:
+      name: Skill Crafter
+      icon: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f99e.png
+      description: Contributed to Nexu's OpenClaw skill ecosystem. Building skills is how Nexu's AI agents gain superpowers.
+      triggers:
+        - trigger:
+            actor: author
+            action: pull_request
+            condition: merged = true & labels in ['skills'] & count() >= 1
 
-  - name: Controller Hacker
-    body: >
-      Contributed to the Nexu controller — the local control plane that
-      compiles OpenClaw config and orchestrates the runtime.
-    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/2699-fe0f.png
-    trigger:
-      type: pull_request
-      merged: true
-      count: 1
-      labels:
-        - controller
+  - achievement:
+      name: Controller Hacker
+      icon: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/2699-fe0f.png
+      description: Contributed to the Nexu controller — the local control plane that compiles OpenClaw config and orchestrates the runtime.
+      triggers:
+        - trigger:
+            actor: author
+            action: pull_request
+            condition: merged = true & labels in ['controller'] & count() >= 1
 
   # ── DOCUMENTATION ────────────────────────────────────────────────────────────
 
-  - name: Doc Writer
-    body: >
-      Merged a documentation PR. Great docs are how open-source projects
-      become genuinely useful to the community.
-    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f4d6.png
-    trigger:
-      type: pull_request
-      merged: true
-      count: 1
-      labels:
-        - documentation
+  - achievement:
+      name: Doc Writer
+      icon: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f4d6.png
+      description: Merged a documentation PR. Great docs are how open-source projects become genuinely useful to the community.
+      triggers:
+        - trigger:
+            actor: author
+            action: pull_request
+            condition: merged = true & labels in ['documentation'] & count() >= 1
 
   # ── ONBOARDING ───────────────────────────────────────────────────────────────
 
-  - name: Good First Step
-    body: >
-      Resolved a good-first-issue. Every expert was a beginner once — welcome
-      to the Nexu contributor community.
-    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f331.png
-    trigger:
-      type: pull_request
-      merged: true
-      count: 1
-      labels:
-        - good first issue
+  - achievement:
+      name: Good First Step
+      icon: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f331.png
+      description: Resolved a good-first-issue. Every expert was a beginner once — welcome to the Nexu contributor community.
+      triggers:
+        - trigger:
+            actor: author
+            action: pull_request
+            condition: merged = true & labels in ['good first issue'] & count() >= 1
 
-  - name: Helper
-    body: >
-      Picked up and closed a help-wanted issue. You saw something that needed
-      doing and stepped up.
-    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f91d.png
-    trigger:
-      type: pull_request
-      merged: true
-      count: 1
-      labels:
-        - help wanted
+  - achievement:
+      name: Helper
+      icon: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f91d.png
+      description: Picked up and closed a help-wanted issue. You saw something that needed doing and stepped up.
+      triggers:
+        - trigger:
+            actor: author
+            action: pull_request
+            condition: merged = true & labels in ['help wanted'] & count() >= 1
 
   # ── CORE CONTRIBUTOR MILESTONES ──────────────────────────────────────────────
 
-  - name: Rising Star
-    body: >
-      Five pull requests merged. You're picking up momentum — the team
-      recognizes your name now.
-    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f31f.png
-    trigger:
-      type: pull_request
-      merged: true
-      count: 5
+  - achievement:
+      name: Rising Star
+      icon: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f31f.png
+      description: Five pull requests merged. You're picking up momentum — the team recognizes your name now.
+      triggers:
+        - trigger:
+            actor: author
+            action: pull_request
+            condition: merged = true & count() >= 5
 
-  - name: Regular
-    body: >
-      Ten pull requests merged. A familiar face in the codebase. You know
-      where things live and how they fit together.
-    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f948.png
-    trigger:
-      type: pull_request
-      merged: true
-      count: 10
+  - achievement:
+      name: Regular
+      icon: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f948.png
+      description: Ten pull requests merged. A familiar face in the codebase. You know where things live and how they fit together.
+      triggers:
+        - trigger:
+            actor: author
+            action: pull_request
+            condition: merged = true & count() >= 10
 
-  - name: Core Contributor
-    body: >
-      Twenty-five pull requests merged. Nexu wouldn't be the same codebase
-      without your work.
-    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f947.png
-    trigger:
-      type: pull_request
-      merged: true
-      count: 25
+  - achievement:
+      name: Core Contributor
+      icon: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f947.png
+      description: Twenty-five pull requests merged. Nexu wouldn't be the same codebase without your work.
+      triggers:
+        - trigger:
+            actor: author
+            action: pull_request
+            condition: merged = true & count() >= 25
 
-  - name: Nexu Legend
-    body: >
-      Fifty pull requests merged. You've shaped this project at a fundamental
-      level. Legendary status — earned, not given.
-    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f3c6.png
-    trigger:
-      type: pull_request
-      merged: true
-      count: 50
+  - achievement:
+      name: Nexu Legend
+      icon: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f3c6.png
+      description: Fifty pull requests merged. You've shaped this project at a fundamental level. Legendary status — earned, not given.
+      triggers:
+        - trigger:
+            actor: author
+            action: pull_request
+            condition: merged = true & count() >= 50

--- a/.vaunt/config.yml
+++ b/.vaunt/config.yml
@@ -1,0 +1,235 @@
+achievements:
+  # ── WELCOME ──────────────────────────────────────────────────────────────────
+
+  - name: Stargazer
+    body: >
+      You starred the Nexu repository. Thanks for the support — every star
+      helps the project grow.
+    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/2b50.png
+    trigger:
+      type: star
+
+  - name: First Report
+    body: >
+      Opened your first issue. Whether it's a bug, a feature idea, or an
+      improvement — you're helping shape Nexu.
+    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f4dd.png
+    trigger:
+      type: issue
+      count: 1
+
+  - name: Lift Off
+    body: >
+      First pull request merged into Nexu. You're officially a contributor.
+      Welcome aboard.
+    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f680.png
+    trigger:
+      type: pull_request
+      merged: true
+      count: 1
+
+  # ── BUG HUNTING ──────────────────────────────────────────────────────────────
+
+  - name: Bug Spotter
+    body: >
+      Reported a confirmed bug in Nexu. Good eyes — finding bugs is half the
+      battle.
+    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f41b.png
+    trigger:
+      type: issue
+      count: 1
+      labels:
+        - bug
+
+  - name: Bug Crusher
+    body: >
+      Merged your first bug-fix PR. You didn't just spot it — you squashed it.
+    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f527.png
+    trigger:
+      type: pull_request
+      merged: true
+      count: 1
+      labels:
+        - bug
+
+  - name: Exterminator
+    body: >
+      Five bug-fix PRs merged. The codebase is measurably better because of you.
+    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/26a1.png
+    trigger:
+      type: pull_request
+      merged: true
+      count: 5
+      labels:
+        - bug
+
+  # ── FEATURE BUILDING ─────────────────────────────────────────────────────────
+
+  - name: Spark
+    body: >
+      Shipped your first enhancement to Nexu. You're not just using it —
+      you're making it better.
+    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/2728.png
+    trigger:
+      type: pull_request
+      merged: true
+      count: 1
+      labels:
+        - enhancement
+
+  - name: Feature Architect
+    body: >
+      Five enhancement PRs merged. You're actively shaping what Nexu becomes.
+    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f4a1.png
+    trigger:
+      type: pull_request
+      merged: true
+      count: 5
+      labels:
+        - enhancement
+
+  # ── IMPROVEMENT ──────────────────────────────────────────────────────────────
+
+  - name: Polish Pro
+    body: >
+      Merged your first improvement PR. Refactoring, performance, DX — the
+      unglamorous work that makes a codebase solid.
+    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f528.png
+    trigger:
+      type: pull_request
+      merged: true
+      count: 1
+      labels:
+        - improvement
+
+  - name: Craftsmanship
+    body: >
+      Five improvement PRs merged. You care about the quality of the craft,
+      not just the feature count.
+    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f3c5.png
+    trigger:
+      type: pull_request
+      merged: true
+      count: 5
+      labels:
+        - improvement
+
+  # ── DOMAIN EXPERTS ───────────────────────────────────────────────────────────
+
+  - name: Desktop Wizard
+    body: >
+      Shipped a change to Nexu's Electron desktop layer. You understand the
+      packaged app, launchd services, or the Electron shell.
+    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f5a5-fe0f.png
+    trigger:
+      type: pull_request
+      merged: true
+      count: 1
+      labels:
+        - desktop
+
+  - name: Skill Crafter
+    body: >
+      Contributed to Nexu's OpenClaw skill ecosystem. Building skills is how
+      Nexu's AI agents gain superpowers.
+    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f99e.png
+    trigger:
+      type: pull_request
+      merged: true
+      count: 1
+      labels:
+        - skills
+
+  - name: Controller Hacker
+    body: >
+      Contributed to the Nexu controller — the local control plane that
+      compiles OpenClaw config and orchestrates the runtime.
+    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/2699-fe0f.png
+    trigger:
+      type: pull_request
+      merged: true
+      count: 1
+      labels:
+        - controller
+
+  # ── DOCUMENTATION ────────────────────────────────────────────────────────────
+
+  - name: Doc Writer
+    body: >
+      Merged a documentation PR. Great docs are how open-source projects
+      become genuinely useful to the community.
+    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f4d6.png
+    trigger:
+      type: pull_request
+      merged: true
+      count: 1
+      labels:
+        - documentation
+
+  # ── ONBOARDING ───────────────────────────────────────────────────────────────
+
+  - name: Good First Step
+    body: >
+      Resolved a good-first-issue. Every expert was a beginner once — welcome
+      to the Nexu contributor community.
+    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f331.png
+    trigger:
+      type: pull_request
+      merged: true
+      count: 1
+      labels:
+        - good first issue
+
+  - name: Helper
+    body: >
+      Picked up and closed a help-wanted issue. You saw something that needed
+      doing and stepped up.
+    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f91d.png
+    trigger:
+      type: pull_request
+      merged: true
+      count: 1
+      labels:
+        - help wanted
+
+  # ── CORE CONTRIBUTOR MILESTONES ──────────────────────────────────────────────
+
+  - name: Rising Star
+    body: >
+      Five pull requests merged. You're picking up momentum — the team
+      recognizes your name now.
+    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f31f.png
+    trigger:
+      type: pull_request
+      merged: true
+      count: 5
+
+  - name: Regular
+    body: >
+      Ten pull requests merged. A familiar face in the codebase. You know
+      where things live and how they fit together.
+    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f948.png
+    trigger:
+      type: pull_request
+      merged: true
+      count: 10
+
+  - name: Core Contributor
+    body: >
+      Twenty-five pull requests merged. Nexu wouldn't be the same codebase
+      without your work.
+    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f947.png
+    trigger:
+      type: pull_request
+      merged: true
+      count: 25
+
+  - name: Nexu Legend
+    body: >
+      Fifty pull requests merged. You've shaped this project at a fundamental
+      level. Legendary status — earned, not given.
+    image: https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f3c6.png
+    trigger:
+      type: pull_request
+      merged: true
+      count: 50

--- a/apps/desktop/static/bundled-skills/libtv-video/SKILL.md
+++ b/apps/desktop/static/bundled-skills/libtv-video/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: LibTV Video
+name: LibTV - Image&Video（Seedance 2.0）
 description: Seedance 2.0 video & image generation via LibTV Gateway - AI text-to-video, image-to-video, video continuation, style transfer, and text-to-image using Seedance 2.0 model. Also supports Kling 3.0, Wan 2.6, Midjourney, Seedream 5.0. Trigger phrases: "seedance", "generate video", "make a video", "generate image", "make an image", "draw", "libtv", "liblib".
 homepage: https://www.liblib.tv/
 metadata:
@@ -12,32 +12,72 @@ metadata:
   }
 ---
 
-# LibTV Video / Image Generation
+# LibTV - Image & Video Generation (Seedance 2.0)
 
-Generate AI videos and images via LibTV Gateway. Supports text-to-video, image-to-video, video continuation, style transfer, short drama generation, and more.
+Generate AI **images** and **videos** through one bundled LibTV skill, powered by Seedance 2.0. Supports text-to-image, image-to-image, text-to-video, and image-to-video workflows, via both Nexu-managed Seedance execution and direct LibTV execution with a user-owned `sk-libtv-...` key.
 
-The backend agent automatically selects the best model. **When sending prompts, always append "use Seedance 2.0 model" to the message unless the user explicitly requests a different model.** Available models: Seedance 2.0, Kling 3.0/O3, Wan 2.6, Midjourney, Seedream 5.0.
+Key routing:
+
+- `mgk_...` keys use Nexu-managed Seedance through `https://seedance.nexu.io/`
+- `sk-libtv-...` keys use direct LibTV OpenAPI through `https://im.liblib.tv`
+
+Delivery architecture (currently Feishu only):
+- `create-session` captures `OPENCLAW_CHANNEL_TYPE` + `OPENCLAW_CHAT_ID`,
+  persists them as the session's `delivery` block, forks a detached
+  `wait-and-deliver` background process via `subprocess.Popen(...,
+  start_new_session=True)`, and returns immediately with a single-line
+  JSON submit confirmation on stdout.
+- The forked waiter polls the upstream LibTV API (Seedance gateway or
+  direct LibTV) and, on terminal success, shells out to
+  `feishu_send_video.py` — the same proven helper used by `medeo-video` —
+  which downloads each result URL, uploads it to Feishu's file API, and
+  posts a native media message to the originating chat.
+- The waiter's output is captured in `$NEXU_HOME/libtv-waiter-<id>.log`
+  for post-hoc debugging. A `delivered_at` timestamp is persisted when
+  the Feishu helper reports success, so re-invoking `wait-and-deliver`
+  on a delivered session is a safe no-op.
+
+No `sessions_spawn`, no subagent model-speech contract, no HTTP
+notification callback, no stale routing fields. Delivery is a direct
+HTTP call using stable per-user identifiers (`open_id` / `chat_id`)
+that never go stale the way the old `account_id` did.
+
+Multi-channel support is a follow-up: adding Discord / Slack / WeChat
+means dropping a new `<channel>_send_video.py` helper next to
+`feishu_send_video.py` and adding one branch in `_deliver_results`.
 
 ## Requirements
 
 - Python 3.8+
 - `apiKey` configured in `~/.nexu/libtv.json`
+- default `videoRatio` configured in `~/.nexu/libtv.json` or implicit default `16:9`
+- `mgk_...` keys target `https://seedance.nexu.io/`
+- `sk-libtv-...` keys target `https://im.liblib.tv`
 
 ## First-Time Setup
 
 If the user has not configured an API Key, guide them to:
-1. Contact the admin to obtain an API Key starting with `mgk_`
-2. Run: `python3 scripts/libtv_video.py setup --api-key mgk_yourkey`
+1. Choose the correct key type:
+   - Nexu-managed key: `mgk_...`
+   - personal LibTV key: `sk-libtv-...`
+2. Run: `python3 scripts/libtv_video.py setup --api-key <your_key> --video-ratio 16:9`
 3. Run: `python3 scripts/libtv_video.py check` to confirm the configuration is correct
+
+To change only the default ratio later:
+
+```bash
+python3 scripts/libtv_video.py update-ratio --video-ratio 9:16
+```
 
 ## Pre-Generation Check (must run before each generation)
 
 1. Run `python3 scripts/libtv_video.py check`
 2. Interpret the output:
    - "API Key not configured" → guide the user to contact the admin for a key, then run setup
-   - "Key valid, N uses remaining" → inform the user of remaining quota, proceed with generation
+   - Nexu-managed key valid with remaining uses → proceed with generation
+   - direct LibTV key configured → proceed with generation
    - "Key expired / exhausted" → guide the user to contact the admin, run update-key
-   - "Cannot connect to gateway" → suggest checking network connectivity
+   - "Cannot connect to gateway" or "Cannot connect to direct LibTV API" → suggest checking network connectivity
 3. Only proceed with generation after check passes
 
 ## Core Principle: Relay, Don't Create
@@ -56,13 +96,54 @@ You are a **messenger**, not a creator. The backend agent handles model selectio
 
 ## Video / Image Generation (async, non-blocking)
 
+### CRITICAL: always pass `--channel` and `--chat-id`
+
+Before running `create-session` you **must** extract the originating
+channel and the user's stable identifier from the inbound message
+metadata block and pass them as CLI args. Without these the background
+waiter cannot deliver the finished video back to the user automatically;
+the user will have to ask for the result manually.
+
+- For **Feishu**: the inbound user message has an `untrusted metadata`
+  JSON block containing `sender_id`. That value is the stable `open_id`
+  (always starts with `ou_`). Pass it as `--chat-id` and pass
+  `--channel feishu`.
+
+Example extraction and invocation:
+
+```text
+Conversation info (untrusted metadata):
+{
+  "message_id": "om_x100...",
+  "sender_id": "ou_33314772052f837a3cb2f919aa4605de",
+  ...
+}
+```
+
+becomes:
+
+```bash
+python3 scripts/libtv_video.py create-session "user's video description" \
+  --channel feishu \
+  --chat-id ou_33314772052f837a3cb2f919aa4605de
+```
+
+The `stdout` JSON returned by `create-session` includes a `deliverable`
+flag. If it is `false`, your `--channel` / `--chat-id` were missing and
+the user will have to ask you for the result later.
+
 ### Text-Only Generation
 
 ```bash
-python3 scripts/libtv_video.py create-session "user's video description"
+python3 scripts/libtv_video.py create-session "user's video description" \
+  --channel feishu --chat-id <ou_xxx from inbound metadata>
 ```
 
-The script automatically appends "please use Seedance 2.0" unless the user specifies another model.
+Message rules:
+
+- Nexu-managed `mgk_...` mode appends the Seedance 2.0 hint unless the user already chose a model
+- direct `sk-libtv-...` mode follows the upstream relay discipline and does not add the Seedance model hint
+- both modes relay the configured video ratio, defaulting to `16:9`
 
 ### Image+Text Generation (image-to-video)
 
@@ -78,15 +159,27 @@ python3 scripts/libtv_video.py create-session "user's description reference: {os
 ### Continue in Existing Session
 
 ```bash
-python3 scripts/libtv_video.py create-session "new description" --session-id SESSION_ID
+python3 scripts/libtv_video.py create-session "new description" \
+  --session-id SESSION_ID \
+  --channel feishu --chat-id <ou_xxx from inbound metadata>
 ```
 
 ### After Submission
 
-1. `create-session` returns immediately without blocking
-2. **Reply to the user immediately**: "Your video is being generated. It typically takes 1-3 minutes and will be sent to you automatically when ready."
-3. **Do not wait** — resume normal conversation
-4. A sub-agent will automatically wait in the background and deliver the results
+1. `create-session` returns immediately without blocking and prints a
+   single-line JSON `{"status":"submitted", "sessionId", "projectUuid",
+   "projectUrl", "channel", "deliverable", "note"}` to stdout.
+2. **Reply to the user immediately** using the `note` field as a hint:
+   "Your video task has been submitted and is now generating. I'll notify
+   you when it finishes."
+3. **Do not wait** — resume normal conversation.
+4. Under the hood, `create-session` has forked a detached `wait-and-deliver`
+   background process that polls the upstream API for you.
+5. When the job finishes, the background waiter delivers each result URL
+   as a native video message directly to the originating Feishu chat via
+   `feishu_send_video.py`. You do not need to speak the result yourself.
+6. If `deliverable` is `false` (no channel context captured), the user will
+   need to ask for the result explicitly via `query-session` or `recover`.
 
 ## When the User Asks "Is my video ready?"
 
@@ -101,9 +194,9 @@ python3 scripts/libtv_video.py create-session "new description" --session-id SES
 
 If you don't remember whether a video was previously generated:
 1. Run `python3 scripts/libtv_video.py recover`
-2. It reads historical sessions from the local persistence file and queries the gateway for latest status
+2. It reads historical sessions from the local persistence file and queries the correct backend for latest status
 3. Completed sessions → send the result URLs to the user directly
-4. Still in progress → inform the user it's still generating
+4. Still in progress → inform the user it's still generating and keep the periodic heartbeat schedule
 
 ## Presenting Results
 
@@ -115,14 +208,19 @@ Do NOT show the project canvas link while generation is in progress.
 
 ### URL Rules
 
-The only valid result URL prefix is `https://libtv-res.liblib.art/sd-gen-save-img/`. Any other domain (e.g. `medeo-res.liblib.art`) is a gateway proxy URL and must be ignored.
+The valid result URL prefixes are:
+
+- `https://libtv-res.liblib.art/sd-gen-save-img/`
+- `https://libtv-res.liblib.art/claw/`
+
+Any other domain (for example `medeo-res.liblib.art`) is not a final result URL and must be ignored.
 
 **Always present the URL exactly as extracted by the script.** Do not:
 - Rewrite or transform URLs
 - Use proxy/cache domain URLs as results
 - Fabricate URLs by guessing paths
 
-The `extract_result_urls()` function in the script extracts only `libtv-res.liblib.art/sd-gen-save-img/` URLs. Trust its output.
+The `extract_result_urls()` function in the script extracts only valid `libtv-res.liblib.art` result URLs. Trust its output.
 
 ## Multi-Session Discipline (CRITICAL)
 
@@ -173,13 +271,41 @@ When any command returns an error:
 | "Unsupported file type" | Only image and video files are supported |
 | "Cannot connect to gateway" | Check network connectivity |
 
+## Mandatory Guard Checklist
+
+This skill has a hard anti-hallucination rule. The model must verify each step before it can describe that step as successful.
+
+Submit step checks:
+- confirm `~/.nexu/libtv.json` exists and contains a non-empty `apiKey`
+- confirm the key starts with either `mgk_` or `sk-libtv-`
+- confirm `mgk_...` keys target `https://seedance.nexu.io/` unless a deliberate local test override is set
+- confirm `sk-libtv-...` keys target `https://im.liblib.tv` unless a deliberate local test override is set
+- never route a personal `sk-libtv-...` key through the Nexu Seedance gateway
+- confirm the effective video ratio is set, defaulting to `16:9`
+- confirm `create-session` returns a real `sessionId`
+- confirm `create-session` returns a real `projectUuid`
+- confirm the accepted session was persisted locally with matching `session_id`, `project_uuid`, `status=submitted`
+- after submit, use the `note` field from `create-session` stdout to acknowledge the submission to the user
+
+Background delivery checks (handled by the detached waiter, not by the model):
+- confirm success only when at least one result URL is extracted from the valid LibTV result domain
+- the waiter persists `delivered_at` after `feishu_send_video.py` returns success; re-running `wait-and-deliver` on a delivered session is a safe no-op
+- if `feishu_send_video.py` fails, the error is logged to `$NEXU_HOME/libtv-waiter-<session-id>.log`; the result URLs remain persisted locally so the user can ask `query-session` to retrieve them
+- if terminal polling times out, the session's `status` is set to `timeout`; the user will have to ask later via `query-session` or `recover`
+
+Output rule:
+- If any guard check fails, stop and return the explicit guard-check error
+- Never claim a video is ready until the terminal success checks have passed
+- Never invent session ids, project ids, URLs, or completion state
+
 ## Command Reference
 
 | Scenario | Command | Blocking? |
 |---|---|---|
-| First-time setup | `setup --api-key mgk_xxx` | No |
+| First-time setup | `setup --api-key <mgk_xxx|sk-libtv_xxx>` | No |
 | Check status | `check` | No |
-| Update key | `update-key --api-key mgk_xxx` | No |
+| Update key | `update-key --api-key <mgk_xxx|sk-libtv_xxx>` | No |
+| Update ratio | `update-ratio --video-ratio 9:16` | No |
 | Remove key | `remove-key` | No |
 | Upload file | `upload --file /path/to/file` | No |
 | **Create session / send message** | **`create-session "description"`** | **No** |

--- a/apps/desktop/static/bundled-skills/libtv-video/SKILL.md
+++ b/apps/desktop/static/bundled-skills/libtv-video/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: LibTV - Image&Video（Seedance 2.0）
+name: LibTV Video
 description: Seedance 2.0 video & image generation via LibTV Gateway - AI text-to-video, image-to-video, video continuation, style transfer, and text-to-image using Seedance 2.0 model. Also supports Kling 3.0, Wan 2.6, Midjourney, Seedream 5.0. Trigger phrases: "seedance", "generate video", "make a video", "generate image", "make an image", "draw", "libtv", "liblib".
 homepage: https://www.liblib.tv/
 metadata:
@@ -12,72 +12,32 @@ metadata:
   }
 ---
 
-# LibTV - Image & Video Generation (Seedance 2.0)
+# LibTV Video / Image Generation
 
-Generate AI **images** and **videos** through one bundled LibTV skill, powered by Seedance 2.0. Supports text-to-image, image-to-image, text-to-video, and image-to-video workflows, via both Nexu-managed Seedance execution and direct LibTV execution with a user-owned `sk-libtv-...` key.
+Generate AI videos and images via LibTV Gateway. Supports text-to-video, image-to-video, video continuation, style transfer, short drama generation, and more.
 
-Key routing:
-
-- `mgk_...` keys use Nexu-managed Seedance through `https://seedance.nexu.io/`
-- `sk-libtv-...` keys use direct LibTV OpenAPI through `https://im.liblib.tv`
-
-Delivery architecture (currently Feishu only):
-- `create-session` captures `OPENCLAW_CHANNEL_TYPE` + `OPENCLAW_CHAT_ID`,
-  persists them as the session's `delivery` block, forks a detached
-  `wait-and-deliver` background process via `subprocess.Popen(...,
-  start_new_session=True)`, and returns immediately with a single-line
-  JSON submit confirmation on stdout.
-- The forked waiter polls the upstream LibTV API (Seedance gateway or
-  direct LibTV) and, on terminal success, shells out to
-  `feishu_send_video.py` — the same proven helper used by `medeo-video` —
-  which downloads each result URL, uploads it to Feishu's file API, and
-  posts a native media message to the originating chat.
-- The waiter's output is captured in `$NEXU_HOME/libtv-waiter-<id>.log`
-  for post-hoc debugging. A `delivered_at` timestamp is persisted when
-  the Feishu helper reports success, so re-invoking `wait-and-deliver`
-  on a delivered session is a safe no-op.
-
-No `sessions_spawn`, no subagent model-speech contract, no HTTP
-notification callback, no stale routing fields. Delivery is a direct
-HTTP call using stable per-user identifiers (`open_id` / `chat_id`)
-that never go stale the way the old `account_id` did.
-
-Multi-channel support is a follow-up: adding Discord / Slack / WeChat
-means dropping a new `<channel>_send_video.py` helper next to
-`feishu_send_video.py` and adding one branch in `_deliver_results`.
+The backend agent automatically selects the best model. **When sending prompts, always append "use Seedance 2.0 model" to the message unless the user explicitly requests a different model.** Available models: Seedance 2.0, Kling 3.0/O3, Wan 2.6, Midjourney, Seedream 5.0.
 
 ## Requirements
 
 - Python 3.8+
 - `apiKey` configured in `~/.nexu/libtv.json`
-- default `videoRatio` configured in `~/.nexu/libtv.json` or implicit default `16:9`
-- `mgk_...` keys target `https://seedance.nexu.io/`
-- `sk-libtv-...` keys target `https://im.liblib.tv`
 
 ## First-Time Setup
 
 If the user has not configured an API Key, guide them to:
-1. Choose the correct key type:
-   - Nexu-managed key: `mgk_...`
-   - personal LibTV key: `sk-libtv-...`
-2. Run: `python3 scripts/libtv_video.py setup --api-key <your_key> --video-ratio 16:9`
+1. Contact the admin to obtain an API Key starting with `mgk_`
+2. Run: `python3 scripts/libtv_video.py setup --api-key mgk_yourkey`
 3. Run: `python3 scripts/libtv_video.py check` to confirm the configuration is correct
-
-To change only the default ratio later:
-
-```bash
-python3 scripts/libtv_video.py update-ratio --video-ratio 9:16
-```
 
 ## Pre-Generation Check (must run before each generation)
 
 1. Run `python3 scripts/libtv_video.py check`
 2. Interpret the output:
    - "API Key not configured" → guide the user to contact the admin for a key, then run setup
-   - Nexu-managed key valid with remaining uses → proceed with generation
-   - direct LibTV key configured → proceed with generation
+   - "Key valid, N uses remaining" → inform the user of remaining quota, proceed with generation
    - "Key expired / exhausted" → guide the user to contact the admin, run update-key
-   - "Cannot connect to gateway" or "Cannot connect to direct LibTV API" → suggest checking network connectivity
+   - "Cannot connect to gateway" → suggest checking network connectivity
 3. Only proceed with generation after check passes
 
 ## Core Principle: Relay, Don't Create
@@ -96,54 +56,13 @@ You are a **messenger**, not a creator. The backend agent handles model selectio
 
 ## Video / Image Generation (async, non-blocking)
 
-### CRITICAL: always pass `--channel` and `--chat-id`
-
-Before running `create-session` you **must** extract the originating
-channel and the user's stable identifier from the inbound message
-metadata block and pass them as CLI args. Without these the background
-waiter cannot deliver the finished video back to the user automatically;
-the user will have to ask for the result manually.
-
-- For **Feishu**: the inbound user message has an `untrusted metadata`
-  JSON block containing `sender_id`. That value is the stable `open_id`
-  (always starts with `ou_`). Pass it as `--chat-id` and pass
-  `--channel feishu`.
-
-Example extraction and invocation:
-
-```text
-Conversation info (untrusted metadata):
-{
-  "message_id": "om_x100...",
-  "sender_id": "ou_33314772052f837a3cb2f919aa4605de",
-  ...
-}
-```
-
-becomes:
-
-```bash
-python3 scripts/libtv_video.py create-session "user's video description" \
-  --channel feishu \
-  --chat-id ou_33314772052f837a3cb2f919aa4605de
-```
-
-The `stdout` JSON returned by `create-session` includes a `deliverable`
-flag. If it is `false`, your `--channel` / `--chat-id` were missing and
-the user will have to ask you for the result later.
-
 ### Text-Only Generation
 
 ```bash
-python3 scripts/libtv_video.py create-session "user's video description" \
-  --channel feishu --chat-id <ou_xxx from inbound metadata>
+python3 scripts/libtv_video.py create-session "user's video description"
 ```
 
-Message rules:
-
-- Nexu-managed `mgk_...` mode appends the Seedance 2.0 hint unless the user already chose a model
-- direct `sk-libtv-...` mode follows the upstream relay discipline and does not add the Seedance model hint
-- both modes relay the configured video ratio, defaulting to `16:9`
+The script automatically appends "please use Seedance 2.0" unless the user specifies another model.
 
 ### Image+Text Generation (image-to-video)
 
@@ -159,27 +78,15 @@ python3 scripts/libtv_video.py create-session "user's description reference: {os
 ### Continue in Existing Session
 
 ```bash
-python3 scripts/libtv_video.py create-session "new description" \
-  --session-id SESSION_ID \
-  --channel feishu --chat-id <ou_xxx from inbound metadata>
+python3 scripts/libtv_video.py create-session "new description" --session-id SESSION_ID
 ```
 
 ### After Submission
 
-1. `create-session` returns immediately without blocking and prints a
-   single-line JSON `{"status":"submitted", "sessionId", "projectUuid",
-   "projectUrl", "channel", "deliverable", "note"}` to stdout.
-2. **Reply to the user immediately** using the `note` field as a hint:
-   "Your video task has been submitted and is now generating. I'll notify
-   you when it finishes."
-3. **Do not wait** — resume normal conversation.
-4. Under the hood, `create-session` has forked a detached `wait-and-deliver`
-   background process that polls the upstream API for you.
-5. When the job finishes, the background waiter delivers each result URL
-   as a native video message directly to the originating Feishu chat via
-   `feishu_send_video.py`. You do not need to speak the result yourself.
-6. If `deliverable` is `false` (no channel context captured), the user will
-   need to ask for the result explicitly via `query-session` or `recover`.
+1. `create-session` returns immediately without blocking
+2. **Reply to the user immediately**: "Your video is being generated. It typically takes 1-3 minutes and will be sent to you automatically when ready."
+3. **Do not wait** — resume normal conversation
+4. A sub-agent will automatically wait in the background and deliver the results
 
 ## When the User Asks "Is my video ready?"
 
@@ -194,9 +101,9 @@ python3 scripts/libtv_video.py create-session "new description" \
 
 If you don't remember whether a video was previously generated:
 1. Run `python3 scripts/libtv_video.py recover`
-2. It reads historical sessions from the local persistence file and queries the correct backend for latest status
+2. It reads historical sessions from the local persistence file and queries the gateway for latest status
 3. Completed sessions → send the result URLs to the user directly
-4. Still in progress → inform the user it's still generating and keep the periodic heartbeat schedule
+4. Still in progress → inform the user it's still generating
 
 ## Presenting Results
 
@@ -208,19 +115,14 @@ Do NOT show the project canvas link while generation is in progress.
 
 ### URL Rules
 
-The valid result URL prefixes are:
-
-- `https://libtv-res.liblib.art/sd-gen-save-img/`
-- `https://libtv-res.liblib.art/claw/`
-
-Any other domain (for example `medeo-res.liblib.art`) is not a final result URL and must be ignored.
+The only valid result URL prefix is `https://libtv-res.liblib.art/sd-gen-save-img/`. Any other domain (e.g. `medeo-res.liblib.art`) is a gateway proxy URL and must be ignored.
 
 **Always present the URL exactly as extracted by the script.** Do not:
 - Rewrite or transform URLs
 - Use proxy/cache domain URLs as results
 - Fabricate URLs by guessing paths
 
-The `extract_result_urls()` function in the script extracts only valid `libtv-res.liblib.art` result URLs. Trust its output.
+The `extract_result_urls()` function in the script extracts only `libtv-res.liblib.art/sd-gen-save-img/` URLs. Trust its output.
 
 ## Multi-Session Discipline (CRITICAL)
 
@@ -271,41 +173,13 @@ When any command returns an error:
 | "Unsupported file type" | Only image and video files are supported |
 | "Cannot connect to gateway" | Check network connectivity |
 
-## Mandatory Guard Checklist
-
-This skill has a hard anti-hallucination rule. The model must verify each step before it can describe that step as successful.
-
-Submit step checks:
-- confirm `~/.nexu/libtv.json` exists and contains a non-empty `apiKey`
-- confirm the key starts with either `mgk_` or `sk-libtv-`
-- confirm `mgk_...` keys target `https://seedance.nexu.io/` unless a deliberate local test override is set
-- confirm `sk-libtv-...` keys target `https://im.liblib.tv` unless a deliberate local test override is set
-- never route a personal `sk-libtv-...` key through the Nexu Seedance gateway
-- confirm the effective video ratio is set, defaulting to `16:9`
-- confirm `create-session` returns a real `sessionId`
-- confirm `create-session` returns a real `projectUuid`
-- confirm the accepted session was persisted locally with matching `session_id`, `project_uuid`, `status=submitted`
-- after submit, use the `note` field from `create-session` stdout to acknowledge the submission to the user
-
-Background delivery checks (handled by the detached waiter, not by the model):
-- confirm success only when at least one result URL is extracted from the valid LibTV result domain
-- the waiter persists `delivered_at` after `feishu_send_video.py` returns success; re-running `wait-and-deliver` on a delivered session is a safe no-op
-- if `feishu_send_video.py` fails, the error is logged to `$NEXU_HOME/libtv-waiter-<session-id>.log`; the result URLs remain persisted locally so the user can ask `query-session` to retrieve them
-- if terminal polling times out, the session's `status` is set to `timeout`; the user will have to ask later via `query-session` or `recover`
-
-Output rule:
-- If any guard check fails, stop and return the explicit guard-check error
-- Never claim a video is ready until the terminal success checks have passed
-- Never invent session ids, project ids, URLs, or completion state
-
 ## Command Reference
 
 | Scenario | Command | Blocking? |
 |---|---|---|
-| First-time setup | `setup --api-key <mgk_xxx|sk-libtv_xxx>` | No |
+| First-time setup | `setup --api-key mgk_xxx` | No |
 | Check status | `check` | No |
-| Update key | `update-key --api-key <mgk_xxx|sk-libtv_xxx>` | No |
-| Update ratio | `update-ratio --video-ratio 9:16` | No |
+| Update key | `update-key --api-key mgk_xxx` | No |
 | Remove key | `remove-key` | No |
 | Upload file | `upload --file /path/to/file` | No |
 | **Create session / send message** | **`create-session "description"`** | **No** |


### PR DESCRIPTION
## What

Add `.vaunt/config.yml` to enable the [Vaunt](https://vaunt.dev) contributor achievement system.

## Why

Gamified contribution recognition to engage and reward community contributors — achievements for starring, filing bugs, merging PRs, domain expertise (desktop/skills/controller), and milestone tiers.

## How

19 achievements across 6 categories:
- **Welcome**: Stargazer, First Report, Lift Off
- **Bug hunting**: Bug Spotter, Bug Crusher, Exterminator
- **Feature building**: Spark, Feature Architect
- **Improvement**: Polish Pro, Craftsmanship
- **Domain experts**: Desktop Wizard, Skill Crafter, Controller Hacker, Doc Writer, Good First Step, Helper
- **Milestones**: Rising Star (5 PRs), Regular (10), Core Contributor (25), Nexu Legend (50)

Badge icons use Twemoji CDN. Config follows the official Vaunt `v0.0.1` schema.

## Affected areas

- [ ] Desktop app (Electron shell)
- [ ] Controller (backend / API)
- [ ] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [x] Build / CI / Tooling

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] No credentials or tokens in code or logs