### PR TITLE
fix: improve channel connect error diagnostics

### DIFF
--- a/apps/controller/openapi.json
+++ b/apps/controller/openapi.json
@@ -4218,7 +4218,7 @@
               }
             }
           },
-          "409": {
+          "422": {
             "description": "Invalid credentials",
             "content": {
               "application/json": {
@@ -4227,10 +4227,192 @@
                   "properties": {
                     "message": {
                       "type": "string"
+                    },
+                    "code": {
+                      "type": "string",
+                      "enum": [
+                        "already_connected",
+                        "app_id_mismatch",
+                        "invalid_credentials",
+                        "network_error",
+                        "proxy_error",
+                        "sync_failed",
+                        "timeout",
+                        "upstream_http_error"
+                      ]
+                    },
+                    "requestId": {
+                      "type": "string"
+                    },
+                    "retryable": {
+                      "type": "boolean"
+                    },
+                    "phase": {
+                      "type": "string",
+                      "enum": [
+                        "verify_credentials",
+                        "verify_app",
+                        "persist_config",
+                        "sync_runtime"
+                      ]
                     }
                   },
                   "required": [
-                    "message"
+                    "message",
+                    "code",
+                    "requestId",
+                    "retryable",
+                    "phase"
+                  ]
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream network or proxy failure",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string",
+                      "enum": [
+                        "already_connected",
+                        "app_id_mismatch",
+                        "invalid_credentials",
+                        "network_error",
+                        "proxy_error",
+                        "sync_failed",
+                        "timeout",
+                        "upstream_http_error"
+                      ]
+                    },
+                    "requestId": {
+                      "type": "string"
+                    },
+                    "retryable": {
+                      "type": "boolean"
+                    },
+                    "phase": {
+                      "type": "string",
+                      "enum": [
+                        "verify_credentials",
+                        "verify_app",
+                        "persist_config",
+                        "sync_runtime"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code",
+                    "requestId",
+                    "retryable",
+                    "phase"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Local runtime sync failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string",
+                      "enum": [
+                        "already_connected",
+                        "app_id_mismatch",
+                        "invalid_credentials",
+                        "network_error",
+                        "proxy_error",
+                        "sync_failed",
+                        "timeout",
+                        "upstream_http_error"
+                      ]
+                    },
+                    "requestId": {
+                      "type": "string"
+                    },
+                    "retryable": {
+                      "type": "boolean"
+                    },
+                    "phase": {
+                      "type": "string",
+                      "enum": [
+                        "verify_credentials",
+                        "verify_app",
+                        "persist_config",
+                        "sync_runtime"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code",
+                    "requestId",
+                    "retryable",
+                    "phase"
+                  ]
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "Upstream timeout",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string",
+                      "enum": [
+                        "already_connected",
+                        "app_id_mismatch",
+                        "invalid_credentials",
+                        "network_error",
+                        "proxy_error",
+                        "sync_failed",
+                        "timeout",
+                        "upstream_http_error"
+                      ]
+                    },
+                    "requestId": {
+                      "type": "string"
+                    },
+                    "retryable": {
+                      "type": "boolean"
+                    },
+                    "phase": {
+                      "type": "string",
+                      "enum": [
+                        "verify_credentials",
+                        "verify_app",
+                        "persist_config",
+                        "sync_runtime"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code",
+                    "requestId",
+                    "retryable",
+                    "phase"
                   ]
                 }
               }
@@ -4468,7 +4650,7 @@
               }
             }
           },
-          "409": {
+          "422": {
             "description": "Invalid credentials",
             "content": {
               "application/json": {
@@ -4477,10 +4659,192 @@
                   "properties": {
                     "message": {
                       "type": "string"
+                    },
+                    "code": {
+                      "type": "string",
+                      "enum": [
+                        "already_connected",
+                        "app_id_mismatch",
+                        "invalid_credentials",
+                        "network_error",
+                        "proxy_error",
+                        "sync_failed",
+                        "timeout",
+                        "upstream_http_error"
+                      ]
+                    },
+                    "requestId": {
+                      "type": "string"
+                    },
+                    "retryable": {
+                      "type": "boolean"
+                    },
+                    "phase": {
+                      "type": "string",
+                      "enum": [
+                        "verify_credentials",
+                        "verify_app",
+                        "persist_config",
+                        "sync_runtime"
+                      ]
                     }
                   },
                   "required": [
-                    "message"
+                    "message",
+                    "code",
+                    "requestId",
+                    "retryable",
+                    "phase"
+                  ]
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream network or proxy failure",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string",
+                      "enum": [
+                        "already_connected",
+                        "app_id_mismatch",
+                        "invalid_credentials",
+                        "network_error",
+                        "proxy_error",
+                        "sync_failed",
+                        "timeout",
+                        "upstream_http_error"
+                      ]
+                    },
+                    "requestId": {
+                      "type": "string"
+                    },
+                    "retryable": {
+                      "type": "boolean"
+                    },
+                    "phase": {
+                      "type": "string",
+                      "enum": [
+                        "verify_credentials",
+                        "verify_app",
+                        "persist_config",
+                        "sync_runtime"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code",
+                    "requestId",
+                    "retryable",
+                    "phase"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Local runtime sync failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string",
+                      "enum": [
+                        "already_connected",
+                        "app_id_mismatch",
+                        "invalid_credentials",
+                        "network_error",
+                        "proxy_error",
+                        "sync_failed",
+                        "timeout",
+                        "upstream_http_error"
+                      ]
+                    },
+                    "requestId": {
+                      "type": "string"
+                    },
+                    "retryable": {
+                      "type": "boolean"
+                    },
+                    "phase": {
+                      "type": "string",
+                      "enum": [
+                        "verify_credentials",
+                        "verify_app",
+                        "persist_config",
+                        "sync_runtime"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code",
+                    "requestId",
+                    "retryable",
+                    "phase"
+                  ]
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "Upstream timeout",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string",
+                      "enum": [
+                        "already_connected",
+                        "app_id_mismatch",
+                        "invalid_credentials",
+                        "network_error",
+                        "proxy_error",
+                        "sync_failed",
+                        "timeout",
+                        "upstream_http_error"
+                      ]
+                    },
+                    "requestId": {
+                      "type": "string"
+                    },
+                    "retryable": {
+                      "type": "boolean"
+                    },
+                    "phase": {
+                      "type": "string",
+                      "enum": [
+                        "verify_credentials",
+                        "verify_app",
+                        "persist_config",
+                        "sync_runtime"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code",
+                    "requestId",
+                    "retryable",
+                    "phase"
                   ]
                 }
               }

--- a/apps/controller/src/lib/channel-connect-error.ts
+++ b/apps/controller/src/lib/channel-connect-error.ts
@@ -1,0 +1,42 @@
+import type {
+  ChannelConnectErrorCode,
+  ChannelConnectPhase,
+} from "@nexu/shared";
+
+type ChannelConnectErrorStatus = 422 | 502 | 503 | 504;
+
+type ChannelConnectErrorOptions = {
+  message: string;
+  code: ChannelConnectErrorCode;
+  status: ChannelConnectErrorStatus;
+  retryable: boolean;
+  phase: ChannelConnectPhase;
+  upstreamHost?: string | null;
+  upstreamStatus?: number | null;
+};
+
+export class ChannelConnectError extends Error {
+  readonly code: ChannelConnectErrorCode;
+  readonly status: ChannelConnectErrorStatus;
+  readonly retryable: boolean;
+  readonly phase: ChannelConnectPhase;
+  readonly upstreamHost: string | null;
+  readonly upstreamStatus: number | null;
+
+  constructor(options: ChannelConnectErrorOptions) {
+    super(options.message);
+    this.name = "ChannelConnectError";
+    this.code = options.code;
+    this.status = options.status;
+    this.retryable = options.retryable;
+    this.phase = options.phase;
+    this.upstreamHost = options.upstreamHost ?? null;
+    this.upstreamStatus = options.upstreamStatus ?? null;
+  }
+}
+
+export function isChannelConnectError(
+  error: unknown,
+): error is ChannelConnectError {
+  return error instanceof ChannelConnectError;
+}

--- a/apps/controller/src/routes/channel-routes.ts
+++ b/apps/controller/src/routes/channel-routes.ts
@@ -1,6 +1,7 @@
 import { type OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import {
   botQuotaResponseSchema,
+  channelConnectErrorSchema,
   channelListResponseSchema,
   channelResponseSchema,
   connectDingtalkSchema,
@@ -23,11 +24,223 @@ import {
   whatsappQrWaitResponseSchema,
 } from "@nexu/shared";
 import type { ControllerContainer } from "../app/container.js";
+import { isChannelConnectError } from "../lib/channel-connect-error.js";
 import { logger } from "../lib/logger.js";
+import {
+  readProxyFetchEnv,
+  redactProxyUrl,
+  shouldBypassProxy,
+} from "../lib/proxy-fetch.js";
 import type { ControllerBindings } from "../types.js";
 
 const channelIdParamSchema = z.object({ channelId: z.string() });
 const errorSchema = z.object({ message: z.string() });
+type ControllerLocale = "en" | "zh-CN";
+
+function getOpenclawOrigin(container: ControllerContainer): string | null {
+  try {
+    return new URL(container.env.openclawBaseUrl).origin;
+  } catch {
+    return null;
+  }
+}
+
+async function getControllerLocale(
+  container: ControllerContainer,
+): Promise<ControllerLocale> {
+  try {
+    return await container.configStore.getDesktopLocale();
+  } catch {
+    return "en";
+  }
+}
+
+function localizeChannelConnectMessage(
+  error: unknown,
+  locale: ControllerLocale,
+): string {
+  if (!isChannelConnectError(error)) {
+    return locale === "zh-CN"
+      ? "连接失败，请稍后重试。"
+      : "Connection failed. Please try again.";
+  }
+
+  if (locale === "zh-CN") {
+    switch (error.code) {
+      case "invalid_credentials":
+        return "凭证无效，请检查后重试。";
+      case "app_id_mismatch":
+        return "Application ID 与 Bot Token 不匹配，请检查后重试。";
+      case "timeout":
+        return "请求超时，请检查网络或代理设置后重试。";
+      case "network_error":
+      case "proxy_error":
+        return "网络请求失败，请检查网络或代理设置后重试。";
+      case "sync_failed":
+        return error.phase === "persist_config"
+          ? "凭证已校验，但本地保存配置失败，请稍后重试。"
+          : "凭证已校验，但本地运行时同步失败，请稍后重试。";
+      case "upstream_http_error":
+        return "上游服务返回异常，请稍后重试。";
+      case "already_connected":
+        return "渠道已连接，正在刷新...";
+    }
+  }
+
+  switch (error.code) {
+    case "invalid_credentials":
+      return "Credentials are invalid. Check them and try again.";
+    case "app_id_mismatch":
+      return "Application ID does not match the provided Bot Token.";
+    case "timeout":
+      return "The request timed out. Check your network or proxy settings and try again.";
+    case "network_error":
+    case "proxy_error":
+      return "The network request failed. Check your network or proxy settings and try again.";
+    case "sync_failed":
+      return error.phase === "persist_config"
+        ? "Credentials were verified, but saving the local channel config failed. Please try again."
+        : "Credentials were verified, but syncing the local runtime failed. Please try again.";
+    case "upstream_http_error":
+      return "The upstream service returned an error. Please try again later.";
+    case "already_connected":
+      return "Channel already connected, refreshing...";
+  }
+}
+
+function getChannelConnectErrorResponse(
+  requestId: string,
+  locale: ControllerLocale,
+  error: unknown,
+) {
+  if (isChannelConnectError(error)) {
+    return {
+      status: error.status,
+      body: {
+        message: localizeChannelConnectMessage(error, locale),
+        code: error.code,
+        requestId,
+        retryable: error.retryable,
+        phase: error.phase,
+      },
+      upstreamHost: error.upstreamHost,
+      upstreamStatus: error.upstreamStatus,
+    } as const;
+  }
+
+  return {
+    status: 502,
+    body: {
+      message: localizeChannelConnectMessage(error, locale),
+      code: "network_error",
+      requestId,
+      retryable: true,
+      phase: "verify_credentials",
+    },
+    upstreamHost: null,
+    upstreamStatus: null,
+  } as const;
+}
+
+function logChannelConnectFailure(
+  container: ControllerContainer,
+  input: {
+    requestId: string;
+    channel: "discord" | "telegram";
+    locale: ControllerLocale;
+    error: unknown;
+  },
+): {
+  status: 422 | 502 | 503 | 504;
+  body: z.infer<typeof channelConnectErrorSchema>;
+} {
+  const response = getChannelConnectErrorResponse(
+    input.requestId,
+    input.locale,
+    input.error,
+  );
+  const proxyEnv = readProxyFetchEnv();
+  const proxyTargetBypassed = response.upstreamHost
+    ? shouldBypassProxy(response.upstreamHost, proxyEnv.noProxy)
+    : null;
+
+  logger.error(
+    {
+      requestId: input.requestId,
+      channel: input.channel,
+      error:
+        input.error instanceof Error
+          ? input.error.message
+          : String(input.error),
+      errorCode: response.body.code,
+      errorPhase: response.body.phase,
+      retryable: response.body.retryable,
+      httpStatus: response.status,
+      upstreamHost: response.upstreamHost,
+      upstreamStatus: response.upstreamStatus,
+      proxy: {
+        httpProxyRedacted: redactProxyUrl(proxyEnv.httpProxy),
+        httpsProxyRedacted: redactProxyUrl(proxyEnv.httpsProxy),
+        allProxyRedacted: redactProxyUrl(proxyEnv.allProxy),
+        noProxy: proxyEnv.noProxy,
+        bypassedForUpstream: proxyTargetBypassed,
+      },
+      runtimeState: {
+        status: container.runtimeState.status,
+        configSyncStatus: container.runtimeState.configSyncStatus,
+        skillsSyncStatus: container.runtimeState.skillsSyncStatus,
+        templatesSyncStatus: container.runtimeState.templatesSyncStatus,
+        gatewayStatus: container.runtimeState.gatewayStatus,
+        lastGatewayProbeAt: container.runtimeState.lastGatewayProbeAt,
+        lastGatewayError: container.runtimeState.lastGatewayError,
+      },
+      runtimeEnv: {
+        manageOpenclawProcess: container.env.manageOpenclawProcess,
+        gatewayProbeEnabled: container.env.gatewayProbeEnabled,
+        openclawBaseUrl: getOpenclawOrigin(container),
+      },
+    },
+    "channel_connect_failure",
+  );
+
+  void container.runtimeHealth
+    .probe()
+    .then((runtimeHealth) => {
+      logger.warn(
+        {
+          requestId: input.requestId,
+          channel: input.channel,
+          errorCode: response.body.code,
+          errorPhase: response.body.phase,
+          runtimeHealth,
+          process: {
+            nodeVersion: process.version,
+            platform: process.platform,
+            arch: process.arch,
+          },
+        },
+        "channel_connect_failure_context",
+      );
+    })
+    .catch((captureError: unknown) => {
+      logger.warn(
+        {
+          requestId: input.requestId,
+          channel: input.channel,
+          error:
+            captureError instanceof Error
+              ? captureError.message
+              : String(captureError),
+        },
+        "channel_connect_failure_context_failed",
+      );
+    });
+
+  return {
+    status: response.status,
+    body: response.body,
+  };
+}
 
 export function registerChannelRoutes(
   app: OpenAPIHono<ControllerBindings>,
@@ -159,9 +372,29 @@ export function registerChannelRoutes(
           content: { "application/json": { schema: channelResponseSchema } },
           description: "Connected discord channel",
         },
-        409: {
-          content: { "application/json": { schema: errorSchema } },
+        422: {
+          content: {
+            "application/json": { schema: channelConnectErrorSchema },
+          },
           description: "Invalid credentials",
+        },
+        502: {
+          content: {
+            "application/json": { schema: channelConnectErrorSchema },
+          },
+          description: "Upstream network or proxy failure",
+        },
+        503: {
+          content: {
+            "application/json": { schema: channelConnectErrorSchema },
+          },
+          description: "Local runtime sync failed",
+        },
+        504: {
+          content: {
+            "application/json": { schema: channelConnectErrorSchema },
+          },
+          description: "Upstream timeout",
         },
       },
     }),
@@ -172,17 +405,15 @@ export function registerChannelRoutes(
           200,
         );
       } catch (error) {
-        logger.error(
-          { error: error instanceof Error ? error.message : String(error) },
-          "channel_connect_error_discord",
-        );
-        return c.json(
-          {
-            message:
-              error instanceof Error ? error.message : "Discord connect failed",
-          },
-          409,
-        );
+        const requestId = c.get("requestId");
+        const locale = await getControllerLocale(container);
+        const response = logChannelConnectFailure(container, {
+          requestId,
+          channel: "discord",
+          locale,
+          error,
+        });
+        return c.json(response.body, response.status);
       }
     },
   );
@@ -246,9 +477,29 @@ export function registerChannelRoutes(
           content: { "application/json": { schema: channelResponseSchema } },
           description: "Connected telegram channel",
         },
-        409: {
-          content: { "application/json": { schema: errorSchema } },
+        422: {
+          content: {
+            "application/json": { schema: channelConnectErrorSchema },
+          },
           description: "Invalid credentials",
+        },
+        502: {
+          content: {
+            "application/json": { schema: channelConnectErrorSchema },
+          },
+          description: "Upstream network or proxy failure",
+        },
+        503: {
+          content: {
+            "application/json": { schema: channelConnectErrorSchema },
+          },
+          description: "Local runtime sync failed",
+        },
+        504: {
+          content: {
+            "application/json": { schema: channelConnectErrorSchema },
+          },
+          description: "Upstream timeout",
         },
       },
     }),
@@ -259,19 +510,15 @@ export function registerChannelRoutes(
           200,
         );
       } catch (error) {
-        logger.error(
-          { error: error instanceof Error ? error.message : String(error) },
-          "channel_connect_error_telegram",
-        );
-        return c.json(
-          {
-            message:
-              error instanceof Error
-                ? error.message
-                : "Telegram connect failed",
-          },
-          409,
-        );
+        const requestId = c.get("requestId");
+        const locale = await getControllerLocale(container);
+        const response = logChannelConnectFailure(container, {
+          requestId,
+          channel: "telegram",
+          locale,
+          error,
+        });
+        return c.json(response.body, response.status);
       }
     },
   );

--- a/apps/controller/src/routes/channel-routes.ts
+++ b/apps/controller/src/routes/channel-routes.ts
@@ -204,7 +204,7 @@ function logChannelConnectFailure(
   );
 
   void container.runtimeHealth
-    .probe()
+    .probe({ timeoutMs: 1500 })
     .then((runtimeHealth) => {
       logger.warn(
         {

--- a/apps/controller/src/runtime/runtime-health.ts
+++ b/apps/controller/src/runtime/runtime-health.ts
@@ -5,7 +5,9 @@ import { resolveOpenclawGatewayBaseUrl } from "./openclaw-gateway-url.js";
 export class RuntimeHealth {
   constructor(private readonly env: ControllerEnv) {}
 
-  async probe(): Promise<{ ok: boolean; status: number | null }> {
+  async probe(options?: {
+    timeoutMs?: number;
+  }): Promise<{ ok: boolean; status: number | null }> {
     if (!this.env.gatewayProbeEnabled) {
       return { ok: true, status: null };
     }
@@ -13,7 +15,7 @@ export class RuntimeHealth {
     try {
       const response = await proxyFetch(
         new URL("/health", resolveOpenclawGatewayBaseUrl(this.env)),
-        { timeoutMs: 1500 },
+        options?.timeoutMs ? { timeoutMs: options.timeoutMs } : undefined,
       );
       return {
         ok: response.ok,

--- a/apps/controller/src/runtime/runtime-health.ts
+++ b/apps/controller/src/runtime/runtime-health.ts
@@ -13,6 +13,7 @@ export class RuntimeHealth {
     try {
       const response = await proxyFetch(
         new URL("/health", resolveOpenclawGatewayBaseUrl(this.env)),
+        { timeoutMs: 1500 },
       );
       return {
         ok: response.ok,

--- a/apps/controller/src/services/channel-service.ts
+++ b/apps/controller/src/services/channel-service.ts
@@ -25,6 +25,7 @@ import type {
   ConnectWecomInput,
 } from "@nexu/shared";
 import type { ControllerEnv } from "../app/env.js";
+import { ChannelConnectError } from "../lib/channel-connect-error.js";
 import { logger } from "../lib/logger.js";
 import { proxyFetch } from "../lib/proxy-fetch.js";
 import type { OpenClawProcessManager } from "../runtime/openclaw-process.js";
@@ -59,6 +60,8 @@ const DINGTALK_PLUGIN_ID = "dingtalk-connector";
 const WECOM_PLUGIN_ID = "wecom";
 const LEGACY_WECOM_PLUGIN_ID = "wecom-openclaw-plugin";
 const QQBOT_PLUGIN_ID = "openclaw-qqbot";
+const DISCORD_API_ORIGIN = "https://discord.com";
+const TELEGRAM_API_ORIGIN = "https://api.telegram.org";
 
 type ActiveWechatLogin = {
   sessionKey: string;
@@ -811,49 +814,114 @@ export class ChannelService {
 
   async connectDiscord(input: ConnectDiscordInput) {
     logger.info({ appId: input.appId }, "discord_connect_start");
-    const userResp = await proxyFetch("https://discord.com/api/v10/users/@me", {
-      headers: { Authorization: `Bot ${input.botToken}` },
-      timeoutMs: 5000,
-    });
+    let userResp: Response;
+    try {
+      userResp = await proxyFetch("https://discord.com/api/v10/users/@me", {
+        headers: { Authorization: `Bot ${input.botToken}` },
+        timeoutMs: 5000,
+      });
+    } catch (error) {
+      throw this.toUpstreamConnectError(error, {
+        channel: "discord",
+        phase: "verify_credentials",
+        upstreamHost: DISCORD_API_ORIGIN,
+      });
+    }
+
     if (!userResp.ok) {
       logger.error(
         { appId: input.appId, status: userResp.status },
         "discord_connect_verify_failed",
       );
-      throw new Error(
+      throw new ChannelConnectError(
         userResp.status === 401
-          ? "Invalid Discord bot token"
-          : `Discord API error (${userResp.status})`,
+          ? {
+              message: "Invalid Discord bot token",
+              code: "invalid_credentials",
+              status: 422,
+              retryable: false,
+              phase: "verify_credentials",
+              upstreamHost: DISCORD_API_ORIGIN,
+              upstreamStatus: userResp.status,
+            }
+          : {
+              message: `Discord API error (${userResp.status})`,
+              code: "upstream_http_error",
+              status: 502,
+              retryable: userResp.status >= 500,
+              phase: "verify_credentials",
+              upstreamHost: DISCORD_API_ORIGIN,
+              upstreamStatus: userResp.status,
+            },
       );
     }
 
     const userData = (await userResp.json()) as { id?: string };
 
-    const appResp = await proxyFetch(
-      "https://discord.com/api/v10/applications/@me",
-      {
-        headers: { Authorization: `Bot ${input.botToken}` },
-        timeoutMs: 5000,
-      },
-    );
-    if (appResp.ok) {
-      const appData = (await appResp.json()) as { id: string };
-      if (appData.id !== input.appId) {
-        logger.error(
-          { expected: input.appId, actual: appData.id },
-          "discord_connect_app_id_mismatch",
-        );
-        throw new Error(
-          `Application ID mismatch: token belongs to ${appData.id}, but ${input.appId} was provided`,
-        );
-      }
+    let appResp: Response;
+    try {
+      appResp = await proxyFetch(
+        "https://discord.com/api/v10/applications/@me",
+        {
+          headers: { Authorization: `Bot ${input.botToken}` },
+          timeoutMs: 5000,
+        },
+      );
+    } catch (error) {
+      throw this.toUpstreamConnectError(error, {
+        channel: "discord",
+        phase: "verify_app",
+        upstreamHost: DISCORD_API_ORIGIN,
+      });
     }
 
-    const channel = await this.configStore.connectDiscord({
-      ...input,
-      botUserId: userData.id ?? null,
-    });
-    await this.syncService.syncAll();
+    if (!appResp.ok) {
+      logger.error(
+        { appId: input.appId, status: appResp.status },
+        "discord_connect_app_verify_failed",
+      );
+      throw new ChannelConnectError({
+        message: `Discord API error (${appResp.status})`,
+        code: "upstream_http_error",
+        status: 502,
+        retryable: appResp.status >= 500,
+        phase: "verify_app",
+        upstreamHost: DISCORD_API_ORIGIN,
+        upstreamStatus: appResp.status,
+      });
+    }
+
+    const appData = (await appResp.json()) as { id: string };
+    if (appData.id !== input.appId) {
+      logger.error(
+        { expected: input.appId, actual: appData.id },
+        "discord_connect_app_id_mismatch",
+      );
+      throw new ChannelConnectError({
+        message: `Application ID mismatch: token belongs to ${appData.id}, but ${input.appId} was provided`,
+        code: "app_id_mismatch",
+        status: 422,
+        retryable: false,
+        phase: "verify_app",
+        upstreamHost: DISCORD_API_ORIGIN,
+        upstreamStatus: 200,
+      });
+    }
+
+    let channel: ChannelResponse;
+    try {
+      channel = await this.configStore.connectDiscord({
+        ...input,
+        botUserId: userData.id ?? null,
+      });
+    } catch (error) {
+      throw this.toPersistConnectError(error, "discord");
+    }
+    try {
+      await this.syncService.syncAll();
+    } catch (error) {
+      throw this.toSyncConnectError(error, "discord");
+    }
     logger.info(
       { channelId: channel.id, botUserId: userData.id },
       "discord_connect_success",
@@ -987,21 +1055,47 @@ export class ChannelService {
 
   async connectTelegram(input: ConnectTelegramInput) {
     logger.info({}, "telegram_connect_start");
-    const response = await proxyFetch(
-      `https://api.telegram.org/bot${encodeURIComponent(input.botToken)}/getMe`,
-      {
-        timeoutMs: 5000,
-      },
-    );
+    let response: Response;
+    try {
+      response = await proxyFetch(
+        `https://api.telegram.org/bot${encodeURIComponent(input.botToken)}/getMe`,
+        {
+          timeoutMs: 5000,
+        },
+      );
+    } catch (error) {
+      throw this.toUpstreamConnectError(error, {
+        channel: "telegram",
+        phase: "verify_credentials",
+        upstreamHost: TELEGRAM_API_ORIGIN,
+      });
+    }
+
     if (!response.ok) {
       logger.error(
         { status: response.status },
         "telegram_connect_verify_failed",
       );
-      throw new Error(
+      throw new ChannelConnectError(
         response.status === 401
-          ? "Invalid Telegram bot token"
-          : `Telegram API error (${response.status})`,
+          ? {
+              message: "Invalid Telegram bot token",
+              code: "invalid_credentials",
+              status: 422,
+              retryable: false,
+              phase: "verify_credentials",
+              upstreamHost: TELEGRAM_API_ORIGIN,
+              upstreamStatus: response.status,
+            }
+          : {
+              message: `Telegram API error (${response.status})`,
+              code: "upstream_http_error",
+              status: 502,
+              retryable: response.status >= 500,
+              phase: "verify_credentials",
+              upstreamHost: TELEGRAM_API_ORIGIN,
+              upstreamStatus: response.status,
+            },
       );
     }
 
@@ -1011,19 +1105,36 @@ export class ChannelService {
         { description: payload.description },
         "telegram_connect_payload_invalid",
       );
-      throw new Error(payload.description ?? "Invalid Telegram bot token");
+      throw new ChannelConnectError({
+        message: payload.description ?? "Invalid Telegram bot token",
+        code: "invalid_credentials",
+        status: 422,
+        retryable: false,
+        phase: "verify_credentials",
+        upstreamHost: TELEGRAM_API_ORIGIN,
+        upstreamStatus: 200,
+      });
     }
 
-    const channel = await this.configStore.connectTelegram({
-      botToken: input.botToken,
-      telegramBotId: String(payload.result.id),
-      botUsername: payload.result.username ?? null,
-      displayName:
-        payload.result.username?.trim() ||
-        payload.result.first_name?.trim() ||
-        null,
-    });
-    await this.syncService.syncAll();
+    let channel: ChannelResponse;
+    try {
+      channel = await this.configStore.connectTelegram({
+        botToken: input.botToken,
+        telegramBotId: String(payload.result.id),
+        botUsername: payload.result.username ?? null,
+        displayName:
+          payload.result.username?.trim() ||
+          payload.result.first_name?.trim() ||
+          null,
+      });
+    } catch (error) {
+      throw this.toPersistConnectError(error, "telegram");
+    }
+    try {
+      await this.syncService.syncAll();
+    } catch (error) {
+      throw this.toSyncConnectError(error, "telegram");
+    }
     logger.info(
       { channelId: channel.id, botUsername: payload.result.username },
       "telegram_connect_success",
@@ -1506,6 +1617,83 @@ export class ChannelService {
     if (!pluginDir) {
       throw new Error(`QQ plugin not installed: ${QQBOT_PLUGIN_ID}`);
     }
+  }
+
+  private toUpstreamConnectError(
+    error: unknown,
+    input: {
+      channel: "discord" | "telegram";
+      phase: "verify_credentials" | "verify_app";
+      upstreamHost: string;
+    },
+  ): ChannelConnectError {
+    if (error instanceof ChannelConnectError) {
+      return error;
+    }
+
+    if (error instanceof Error && error.name === "TimeoutError") {
+      return new ChannelConnectError({
+        message: `${input.channel === "discord" ? "Discord" : "Telegram"} request timed out after 5000ms`,
+        code: "timeout",
+        status: 504,
+        retryable: true,
+        phase: input.phase,
+        upstreamHost: input.upstreamHost,
+      });
+    }
+
+    return new ChannelConnectError({
+      message: `${input.channel === "discord" ? "Discord" : "Telegram"} network request failed`,
+      code: "network_error",
+      status: 502,
+      retryable: true,
+      phase: input.phase,
+      upstreamHost: input.upstreamHost,
+    });
+  }
+
+  private toSyncConnectError(
+    error: unknown,
+    channel: "discord" | "telegram",
+  ): ChannelConnectError {
+    if (error instanceof ChannelConnectError) {
+      return error;
+    }
+
+    const message =
+      error instanceof Error && error.message.trim().length > 0
+        ? error.message
+        : "Runtime sync failed";
+
+    return new ChannelConnectError({
+      message: `${channel === "discord" ? "Discord" : "Telegram"} credentials were saved, but runtime sync failed: ${message}`,
+      code: "sync_failed",
+      status: 503,
+      retryable: true,
+      phase: "sync_runtime",
+    });
+  }
+
+  private toPersistConnectError(
+    error: unknown,
+    channel: "discord" | "telegram",
+  ): ChannelConnectError {
+    if (error instanceof ChannelConnectError) {
+      return error;
+    }
+
+    const message =
+      error instanceof Error && error.message.trim().length > 0
+        ? error.message
+        : "Local config persistence failed";
+
+    return new ChannelConnectError({
+      message: `${channel === "discord" ? "Discord" : "Telegram"} credentials were verified, but saving local channel config failed: ${message}`,
+      code: "sync_failed",
+      status: 503,
+      retryable: true,
+      phase: "persist_config",
+    });
   }
 
   private ensureDingtalkPluginInstalled(): void {

--- a/apps/web/lib/api/types.gen.ts
+++ b/apps/web/lib/api/types.gen.ts
@@ -1422,8 +1422,42 @@ export type PostApiV1ChannelsDiscordConnectErrors = {
     /**
      * Invalid credentials
      */
-    409: {
+    422: {
         message: string;
+        code: 'already_connected' | 'app_id_mismatch' | 'invalid_credentials' | 'network_error' | 'proxy_error' | 'sync_failed' | 'timeout' | 'upstream_http_error';
+        requestId: string;
+        retryable: boolean;
+        phase: 'verify_credentials' | 'verify_app' | 'persist_config' | 'sync_runtime';
+    };
+    /**
+     * Upstream network or proxy failure
+     */
+    502: {
+        message: string;
+        code: 'already_connected' | 'app_id_mismatch' | 'invalid_credentials' | 'network_error' | 'proxy_error' | 'sync_failed' | 'timeout' | 'upstream_http_error';
+        requestId: string;
+        retryable: boolean;
+        phase: 'verify_credentials' | 'verify_app' | 'persist_config' | 'sync_runtime';
+    };
+    /**
+     * Local runtime sync failed
+     */
+    503: {
+        message: string;
+        code: 'already_connected' | 'app_id_mismatch' | 'invalid_credentials' | 'network_error' | 'proxy_error' | 'sync_failed' | 'timeout' | 'upstream_http_error';
+        requestId: string;
+        retryable: boolean;
+        phase: 'verify_credentials' | 'verify_app' | 'persist_config' | 'sync_runtime';
+    };
+    /**
+     * Upstream timeout
+     */
+    504: {
+        message: string;
+        code: 'already_connected' | 'app_id_mismatch' | 'invalid_credentials' | 'network_error' | 'proxy_error' | 'sync_failed' | 'timeout' | 'upstream_http_error';
+        requestId: string;
+        retryable: boolean;
+        phase: 'verify_credentials' | 'verify_app' | 'persist_config' | 'sync_runtime';
     };
 };
 
@@ -1505,8 +1539,42 @@ export type PostApiV1ChannelsTelegramConnectErrors = {
     /**
      * Invalid credentials
      */
-    409: {
+    422: {
         message: string;
+        code: 'already_connected' | 'app_id_mismatch' | 'invalid_credentials' | 'network_error' | 'proxy_error' | 'sync_failed' | 'timeout' | 'upstream_http_error';
+        requestId: string;
+        retryable: boolean;
+        phase: 'verify_credentials' | 'verify_app' | 'persist_config' | 'sync_runtime';
+    };
+    /**
+     * Upstream network or proxy failure
+     */
+    502: {
+        message: string;
+        code: 'already_connected' | 'app_id_mismatch' | 'invalid_credentials' | 'network_error' | 'proxy_error' | 'sync_failed' | 'timeout' | 'upstream_http_error';
+        requestId: string;
+        retryable: boolean;
+        phase: 'verify_credentials' | 'verify_app' | 'persist_config' | 'sync_runtime';
+    };
+    /**
+     * Local runtime sync failed
+     */
+    503: {
+        message: string;
+        code: 'already_connected' | 'app_id_mismatch' | 'invalid_credentials' | 'network_error' | 'proxy_error' | 'sync_failed' | 'timeout' | 'upstream_http_error';
+        requestId: string;
+        retryable: boolean;
+        phase: 'verify_credentials' | 'verify_app' | 'persist_config' | 'sync_runtime';
+    };
+    /**
+     * Upstream timeout
+     */
+    504: {
+        message: string;
+        code: 'already_connected' | 'app_id_mismatch' | 'invalid_credentials' | 'network_error' | 'proxy_error' | 'sync_failed' | 'timeout' | 'upstream_http_error';
+        requestId: string;
+        retryable: boolean;
+        phase: 'verify_credentials' | 'verify_app' | 'persist_config' | 'sync_runtime';
     };
 };
 

--- a/apps/web/src/components/channel-connect-modal.tsx
+++ b/apps/web/src/components/channel-connect-modal.tsx
@@ -1,3 +1,7 @@
+import {
+  formatChannelConnectErrorMessage,
+  isAlreadyConnectedError,
+} from "@/lib/channel-connect-errors";
 import { identify, track } from "@/lib/tracking";
 import { ExternalLink, Eye, EyeOff, FileText, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -216,11 +220,12 @@ export function ChannelConnectModal({
           channel: channelType,
           success: false,
         });
-        if (response?.status === 409) {
+        if (response?.status === 409 && isAlreadyConnectedError(error)) {
           toast.info(t("modal.channelConnected"));
         } else {
-          toast.error(error.message ?? t("modal.connectFailed"));
-          onClose();
+          toast.error(
+            formatChannelConnectErrorMessage(error, t("modal.connectFailed")),
+          );
           return;
         }
       } else {

--- a/apps/web/src/components/channel-setup/discord-setup-view.tsx
+++ b/apps/web/src/components/channel-setup/discord-setup-view.tsx
@@ -1,4 +1,5 @@
 import { Input } from "@/components/ui/input";
+import { formatChannelConnectErrorMessage } from "@/lib/channel-connect-errors";
 import { identify, track } from "@/lib/tracking";
 import {
   ArrowLeft,
@@ -72,7 +73,12 @@ export function DiscordSetupView({
           channel: "discord",
           success: false,
         });
-        toast.error(error.message ?? t("discordSetup.connectFailed"));
+        toast.error(
+          formatChannelConnectErrorMessage(
+            error,
+            t("discordSetup.connectFailed"),
+          ),
+        );
         return;
       }
       track("workspace_channel_config_submit", {

--- a/apps/web/src/components/channel-setup/telegram-setup-view.tsx
+++ b/apps/web/src/components/channel-setup/telegram-setup-view.tsx
@@ -1,3 +1,4 @@
+import { formatChannelConnectErrorMessage } from "@/lib/channel-connect-errors";
 import { identify, track } from "@/lib/tracking";
 import { KeyRound, Loader2, MessageCircle } from "lucide-react";
 import { useState } from "react";
@@ -32,7 +33,12 @@ export function TelegramSetupView({
       });
 
       if (error || !data) {
-        toast.error(t("telegramSetup.connectFailed"));
+        toast.error(
+          formatChannelConnectErrorMessage(
+            error,
+            t("telegramSetup.connectFailed"),
+          ),
+        );
         return;
       }
 

--- a/apps/web/src/lib/channel-connect-errors.ts
+++ b/apps/web/src/lib/channel-connect-errors.ts
@@ -1,0 +1,46 @@
+type ChannelConnectErrorShape = {
+  message?: string;
+  code?: string;
+  requestId?: string;
+};
+
+function isRecord(
+  value: unknown,
+): value is Record<string, string | number | boolean | null | undefined> {
+  return typeof value === "object" && value !== null;
+}
+
+export function getChannelConnectError(
+  error: unknown,
+): ChannelConnectErrorShape {
+  if (!isRecord(error)) {
+    return {};
+  }
+
+  const message = typeof error.message === "string" ? error.message : undefined;
+  const code = typeof error.code === "string" ? error.code : undefined;
+  const requestId =
+    typeof error.requestId === "string" ? error.requestId : undefined;
+
+  return { message, code, requestId };
+}
+
+export function formatChannelConnectErrorMessage(
+  error: unknown,
+  fallback: string,
+): string {
+  const parsed = getChannelConnectError(error);
+  if (!parsed.message) {
+    return fallback;
+  }
+
+  if (!parsed.requestId) {
+    return parsed.message;
+  }
+
+  return `${parsed.message} (request: ${parsed.requestId})`;
+}
+
+export function isAlreadyConnectedError(error: unknown): boolean {
+  return getChannelConnectError(error).code === "already_connected";
+}

--- a/packages/shared/src/schemas/channel.ts
+++ b/packages/shared/src/schemas/channel.ts
@@ -68,6 +68,32 @@ export const connectQqbotSchema = z.object({
   appSecret: z.string().min(1),
 });
 
+export const channelConnectErrorCodeSchema = z.enum([
+  "already_connected",
+  "app_id_mismatch",
+  "invalid_credentials",
+  "network_error",
+  "proxy_error",
+  "sync_failed",
+  "timeout",
+  "upstream_http_error",
+]);
+
+export const channelConnectPhaseSchema = z.enum([
+  "verify_credentials",
+  "verify_app",
+  "persist_config",
+  "sync_runtime",
+]);
+
+export const channelConnectErrorSchema = z.object({
+  message: z.string(),
+  code: channelConnectErrorCodeSchema,
+  requestId: z.string(),
+  retryable: z.boolean(),
+  phase: channelConnectPhaseSchema,
+});
+
 export const qqbotConnectivityResponseSchema = z.object({
   success: z.boolean(),
   message: z.string(),
@@ -145,6 +171,11 @@ export type ConnectWechatInput = z.infer<typeof connectWechatSchema>;
 export type ConnectTelegramInput = z.infer<typeof connectTelegramSchema>;
 export type ConnectWhatsappInput = z.infer<typeof connectWhatsappSchema>;
 export type ConnectQqbotInput = z.infer<typeof connectQqbotSchema>;
+export type ChannelConnectErrorCode = z.infer<
+  typeof channelConnectErrorCodeSchema
+>;
+export type ChannelConnectPhase = z.infer<typeof channelConnectPhaseSchema>;
+export type ChannelConnectError = z.infer<typeof channelConnectErrorSchema>;
 export type WecomConnectivityResponse = z.infer<
   typeof wecomConnectivityResponseSchema
 >;


### PR DESCRIPTION
## What

Improve Discord and Telegram connect error handling so users see accurate, localized failure messages and diagnostics include enough proxy/runtime context to debug real connection issues.

## Why

Discord and Telegram connect failures were too opaque during user debugging:
- the frontend could show misleading success-style messaging for connect failures
- backend responses flattened distinct failure modes into generic connect errors
- failure logs were missing the proxy/runtime context needed to quickly identify network and proxy issues

## How

- add structured channel connect error responses with `code`, `phase`, `retryable`, and `requestId`
- classify Discord/Telegram failures into credential, app-id mismatch, timeout, network, persist, and sync phases
- localize backend error descriptions from controller locale instead of surfacing raw internal errors
- update web to show returned error messages for Telegram/Discord and stop treating generic connect failures as already-connected states
- log proxy/runtime context on connect failures and bound async runtime health capture with a short timeout
- regenerate OpenAPI and web SDK types for the new error contract

## Affected areas

- [ ] Desktop app (Electron shell)
- [x] Controller (backend / API)
- [x] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [x] Shared schemas / packages
- [ ] Build / CI / Tooling

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes
- [x] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

## Notes for reviewers

`pnpm test` hit an unrelated flaky failure in `tests/desktop/skill-dir-watcher-workspace.test.ts` (`Timed out waiting for watcher state` while waiting for `agent-tool` to appear for `bot-1`).