### PR TITLE
feat(desktop): background auto-download updates

### DIFF
--- a/apps/desktop/main/index.ts
+++ b/apps/desktop/main/index.ts
@@ -1756,7 +1756,7 @@ app.whenReady().then(async () => {
         channel: runtimeConfig.updates.channel,
         feedUrl: runtimeConfig.urls.updateFeed,
         autoDownload: true,
-        initialDelayMs: process.platform === "win32" ? 45_000 : 0,
+        initialDelayMs: process.platform === "win32" ? 30_000 : 0,
         prepareForUpdateInstall: runtimeLifecycle.prepareForUpdateInstall
           ? async (args: PrepareForUpdateInstallArgs) => {
               await runtimeLifecycle.prepareForUpdateInstall?.(args);

--- a/apps/desktop/main/index.ts
+++ b/apps/desktop/main/index.ts
@@ -1755,6 +1755,7 @@ app.whenReady().then(async () => {
       const updateMgr = new UpdateManager(win, orchestrator, {
         channel: runtimeConfig.updates.channel,
         feedUrl: runtimeConfig.urls.updateFeed,
+        autoDownload: true,
         initialDelayMs: process.platform === "win32" ? 45_000 : 0,
         prepareForUpdateInstall: runtimeLifecycle.prepareForUpdateInstall
           ? async (args: PrepareForUpdateInstallArgs) => {

--- a/apps/desktop/main/ipc.ts
+++ b/apps/desktop/main/ipc.ts
@@ -744,7 +744,7 @@ export function registerIpcHandlers(
           if (!updateManager) {
             return { updateAvailable: false };
           }
-          return updateManager.checkNow();
+          return updateManager.checkNow({ userInitiated: true });
         }
 
         case "update:get-capability": {

--- a/apps/desktop/main/ipc.ts
+++ b/apps/desktop/main/ipc.ts
@@ -781,6 +781,13 @@ export function registerIpcHandlers(
           return { version: app.getVersion() };
         }
 
+        case "update:get-status": {
+          if (!updateManager) {
+            return { phase: "idle", version: null };
+          }
+          return updateManager.getStatus();
+        }
+
         case "update:set-channel": {
           const typedPayload =
             payload as HostInvokePayloadMap["update:set-channel"];

--- a/apps/desktop/main/updater/update-manager.ts
+++ b/apps/desktop/main/updater/update-manager.ts
@@ -22,6 +22,8 @@ import { UnsupportedUpdateDriver } from "./unsupported-update-driver";
 import type { PlatformUpdateDriver } from "./update-driver";
 import { WindowsUpdateDriver } from "./windows-update-driver";
 
+type DownloadMode = "idle" | "background" | "foreground";
+
 export interface UpdateManagerOptions {
   source?: UpdateSource;
   channel?: UpdateChannelName;
@@ -104,6 +106,13 @@ export class UpdateManager {
   private currentFeedUrl: string;
   private readonly platform: NodeJS.Platform;
   private readonly driver: PlatformUpdateDriver;
+  private readonly autoDownload: boolean;
+  private downloadMode: DownloadMode = "idle";
+  private pendingVersion: string | null = null;
+  private pendingReleaseDate: string | undefined = undefined;
+  private pendingReleaseNotes: string | undefined = undefined;
+  private pendingActionUrl: string | undefined = undefined;
+  private downloadComplete = false;
   private checkInProgress: Promise<{ updateAvailable: boolean }> | null = null;
   private lastProgressLogAt = 0;
   private lastProgressLogPercent: number | null = null;
@@ -125,6 +134,7 @@ export class UpdateManager {
     this.initialDelayMs = options?.initialDelayMs ?? 0;
     this.launchdCtx = options?.launchd;
     this.options = options;
+    this.autoDownload = options?.autoDownload ?? false;
     this.platform = options?.platform ?? process.platform;
     this.driver = createUpdateDriver(
       this.platform,
@@ -197,6 +207,27 @@ export class UpdateManager {
           remoteReleaseDate: info.releaseDate,
         });
         this.logCheck("update event: update available", diagnostic);
+
+        if (this.autoDownload) {
+          // Background auto-download: suppress UI, start downloading silently
+          this.downloadMode = "background";
+          this.pendingVersion = info.version;
+          this.pendingReleaseDate = info.releaseDate;
+          this.pendingReleaseNotes = info.releaseNotes;
+          this.pendingActionUrl = info.actionUrl;
+          this.logCheck(
+            "auto-download: starting background download",
+            diagnostic,
+          );
+
+          // On Windows, trigger download manually (Mac electron-updater
+          // auto-downloads when autoDownload is true)
+          if (this.platform === "win32") {
+            void this.driver.downloadUpdate();
+          }
+          return;
+        }
+
         this.send("update:available", {
           version: info.version,
           releaseNotes: info.releaseNotes,
@@ -228,6 +259,12 @@ export class UpdateManager {
             this.getDiagnostic(),
           );
         }
+
+        // Suppress progress events during background download
+        if (this.downloadMode === "background") {
+          return;
+        }
+
         this.send("update:progress", {
           percent: progress.percent,
           bytesPerSecond: progress.bytesPerSecond,
@@ -243,11 +280,25 @@ export class UpdateManager {
             remoteReleaseDate: info.releaseDate,
           }),
         );
+        this.downloadMode = "idle";
+        this.downloadComplete = true;
+        // Always notify renderer when download completes
         this.send("update:downloaded", { version: info.version });
       },
       onError: (error) => {
         const diagnostic = this.getDiagnostic();
         this.logCheck(`update error: ${error.message}`, diagnostic);
+
+        if (this.downloadMode === "background") {
+          // Suppress error UI during background download
+          this.logCheck(
+            "auto-download: background download failed, suppressing UI error",
+            diagnostic,
+          );
+          this.downloadMode = "idle";
+          return;
+        }
+
         this.send("update:error", { message: error.message, diagnostic });
       },
     });
@@ -270,6 +321,45 @@ export class UpdateManager {
   async checkNow(): Promise<{ updateAvailable: boolean }> {
     const startedAt = Date.now();
     this.logCheck("update check start", this.getDiagnostic());
+
+    // If background download already completed, surface it immediately
+    if (this.downloadComplete && this.pendingVersion) {
+      this.logCheck(
+        "update check: background download already complete, surfacing",
+        this.getDiagnostic(),
+      );
+      // Brief "checking" flash so the settings button shows a transition
+      this.send("update:checking", this.getDiagnostic());
+      this.send("update:downloaded", { version: this.pendingVersion });
+      return { updateAvailable: true };
+    }
+
+    // If background download is in progress, show "available" with version
+    // info but keep downloading in the background. User can decide whether
+    // to install — clicking Install will switch to foreground mode with
+    // visible progress.
+    if (this.downloadMode === "background" && this.pendingVersion) {
+      this.logCheck(
+        "update check: background download in progress, surfacing available state",
+        this.getDiagnostic(),
+      );
+
+      // Brief "checking" flash so the settings button shows a transition
+      this.send("update:checking", this.getDiagnostic());
+
+      const diagnostic = this.getDiagnostic({
+        remoteVersion: this.pendingVersion,
+        remoteReleaseDate: this.pendingReleaseDate,
+      });
+      this.send("update:available", {
+        version: this.pendingVersion,
+        releaseNotes: this.pendingReleaseNotes,
+        actionUrl: this.pendingActionUrl,
+        diagnostic,
+      });
+      return { updateAvailable: true };
+    }
+
     if (this.checkInProgress) {
       this.logCheck(
         "update check skipped: already in progress",
@@ -322,6 +412,15 @@ export class UpdateManager {
         this.getDiagnostic(),
       );
       return { ok: false };
+    }
+
+    // Switch to foreground mode and remove rate limit
+    this.downloadMode = "foreground";
+    if (
+      this.platform === "win32" &&
+      this.driver instanceof WindowsUpdateDriver
+    ) {
+      this.driver.setRateLimit(null);
     }
 
     return this.driver.downloadUpdate();
@@ -404,63 +503,61 @@ export class UpdateManager {
 
     logStep("phase 1 cleanup end");
 
-    // --- Phase 2: Process verification ---
-    // Two sweeps of SIGKILL to clear all Nexu sidecar processes. Uses both
-    // authoritative sources (launchd labels, runtime-ports.json) and pgrep.
-    const firstSweepStartedAt = Date.now();
-    let { clean, remainingPids } = await ensureNexuProcessesDead({
-      timeoutMs: 8_000,
-      intervalMs: 200,
-    });
-    this.logCheck(
-      `quit-and-install: first sweep complete in ${Date.now() - firstSweepStartedAt}ms (${clean ? "clean" : `survivors: ${remainingPids.join(", ")}`})`,
-      this.getDiagnostic(),
-    );
-
-    if (!clean) {
-      const secondSweepStartedAt = Date.now();
-      ({ clean, remainingPids } = await ensureNexuProcessesDead({
-        timeoutMs: 5_000,
+    // --- Phase 2 & 3: macOS-only process verification and lock check ---
+    // On Windows, the NSIS installer handles process detection itself.
+    if (this.platform === "darwin") {
+      // Two sweeps of SIGKILL to clear all Nexu sidecar processes. Uses both
+      // authoritative sources (launchd labels, runtime-ports.json) and pgrep.
+      const firstSweepStartedAt = Date.now();
+      let { clean, remainingPids } = await ensureNexuProcessesDead({
+        timeoutMs: 8_000,
         intervalMs: 200,
-      }));
+      });
       this.logCheck(
-        `quit-and-install: second sweep complete in ${Date.now() - secondSweepStartedAt}ms (${clean ? "clean" : `survivors: ${remainingPids.join(", ")}`})`,
+        `quit-and-install: first sweep complete in ${Date.now() - firstSweepStartedAt}ms (${clean ? "clean" : `survivors: ${remainingPids.join(", ")}`})`,
         this.getDiagnostic(),
       );
-    }
 
-    // --- Phase 3: Evidence-based install decision ---
-    // Even with surviving processes, the update may be safe if those
-    // processes don't hold file handles to critical update paths. Use
-    // lsof to check whether the .app bundle or extracted sidecar dirs
-    // are actually locked.
-    const lockCheckStartedAt = Date.now();
-    const { locked, lockedPaths } = await checkCriticalPathsLocked();
-    this.logCheck(
-      `quit-and-install: critical-path lock check complete in ${Date.now() - lockCheckStartedAt}ms (${locked ? `locked: ${lockedPaths.join(", ")}` : "unlocked"})`,
-      this.getDiagnostic(),
-    );
+      if (!clean) {
+        const secondSweepStartedAt = Date.now();
+        ({ clean, remainingPids } = await ensureNexuProcessesDead({
+          timeoutMs: 5_000,
+          intervalMs: 200,
+        }));
+        this.logCheck(
+          `quit-and-install: second sweep complete in ${Date.now() - secondSweepStartedAt}ms (${clean ? "clean" : `survivors: ${remainingPids.join(", ")}`})`,
+          this.getDiagnostic(),
+        );
+      }
 
-    if (locked) {
-      // Critical paths are held open — installing now would fail or
-      // corrupt the app. Skip this attempt; electron-updater will
-      // re-detect the pending update on next launch.
+      // Evidence-based install decision: check if critical paths are locked.
+      const lockCheckStartedAt = Date.now();
+      const { locked, lockedPaths } = await checkCriticalPathsLocked();
       this.logCheck(
-        `quit-and-install: ABORTING — critical paths still locked: ${lockedPaths.join(", ")}`,
+        `quit-and-install: critical-path lock check complete in ${Date.now() - lockCheckStartedAt}ms (${locked ? `locked: ${lockedPaths.join(", ")}` : "unlocked"})`,
         this.getDiagnostic(),
       );
-      return;
+
+      if (locked) {
+        this.logCheck(
+          `quit-and-install: ABORTING — critical paths still locked: ${lockedPaths.join(", ")}`,
+          this.getDiagnostic(),
+        );
+        return;
+      }
+
+      if (!clean) {
+        this.logCheck(
+          "quit-and-install: residual processes exist but no critical path locks, proceeding",
+          this.getDiagnostic(),
+        );
+      }
     }
 
-    if (!clean) {
-      // Processes alive but no critical file handles — safe to proceed.
-      this.logCheck(
-        "quit-and-install: residual processes exist but no critical path locks, proceeding",
-        this.getDiagnostic(),
-      );
-    }
-
-    if (this.driver.capability.applyMode !== "in-app") {
+    if (
+      this.driver.capability.applyMode !== "in-app" &&
+      this.driver.capability.applyMode !== "external-installer"
+    ) {
       this.logCheck(
         "quit-and-install skipped: capability disabled on this platform",
         this.getDiagnostic(),
@@ -470,7 +567,7 @@ export class UpdateManager {
 
     // Set force-quit flag so window close handlers don't intercept the exit
     (app as unknown as Record<string, unknown>).__nexuForceQuit = true;
-    logStep("triggering autoUpdater.quitAndInstall");
+    logStep("triggering update apply");
     await this.driver.applyUpdate();
   }
 

--- a/apps/desktop/main/updater/update-manager.ts
+++ b/apps/desktop/main/updater/update-manager.ts
@@ -170,6 +170,22 @@ export class UpdateManager {
     return this.driver.capability;
   }
 
+  getStatus(): {
+    phase: "idle" | "downloading" | "ready";
+    version: string | null;
+  } {
+    if (this.downloadComplete) {
+      return { phase: "ready", version: this.pendingVersion };
+    }
+    if (
+      this.downloadMode === "background" ||
+      this.downloadMode === "foreground"
+    ) {
+      return { phase: "downloading", version: this.pendingVersion };
+    }
+    return { phase: "idle", version: null };
+  }
+
   private getDiagnostic(partial?: {
     remoteVersion?: string;
     remoteReleaseDate?: string;

--- a/apps/desktop/main/updater/update-manager.ts
+++ b/apps/desktop/main/updater/update-manager.ts
@@ -113,6 +113,7 @@ export class UpdateManager {
   private pendingReleaseNotes: string | undefined = undefined;
   private pendingActionUrl: string | undefined = undefined;
   private downloadComplete = false;
+  private userInitiatedCheck = false;
   private checkInProgress: Promise<{ updateAvailable: boolean }> | null = null;
   private lastProgressLogAt = 0;
   private lastProgressLogPercent: number | null = null;
@@ -208,13 +209,15 @@ export class UpdateManager {
         });
         this.logCheck("update event: update available", diagnostic);
 
-        if (this.autoDownload) {
-          // Background auto-download: suppress UI, start downloading silently
+        // Always store pending info for later surfacing
+        this.pendingVersion = info.version;
+        this.pendingReleaseDate = info.releaseDate;
+        this.pendingReleaseNotes = info.releaseNotes;
+        this.pendingActionUrl = info.actionUrl;
+
+        if (this.autoDownload && !this.userInitiatedCheck) {
+          // Periodic check: suppress UI, start downloading silently
           this.downloadMode = "background";
-          this.pendingVersion = info.version;
-          this.pendingReleaseDate = info.releaseDate;
-          this.pendingReleaseNotes = info.releaseNotes;
-          this.pendingActionUrl = info.actionUrl;
           this.logCheck(
             "auto-download: starting background download",
             diagnostic,
@@ -226,6 +229,19 @@ export class UpdateManager {
             void this.driver.downloadUpdate();
           }
           return;
+        }
+
+        // User-initiated check: always send the event so the renderer
+        // can exit "checking" state. Background download still proceeds.
+        if (this.autoDownload) {
+          this.downloadMode = "background";
+          this.logCheck(
+            "auto-download: user-initiated check, sending available event and starting background download",
+            diagnostic,
+          );
+          if (this.platform === "win32") {
+            void this.driver.downloadUpdate();
+          }
         }
 
         this.send("update:available", {
@@ -289,14 +305,18 @@ export class UpdateManager {
         const diagnostic = this.getDiagnostic();
         this.logCheck(`update error: ${error.message}`, diagnostic);
 
-        if (this.downloadMode === "background") {
-          // Suppress error UI during background download
+        if (this.downloadMode === "background" && !this.userInitiatedCheck) {
+          // Suppress error UI during background-only download
           this.logCheck(
             "auto-download: background download failed, suppressing UI error",
             diagnostic,
           );
           this.downloadMode = "idle";
           return;
+        }
+
+        if (this.downloadMode === "background") {
+          this.downloadMode = "idle";
         }
 
         this.send("update:error", { message: error.message, diagnostic });
@@ -318,8 +338,11 @@ export class UpdateManager {
     }
   }
 
-  async checkNow(): Promise<{ updateAvailable: boolean }> {
+  async checkNow(options?: {
+    userInitiated?: boolean;
+  }): Promise<{ updateAvailable: boolean }> {
     const startedAt = Date.now();
+    this.userInitiatedCheck = options?.userInitiated ?? false;
     this.logCheck("update check start", this.getDiagnostic());
 
     // If background download already completed, surface it immediately
@@ -396,6 +419,7 @@ export class UpdateManager {
         return { updateAvailable: false };
       } finally {
         this.checkInProgress = null;
+        this.userInitiatedCheck = false;
       }
     })();
 

--- a/apps/desktop/main/updater/windows-update-driver.ts
+++ b/apps/desktop/main/updater/windows-update-driver.ts
@@ -1,3 +1,10 @@
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { createWriteStream, existsSync, statSync, unlinkSync } from "node:fs";
+import { get as httpGet } from "node:http";
+import { get as httpsGet } from "node:https";
+import { join } from "node:path";
+import { app } from "electron";
 import type {
   DesktopUpdateCapability,
   UpdateChannelName,
@@ -30,12 +37,17 @@ type WindowsUpdateManifest = {
 const WINDOWS_UPDATE_CAPABILITY: DesktopUpdateCapability = {
   platform: "win32",
   check: true,
-  downloadMode: "external",
-  applyMode: "redirect",
-  applyLabel: "Download installer",
-  notes:
-    "Windows desktop updates are delivered through the packaged installer.",
+  downloadMode: "in-app",
+  applyMode: "external-installer",
+  applyLabel: "Install",
+  notes: null,
 };
+
+/** Default background download rate limit: 1 MB/s */
+const DEFAULT_RATE_LIMIT_BPS = 1_048_576;
+
+/** Minimum interval between progress event emissions (ms) */
+const PROGRESS_EMIT_INTERVAL_MS = 500;
 
 function resolveWindowsManifestUrl(options: {
   source: UpdateSource;
@@ -138,6 +150,10 @@ function compareDesktopVersions(left: string, right: string): number {
   return 0;
 }
 
+function resolveInstallerPath(version: string): string {
+  return join(app.getPath("temp"), `nexu-setup-${version}.exe`);
+}
+
 export class WindowsUpdateDriver implements PlatformUpdateDriver {
   readonly capability = WINDOWS_UPDATE_CAPABILITY;
   private currentFeedUrl = resolveWindowsManifestUrl({
@@ -147,6 +163,9 @@ export class WindowsUpdateDriver implements PlatformUpdateDriver {
   });
   private handlers: UpdateDriverEventHandlers | null = null;
   private latestManifest: WindowsUpdateManifest | null = null;
+  private downloadedInstallerPath: string | null = null;
+  private abortController: AbortController | null = null;
+  private rateLimitBps: number | null = DEFAULT_RATE_LIMIT_BPS;
 
   constructor(private readonly context: UpdateDriverContext) {}
 
@@ -160,6 +179,16 @@ export class WindowsUpdateDriver implements PlatformUpdateDriver {
 
   bindEvents(handlers: UpdateDriverEventHandlers): void {
     this.handlers = handlers;
+  }
+
+  /** Set download rate limit in bytes/second, or null for unlimited. */
+  setRateLimit(bps: number | null): void {
+    this.rateLimitBps = bps;
+  }
+
+  /** Whether a download is currently in progress. */
+  isDownloading(): boolean {
+    return this.abortController !== null;
   }
 
   async checkForUpdates(): Promise<UpdateDriverCheckResult> {
@@ -210,22 +239,328 @@ export class WindowsUpdateDriver implements PlatformUpdateDriver {
   }
 
   async downloadUpdate(): Promise<{ ok: boolean }> {
-    const installerUrl = this.latestManifest?.installer.url;
-    if (!installerUrl) {
+    const manifest = this.latestManifest;
+    if (!manifest) {
       return { ok: false };
     }
 
-    await this.context.openExternal(installerUrl);
-    return { ok: true };
+    const installerUrl = manifest.installer.url;
+    const expectedSize = manifest.installer.size ?? null;
+    const expectedSha256 = manifest.installer.sha256 ?? null;
+    const destPath = resolveInstallerPath(manifest.version);
+
+    // If already fully downloaded with correct size, skip
+    if (existsSync(destPath) && expectedSize !== null) {
+      try {
+        const stat = statSync(destPath);
+        if (stat.size === expectedSize) {
+          this.downloadedInstallerPath = destPath;
+          this.handlers?.onDownloaded({
+            version: manifest.version,
+            releaseDate: manifest.releaseDate,
+          });
+          return { ok: true };
+        }
+      } catch {
+        // stat failed, re-download
+      }
+    }
+
+    // Clean up partial file
+    try {
+      if (existsSync(destPath)) unlinkSync(destPath);
+    } catch {
+      // ignore cleanup errors
+    }
+
+    const ac = new AbortController();
+    this.abortController = ac;
+
+    return new Promise<{ ok: boolean }>((resolve) => {
+      const getter = installerUrl.startsWith("https://") ? httpsGet : httpGet;
+
+      const request = getter(installerUrl, (response) => {
+        if (ac.signal.aborted) {
+          response.destroy();
+          resolve({ ok: false });
+          return;
+        }
+
+        // Handle redirects
+        if (
+          response.statusCode &&
+          response.statusCode >= 300 &&
+          response.statusCode < 400 &&
+          response.headers.location
+        ) {
+          request.destroy();
+          // Follow redirect by updating URL and retrying
+          const redirectGetter = response.headers.location.startsWith(
+            "https://",
+          )
+            ? httpsGet
+            : httpGet;
+          this.downloadWithStream(
+            redirectGetter,
+            response.headers.location,
+            destPath,
+            manifest,
+            expectedSize,
+            expectedSha256,
+            ac,
+            resolve,
+          );
+          return;
+        }
+
+        if (response.statusCode !== 200) {
+          this.abortController = null;
+          const error = new Error(
+            `Installer download failed: ${response.statusCode} ${response.statusMessage}`,
+          );
+          this.handlers?.onError(error);
+          resolve({ ok: false });
+          return;
+        }
+
+        this.handleDownloadStream(
+          response,
+          destPath,
+          manifest,
+          expectedSize,
+          expectedSha256,
+          ac,
+          resolve,
+        );
+      });
+
+      request.on("error", (error) => {
+        this.abortController = null;
+        this.handlers?.onError(error);
+        resolve({ ok: false });
+      });
+
+      ac.signal.addEventListener("abort", () => {
+        request.destroy();
+      });
+    });
+  }
+
+  private downloadWithStream(
+    getter: typeof httpsGet | typeof httpGet,
+    url: string,
+    destPath: string,
+    manifest: WindowsUpdateManifest,
+    expectedSize: number | null,
+    expectedSha256: string | null,
+    ac: AbortController,
+    resolve: (value: { ok: boolean }) => void,
+  ): void {
+    const request = getter(url, (response) => {
+      if (ac.signal.aborted) {
+        response.destroy();
+        resolve({ ok: false });
+        return;
+      }
+
+      if (response.statusCode !== 200) {
+        this.abortController = null;
+        const error = new Error(
+          `Installer download failed: ${response.statusCode} ${response.statusMessage}`,
+        );
+        this.handlers?.onError(error);
+        resolve({ ok: false });
+        return;
+      }
+
+      this.handleDownloadStream(
+        response,
+        destPath,
+        manifest,
+        expectedSize,
+        expectedSha256,
+        ac,
+        resolve,
+      );
+    });
+
+    request.on("error", (error) => {
+      this.abortController = null;
+      this.handlers?.onError(error);
+      resolve({ ok: false });
+    });
+
+    ac.signal.addEventListener("abort", () => {
+      request.destroy();
+    });
+  }
+
+  private handleDownloadStream(
+    response: NodeJS.ReadableStream & {
+      headers?: Record<string, string | string[] | undefined>;
+    },
+    destPath: string,
+    manifest: WindowsUpdateManifest,
+    expectedSize: number | null,
+    expectedSha256: string | null,
+    ac: AbortController,
+    resolve: (value: { ok: boolean }) => void,
+  ): void {
+    const contentLength =
+      expectedSize ??
+      Number.parseInt(
+        (response.headers as Record<string, string | undefined>)?.[
+          "content-length"
+        ] ?? "0",
+        10,
+      );
+    const total = contentLength || 0;
+    let transferred = 0;
+    let lastProgressAt = 0;
+    const startedAt = Date.now();
+
+    const hash = expectedSha256 ? createHash("sha256") : null;
+    const fileStream = createWriteStream(destPath);
+
+    const emitProgress = (): void => {
+      const now = Date.now();
+      if (now - lastProgressAt < PROGRESS_EMIT_INTERVAL_MS) return;
+      lastProgressAt = now;
+
+      const elapsed = (now - startedAt) / 1000;
+      const bytesPerSecond = elapsed > 0 ? transferred / elapsed : 0;
+      const percent = total > 0 ? (transferred / total) * 100 : 0;
+
+      this.handlers?.onProgress({
+        percent: Math.min(percent, 100),
+        bytesPerSecond,
+        transferred,
+        total,
+      });
+    };
+
+    const cleanup = (success: boolean): void => {
+      this.abortController = null;
+      if (!success) {
+        try {
+          fileStream.close();
+          if (existsSync(destPath)) unlinkSync(destPath);
+        } catch {
+          // ignore cleanup errors
+        }
+      }
+    };
+
+    response.on("data", (chunk: Buffer) => {
+      if (ac.signal.aborted) {
+        (
+          response as NodeJS.ReadableStream & { destroy?: () => void }
+        ).destroy?.();
+        cleanup(false);
+        resolve({ ok: false });
+        return;
+      }
+
+      hash?.update(chunk);
+      fileStream.write(chunk);
+      transferred += chunk.length;
+      emitProgress();
+
+      // Rate limiting: pause the stream and resume after delay
+      const rateLimit = this.rateLimitBps;
+      if (rateLimit !== null && rateLimit > 0) {
+        const delayMs = (chunk.length / rateLimit) * 1000;
+        if (delayMs > 10) {
+          (
+            response as NodeJS.ReadableStream & { pause?: () => void }
+          ).pause?.();
+          setTimeout(() => {
+            if (!ac.signal.aborted) {
+              (
+                response as NodeJS.ReadableStream & { resume?: () => void }
+              ).resume?.();
+            }
+          }, delayMs);
+        }
+      }
+    });
+
+    response.on("end", () => {
+      fileStream.end(() => {
+        if (ac.signal.aborted) {
+          cleanup(false);
+          resolve({ ok: false });
+          return;
+        }
+
+        // SHA256 verification
+        if (hash && expectedSha256) {
+          const actualSha256 = hash.digest("hex");
+          if (actualSha256.toLowerCase() !== expectedSha256.toLowerCase()) {
+            cleanup(false);
+            const error = new Error(
+              `Installer SHA256 mismatch: expected ${expectedSha256}, got ${actualSha256}`,
+            );
+            this.handlers?.onError(error);
+            resolve({ ok: false });
+            return;
+          }
+        }
+
+        // Emit final 100% progress
+        this.handlers?.onProgress({
+          percent: 100,
+          bytesPerSecond: 0,
+          transferred,
+          total: transferred,
+        });
+
+        this.downloadedInstallerPath = destPath;
+        this.handlers?.onDownloaded({
+          version: manifest.version,
+          releaseDate: manifest.releaseDate,
+        });
+        resolve({ ok: true });
+      });
+    });
+
+    response.on("error", (error: Error) => {
+      cleanup(false);
+      this.handlers?.onError(error);
+      resolve({ ok: false });
+    });
+
+    fileStream.on("error", (error: Error) => {
+      cleanup(false);
+      this.handlers?.onError(error);
+      resolve({ ok: false });
+    });
+
+    ac.signal.addEventListener("abort", () => {
+      (
+        response as NodeJS.ReadableStream & { destroy?: () => void }
+      ).destroy?.();
+      cleanup(false);
+      resolve({ ok: false });
+    });
   }
 
   async applyUpdate(): Promise<void> {
-    const installerUrl = this.latestManifest?.installer.url;
-    if (!installerUrl) {
+    const installerPath = this.downloadedInstallerPath;
+    if (installerPath && existsSync(installerPath)) {
+      spawn(installerPath, [], {
+        detached: true,
+        stdio: "ignore",
+      }).unref();
+      app.quit();
       return;
     }
 
-    await this.context.openExternal(installerUrl);
+    // Fallback: open installer URL in browser
+    const installerUrl = this.latestManifest?.installer.url;
+    if (installerUrl) {
+      await this.context.openExternal(installerUrl);
+    }
   }
 }
 

--- a/apps/desktop/main/updater/windows-update-driver.ts
+++ b/apps/desktop/main/updater/windows-update-driver.ts
@@ -1,6 +1,12 @@
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
-import { createWriteStream, existsSync, statSync, unlinkSync } from "node:fs";
+import {
+  createWriteStream,
+  existsSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+} from "node:fs";
 import { get as httpGet } from "node:http";
 import { get as httpsGet } from "node:https";
 import { join } from "node:path";
@@ -165,6 +171,7 @@ export class WindowsUpdateDriver implements PlatformUpdateDriver {
   private latestManifest: WindowsUpdateManifest | null = null;
   private downloadedInstallerPath: string | null = null;
   private abortController: AbortController | null = null;
+  private downloadPromise: Promise<{ ok: boolean }> | null = null;
   private rateLimitBps: number | null = DEFAULT_RATE_LIMIT_BPS;
 
   constructor(private readonly context: UpdateDriverContext) {}
@@ -244,16 +251,25 @@ export class WindowsUpdateDriver implements PlatformUpdateDriver {
       return { ok: false };
     }
 
+    if (this.downloadPromise) {
+      return this.downloadPromise;
+    }
+
     const installerUrl = manifest.installer.url;
     const expectedSize = manifest.installer.size ?? null;
     const expectedSha256 = manifest.installer.sha256 ?? null;
     const destPath = resolveInstallerPath(manifest.version);
 
-    // If already fully downloaded with correct size, skip
-    if (existsSync(destPath) && expectedSize !== null) {
+    // If already fully downloaded, verify checksum when available before reuse.
+    if (existsSync(destPath)) {
       try {
         const stat = statSync(destPath);
-        if (stat.size === expectedSize) {
+        const sizeMatches = expectedSize === null || stat.size === expectedSize;
+        const shaMatches =
+          expectedSha256 === null
+            ? true
+            : this.verifyFileSha256(destPath, expectedSha256);
+        if (sizeMatches && shaMatches) {
           this.downloadedInstallerPath = destPath;
           this.handlers?.onDownloaded({
             version: manifest.version,
@@ -276,7 +292,7 @@ export class WindowsUpdateDriver implements PlatformUpdateDriver {
     const ac = new AbortController();
     this.abortController = ac;
 
-    return new Promise<{ ok: boolean }>((resolve) => {
+    const downloadPromise = new Promise<{ ok: boolean }>((resolve) => {
       const getter = installerUrl.startsWith("https://") ? httpsGet : httpGet;
 
       const request = getter(installerUrl, (response) => {
@@ -344,6 +360,19 @@ export class WindowsUpdateDriver implements PlatformUpdateDriver {
         request.destroy();
       });
     });
+
+    this.downloadPromise = downloadPromise.finally(() => {
+      this.downloadPromise = null;
+    });
+
+    return this.downloadPromise;
+  }
+
+  private verifyFileSha256(filePath: string, expectedSha256: string): boolean {
+    const hash = createHash("sha256");
+    const fileBuffer = readFileSync(filePath);
+    hash.update(fileBuffer);
+    return hash.digest("hex").toLowerCase() === expectedSha256.toLowerCase();
   }
 
   private downloadWithStream(

--- a/apps/desktop/mock-update-server.mjs
+++ b/apps/desktop/mock-update-server.mjs
@@ -1,50 +1,95 @@
 /**
  * Mock update server for electron-updater (generic provider).
- * Serves latest-mac.yml with a fake version higher than the current app version.
- * Provides a slow fake .zip download to exercise the progress UI.
  *
- * Usage:  node apps/desktop/mock-update-server.mjs
- * Then:   NEXU_UPDATE_FEED_URL=http://localhost:8976 pnpm desktop:start
+ * Supports two modes:
+ * 1) default fake ZIP stream for UI-state testing
+ * 2) real ZIP passthrough via MOCK_UPDATE_ZIP_PATH for download validation
+ *
+ * Usage:
+ *   node apps/desktop/mock-update-server.mjs
+ *   MOCK_UPDATE_ZIP_PATH=/abs/path/to/nexu.zip MOCK_UPDATE_VERSION=0.1.11-mock node apps/desktop/mock-update-server.mjs
  */
 
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { readFile, stat } from "node:fs/promises";
 import { createServer } from "node:http";
+import { basename, resolve } from "node:path";
 
-const PORT = 8976;
-const FAKE_VERSION = "0.2.0";
-const FAKE_ZIP_SIZE = 5_000_000; // 5 MB fake payload
-const CHUNK_SIZE = 50_000; // 50 KB per chunk
-const CHUNK_INTERVAL_MS = 100; // send a chunk every 100ms (~500 KB/s)
+const PORT = Number(process.env.PORT ?? 8976);
+const FAKE_VERSION = process.env.MOCK_UPDATE_VERSION ?? "0.2.0";
+const FAKE_ZIP_SIZE = Number(process.env.MOCK_UPDATE_FAKE_SIZE ?? 5_000_000);
+const CHUNK_SIZE = Number(process.env.MOCK_UPDATE_CHUNK_SIZE ?? 50_000);
+const CHUNK_INTERVAL_MS = Number(process.env.MOCK_UPDATE_CHUNK_INTERVAL_MS ?? 100);
+const zipPath = process.env.MOCK_UPDATE_ZIP_PATH
+  ? resolve(process.env.MOCK_UPDATE_ZIP_PATH)
+  : null;
 
-// Compute a deterministic fake sha512 (88 chars base64)
 const fakeSha512 = Buffer.alloc(64, 0xab).toString("base64");
 
-// electron-updater on macOS expects a .zip file in latest-mac.yml
+async function getZipMetadata() {
+  if (!zipPath) {
+    return {
+      zipPath: null,
+      zipFileName: `nexu-${FAKE_VERSION}-arm64-mac.zip`,
+      zipSize: FAKE_ZIP_SIZE,
+      sha512: fakeSha512,
+      mode: "fake",
+    };
+  }
+
+  const [zipStat, zipBuffer] = await Promise.all([stat(zipPath), readFile(zipPath)]);
+  return {
+    zipPath,
+    zipFileName: basename(zipPath),
+    zipSize: zipStat.size,
+    sha512: createHash("sha512").update(zipBuffer).digest("base64"),
+    mode: "real",
+  };
+}
+
+const zipMeta = await getZipMetadata();
+
 const latestMacYml = `version: ${FAKE_VERSION}
 files:
-  - url: nexu-${FAKE_VERSION}-arm64-mac.zip
-    sha512: ${fakeSha512}
-    size: ${FAKE_ZIP_SIZE}
-path: nexu-${FAKE_VERSION}-arm64-mac.zip
-sha512: ${fakeSha512}
-releaseDate: '2026-03-20T00:00:00.000Z'
-releaseNotes: 'Mock update for UI testing'
+  - url: ${zipMeta.zipFileName}
+    sha512: ${zipMeta.sha512}
+    size: ${zipMeta.zipSize}
+path: ${zipMeta.zipFileName}
+sha512: ${zipMeta.sha512}
+releaseDate: '2026-04-10T00:00:00.000Z'
+releaseNotes: 'Mock update for local desktop testing'
 `;
+
+function normalizePath(pathname) {
+  return pathname.replace(/^\/(arm64|x64)(?=\/)/, "");
+}
 
 const server = createServer((req, res) => {
   const url = new URL(req.url, `http://localhost:${PORT}`);
+  const pathname = normalizePath(url.pathname);
   console.log(`${req.method} ${url.pathname}`);
 
   // CORS for Electron renderer
   res.setHeader("Access-Control-Allow-Origin", "*");
 
-  if (url.pathname === "/latest-mac.yml" || url.pathname === "/latest.yml") {
+  if (pathname === "/latest-mac.yml" || pathname === "/latest.yml") {
     res.writeHead(200, { "Content-Type": "text/yaml" });
     res.end(latestMacYml);
     return;
   }
 
-  // Serve a slow fake .zip download to exercise the progress bar UI
-  if (url.pathname.endsWith(".zip")) {
+  if (pathname === `/${zipMeta.zipFileName}`) {
+    if (zipMeta.mode === "real" && zipMeta.zipPath) {
+      console.log(`  → Streaming real ZIP ${zipMeta.zipPath}`);
+      res.writeHead(200, {
+        "Content-Type": "application/zip",
+        "Content-Length": String(zipMeta.zipSize),
+      });
+      createReadStream(zipMeta.zipPath).pipe(res);
+      return;
+    }
+
     console.log(`  → Serving fake ${FAKE_ZIP_SIZE} byte ZIP (slow stream)`);
     res.writeHead(200, {
       "Content-Type": "application/zip",
@@ -74,7 +119,7 @@ const server = createServer((req, res) => {
   }
 
   // Any .dmg download request — return 404
-  if (url.pathname.endsWith(".dmg")) {
+  if (pathname.endsWith(".dmg")) {
     res.writeHead(404, { "Content-Type": "text/plain" });
     res.end("Mock server: use .zip for macOS");
     return;
@@ -87,5 +132,7 @@ const server = createServer((req, res) => {
 server.listen(PORT, () => {
   console.log(`Mock update server running at http://localhost:${PORT}`);
   console.log(`Serving version ${FAKE_VERSION} via latest-mac.yml`);
+  console.log(`ZIP mode: ${zipMeta.mode}`);
+  console.log(`ZIP file: ${zipMeta.zipFileName}`);
   console.log(`\nTo use: export NEXU_UPDATE_FEED_URL=http://localhost:${PORT}`);
 });

--- a/apps/desktop/mock-update-server.mjs
+++ b/apps/desktop/mock-update-server.mjs
@@ -20,7 +20,9 @@ const PORT = Number(process.env.PORT ?? 8976);
 const FAKE_VERSION = process.env.MOCK_UPDATE_VERSION ?? "0.2.0";
 const FAKE_ZIP_SIZE = Number(process.env.MOCK_UPDATE_FAKE_SIZE ?? 5_000_000);
 const CHUNK_SIZE = Number(process.env.MOCK_UPDATE_CHUNK_SIZE ?? 50_000);
-const CHUNK_INTERVAL_MS = Number(process.env.MOCK_UPDATE_CHUNK_INTERVAL_MS ?? 100);
+const CHUNK_INTERVAL_MS = Number(
+  process.env.MOCK_UPDATE_CHUNK_INTERVAL_MS ?? 100,
+);
 const zipPath = process.env.MOCK_UPDATE_ZIP_PATH
   ? resolve(process.env.MOCK_UPDATE_ZIP_PATH)
   : null;
@@ -38,7 +40,10 @@ async function getZipMetadata() {
     };
   }
 
-  const [zipStat, zipBuffer] = await Promise.all([stat(zipPath), readFile(zipPath)]);
+  const [zipStat, zipBuffer] = await Promise.all([
+    stat(zipPath),
+    readFile(zipPath),
+  ]);
   return {
     zipPath,
     zipFileName: basename(zipPath),

--- a/apps/desktop/preload/webview-preload.ts
+++ b/apps/desktop/preload/webview-preload.ts
@@ -7,7 +7,11 @@ import {
   type HostInvokeResultMap,
   type RuntimeEvent,
   type StartupProbePayload,
+  type UpdaterBridge,
+  type UpdaterEvent,
+  type UpdaterEventMap,
   hostInvokeChannels,
+  updaterEvents,
 } from "../shared/host";
 import { getDesktopRuntimeConfig } from "../shared/runtime-config";
 import { resolveWebviewPreloadUrl } from "./webview-preload-url";
@@ -91,3 +95,31 @@ const hostBridge: HostBridge = {
 };
 
 contextBridge.exposeInMainWorld("nexuHost", hostBridge);
+
+const validUpdaterEvents = new Set<string>(updaterEvents);
+
+const updaterBridge: UpdaterBridge = {
+  onEvent<TEvent extends UpdaterEvent>(
+    event: TEvent,
+    callback: (data: UpdaterEventMap[TEvent]) => void,
+  ): () => void {
+    if (!validUpdaterEvents.has(event)) {
+      throw new Error(`Invalid updater event: ${event}`);
+    }
+
+    const handler = (
+      _event: Electron.IpcRendererEvent,
+      data: UpdaterEventMap[TEvent],
+    ) => {
+      callback(data);
+    };
+
+    ipcRenderer.on(event, handler);
+
+    return () => {
+      ipcRenderer.removeListener(event, handler);
+    };
+  },
+};
+
+contextBridge.exposeInMainWorld("nexuUpdater", updaterBridge);

--- a/apps/desktop/shared/host.ts
+++ b/apps/desktop/shared/host.ts
@@ -38,6 +38,7 @@ export const hostInvokeChannels = [
   "update:download",
   "update:install",
   "update:get-current-version",
+  "update:get-status",
   "update:set-channel",
   "update:set-source",
   "component:check",
@@ -156,6 +157,7 @@ export type HostInvokePayloadMap = {
   "update:download": undefined;
   "update:install": undefined;
   "update:get-current-version": undefined;
+  "update:get-status": undefined;
   "update:set-channel": { channel: UpdateChannelName };
   "update:set-source": { source: UpdateSource };
   "component:check": undefined;
@@ -451,6 +453,10 @@ export type HostInvokeResultMap = {
   "update:download": { ok: boolean };
   "update:install": undefined;
   "update:get-current-version": { version: string };
+  "update:get-status": {
+    phase: "idle" | "downloading" | "ready";
+    version: string | null;
+  };
   "update:set-channel": { ok: boolean };
   "update:set-source": { ok: boolean };
   "component:check": {

--- a/apps/desktop/shared/update-policy.ts
+++ b/apps/desktop/shared/update-policy.ts
@@ -27,7 +27,8 @@ export function shouldStartDesktopPeriodicUpdateChecks(input: {
   buildSource: DesktopBuildSource;
   updateFeed: string | null;
 }): boolean {
-  return resolveDesktopUpdateExperience(input) === "normal";
+  const experience = resolveDesktopUpdateExperience(input);
+  return experience === "normal" || experience === "local-test-feed";
 }
 
 export function getDesktopUpdateTestingGuideUrl(

--- a/apps/desktop/src/components/desktop-shell.tsx
+++ b/apps/desktop/src/components/desktop-shell.tsx
@@ -191,25 +191,27 @@ export function DesktopShell() {
         </div>
       </main>
 
-      <UpdateBanner
-        canCheckForUpdates={
-          updateExperience === "local-test-feed" &&
-          Boolean(update.capability?.check)
-        }
-        capability={update.capability}
-        currentVersion={runtimeConfig?.buildInfo.version ?? null}
-        dismissed={update.dismissed}
-        errorMessage={update.errorMessage}
-        experience={updateExperience}
-        onCheck={() => void update.check()}
-        onDismiss={update.dismiss}
-        onDownload={() => void update.download()}
-        onInstall={() => void update.install()}
-        percent={update.percent}
-        phase={update.phase}
-        releaseNotes={update.releaseNotes}
-        version={update.version}
-      />
+      {chromeMode !== "immersive" && (
+        <UpdateBanner
+          canCheckForUpdates={
+            updateExperience === "local-test-feed" &&
+            Boolean(update.capability?.check)
+          }
+          capability={update.capability}
+          currentVersion={runtimeConfig?.buildInfo.version ?? null}
+          dismissed={update.dismissed}
+          errorMessage={update.errorMessage}
+          experience={updateExperience}
+          onCheck={() => void update.check()}
+          onDismiss={update.dismiss}
+          onDownload={() => void update.download()}
+          onInstall={() => void update.install()}
+          percent={update.percent}
+          phase={update.phase}
+          releaseNotes={update.releaseNotes}
+          version={update.version}
+        />
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/hooks/use-auto-update.ts
+++ b/apps/desktop/src/hooks/use-auto-update.ts
@@ -248,7 +248,10 @@ export function useAutoUpdate(options?: {
   }, [state.capability]);
 
   const install = useCallback(async () => {
-    if (state.capability?.applyMode !== "in-app") {
+    if (
+      state.capability?.applyMode !== "in-app" &&
+      state.capability?.applyMode !== "external-installer"
+    ) {
       return;
     }
 

--- a/apps/web/src/hooks/use-auto-update.ts
+++ b/apps/web/src/hooks/use-auto-update.ts
@@ -31,11 +31,17 @@ export type UpdatePhase =
   | "ready"
   | "error";
 
+type UpdateCapability = {
+  downloadMode: "in-app" | "external" | "none";
+  applyMode: "in-app" | "redirect" | "external-installer" | "none";
+};
+
 export type UpdateState = {
   phase: UpdatePhase;
   version: string | null;
   percent: number;
   errorMessage: string | null;
+  capability: UpdateCapability | null;
 };
 
 export function restorePhaseAfterInstall(
@@ -58,7 +64,26 @@ export function useAutoUpdate() {
     version: null,
     percent: 0,
     errorMessage: null,
+    capability: null,
   });
+
+  useEffect(() => {
+    const host = (window as unknown as NexuWindow).nexuHost;
+    if (!host) return;
+    let cancelled = false;
+    void host
+      .invoke("update:get-capability", undefined)
+      .then((result) => {
+        if (!cancelled) {
+          const cap = result as UpdateCapability | null;
+          setState((prev) => ({ ...prev, capability: cap }));
+        }
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     const updater = (window as unknown as NexuWindow).nexuUpdater;
@@ -152,14 +177,24 @@ export function useAutoUpdate() {
   }, [bridge]);
 
   const download = useCallback(async () => {
-    // Immediately show downloading state before the IPC round-trip
+    if (state.capability?.downloadMode === "external") {
+      // External download opens the installer URL in the system browser.
+      // Don't show "downloading" state — the browser handles the download.
+      try {
+        await bridge?.invoke("update:download", undefined);
+      } catch {
+        /* errors via event */
+      }
+      return;
+    }
+    // In-app download: show downloading state before the IPC round-trip
     setState((prev) => ({ ...prev, phase: "downloading", percent: 0 }));
     try {
       await bridge?.invoke("update:download", undefined);
     } catch {
       /* errors via event */
     }
-  }, [bridge]);
+  }, [bridge, state.capability]);
 
   const install = useCallback(async () => {
     let previousPhase: Exclude<UpdatePhase, "installing"> = "ready";

--- a/apps/web/src/hooks/use-auto-update.ts
+++ b/apps/web/src/hooks/use-auto-update.ts
@@ -71,6 +71,8 @@ export function useAutoUpdate() {
     const host = (window as unknown as NexuWindow).nexuHost;
     if (!host) return;
     let cancelled = false;
+
+    // Query capability
     void host
       .invoke("update:get-capability", undefined)
       .then((result) => {
@@ -80,6 +82,28 @@ export function useAutoUpdate() {
         }
       })
       .catch(() => {});
+
+    // Query current update status (catches background downloads that
+    // completed before this component mounted)
+    void host
+      .invoke("update:get-status", undefined)
+      .then((result) => {
+        if (cancelled) return;
+        const status = result as {
+          phase: "idle" | "downloading" | "ready";
+          version: string | null;
+        };
+        if (status.phase === "ready" && status.version) {
+          setState((prev) => ({
+            ...prev,
+            phase: "ready",
+            version: status.version,
+            percent: 100,
+          }));
+        }
+      })
+      .catch(() => {});
+
     return () => {
       cancelled = true;
     };

--- a/apps/web/src/hooks/use-auto-update.ts
+++ b/apps/web/src/hooks/use-auto-update.ts
@@ -93,12 +93,15 @@ export function useAutoUpdate() {
           phase: "idle" | "downloading" | "ready";
           version: string | null;
         };
-        if (status.phase === "ready" && status.version) {
+        if (
+          (status.phase === "ready" || status.phase === "downloading") &&
+          status.version
+        ) {
           setState((prev) => ({
             ...prev,
-            phase: "ready",
+            phase: status.phase,
             version: status.version,
-            percent: 100,
+            percent: status.phase === "ready" ? 100 : prev.percent,
           }));
         }
       })

--- a/apps/web/src/layouts/workspace-layout.tsx
+++ b/apps/web/src/layouts/workspace-layout.tsx
@@ -298,7 +298,7 @@ function UpdateFloatCard({
             </span>
           </div>
         </div>
-        {!updating && phase !== "ready" && (
+        {!updating && (
           <button
             type="button"
             onClick={onDismiss}
@@ -334,6 +334,13 @@ function UpdateFloatCard({
             className="rounded-[6px] px-2.5 py-1 text-[11px] font-medium bg-[var(--color-accent)] text-white hover:opacity-85 transition-opacity"
           >
             {t("layout.update.install")}
+          </button>
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="rounded-[6px] px-2 py-1 text-[11px] font-medium text-text-muted hover:text-text-primary transition-colors"
+          >
+            {t("layout.update.later")}
           </button>
         </div>
       ) : (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,10 +323,6 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
-  packages/pkg-utils: {}
-
-  packages/platform-utils: {}
-
   packages/shared:
     dependencies:
       zod:
@@ -3463,6 +3459,7 @@ packages:
   basic-ftp@5.2.0:
     resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   better-auth@1.4.19:
     resolution: {integrity: sha512-3RlZJcA0+NH25wYD85vpIGwW9oSTuEmLIaGbT8zg41w/Pa2hVWHKedjoUHHJtnzkBXzDb+CShkLnSw7IThDdqQ==}

--- a/tests/auto-update-install-phase.test.ts
+++ b/tests/auto-update-install-phase.test.ts
@@ -70,4 +70,18 @@ describe("web useAutoUpdate", () => {
       ).phase,
     ).toBe("error");
   });
+
+  it("restores downloading after install returns without quitting", () => {
+    expect(
+      restoreWebPhase(
+        {
+          phase: "installing",
+          version: "1.2.3",
+          percent: 100,
+          errorMessage: null,
+        },
+        "downloading",
+      ).phase,
+    ).toBe("downloading");
+  });
 });

--- a/tests/desktop/update-manager-full.test.ts
+++ b/tests/desktop/update-manager-full.test.ts
@@ -172,6 +172,67 @@ describe("bindEvents", () => {
     );
   });
 
+  it("auto-download: user-initiated checks surface available state", async () => {
+    let resolveCheck!: (value: unknown) => void;
+    mockAutoUpdater.checkForUpdates.mockReturnValue(
+      new Promise((resolve) => {
+        resolveCheck = resolve;
+      }),
+    );
+
+    const { mgr, win } = await createManager(undefined, { autoDownload: true });
+    const handlers = extractHandlers();
+
+    const checkPromise = mgr.checkNow({ userInitiated: true });
+    handlers["update-available"]({
+      version: "1.0.0",
+      releaseDate: "2026-03-20",
+      releaseNotes: "Bug fixes",
+    });
+    resolveCheck({
+      updateInfo: { version: "1.0.0", releaseDate: "2026-03-20" },
+    });
+
+    await checkPromise;
+
+    expect(win.webContents.send).toHaveBeenCalledWith(
+      "update:available",
+      expect.objectContaining({
+        version: "1.0.0",
+        diagnostic: expect.objectContaining({ remoteVersion: "1.0.0" }),
+      }),
+    );
+  });
+
+  it("auto-download: background checks stay silent", async () => {
+    let resolveCheck!: (value: unknown) => void;
+    mockAutoUpdater.checkForUpdates.mockReturnValue(
+      new Promise((resolve) => {
+        resolveCheck = resolve;
+      }),
+    );
+
+    const { mgr, win } = await createManager(undefined, { autoDownload: true });
+    const handlers = extractHandlers();
+
+    const checkPromise = mgr.checkNow();
+    handlers["update-available"]({
+      version: "1.0.0",
+      releaseDate: "2026-03-20",
+      releaseNotes: "Bug fixes",
+    });
+    resolveCheck({
+      updateInfo: { version: "1.0.0", releaseDate: "2026-03-20" },
+    });
+
+    await checkPromise;
+
+    expect(win.webContents.send).not.toHaveBeenCalledWith(
+      "update:available",
+      expect.anything(),
+    );
+  });
+
   // -------------------------------------------------------------------------
   // checking-for-update
   // -------------------------------------------------------------------------

--- a/tests/desktop/update-manager-full.test.ts
+++ b/tests/desktop/update-manager-full.test.ts
@@ -978,10 +978,10 @@ describe("constructor", () => {
     expect(mgr.getCapability()).toEqual({
       platform: "win32",
       check: true,
-      downloadMode: "external",
-      applyMode: "redirect",
-      applyLabel: "Download installer",
-      notes: expect.stringContaining("packaged installer"),
+      downloadMode: "in-app",
+      applyMode: "external-installer",
+      applyLabel: "Install",
+      notes: null,
     });
     expect(mockAutoUpdater.on).not.toHaveBeenCalled();
   });

--- a/tests/desktop/update-policy.test.ts
+++ b/tests/desktop/update-policy.test.ts
@@ -46,7 +46,7 @@ describe("desktop update policy", () => {
         buildSource: "local-dist",
         updateFeed: "https://example.test/latest-win.json",
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("keeps non-local builds on the normal update path", () => {

--- a/tests/desktop/windows-update-driver.test.ts
+++ b/tests/desktop/windows-update-driver.test.ts
@@ -1,4 +1,19 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
+
+const tempDir = join(tmpdir(), `nexu-windows-update-driver-${Date.now()}`);
+
+vi.mock("electron", () => ({
+  app: {
+    getPath: (name: string) => (name === "temp" ? tempDir : tempDir),
+    quit: vi.fn(),
+  },
+}));
+
 import {
   WindowsUpdateDriver,
   compareDesktopVersionsForTests,
@@ -6,6 +21,64 @@ import {
 } from "../../apps/desktop/main/updater/windows-update-driver";
 
 describe("windows update driver", () => {
+  it("reuses an existing installer when sha256 matches", async () => {
+    mkdirSync(tempDir, { recursive: true });
+    const payload = Buffer.from("verified-installer");
+    const sha256 = createHash("sha256").update(payload).digest("hex");
+    const installerPath = join(tempDir, "nexu-setup-0.1.1.exe");
+    writeFileSync(installerPath, payload);
+
+    const onDownloaded = vi.fn();
+    const driver = new WindowsUpdateDriver({
+      currentVersion: "0.1.0",
+      autoDownload: false,
+      openExternal: vi.fn(),
+      writeLog: vi.fn(),
+    });
+    driver.configure({ source: "r2", channel: "stable", feedUrl: null });
+    driver.bindEvents({
+      onChecking: vi.fn(),
+      onAvailable: vi.fn(),
+      onUnavailable: vi.fn(),
+      onProgress: vi.fn(),
+      onDownloaded,
+      onError: vi.fn(),
+    });
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        version: "0.1.1",
+        channel: "stable",
+        platform: "win32",
+        arch: "x64",
+        releaseDate: "2026-04-10T00:00:00Z",
+        installer: {
+          url: "http://localhost/installer.exe",
+          sha256,
+          size: payload.length,
+        },
+      }),
+      status: 200,
+      statusText: "OK",
+    });
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as typeof fetch;
+    try {
+      await driver.checkForUpdates();
+      const result = await driver.downloadUpdate();
+
+      expect(result).toEqual({ ok: true });
+      expect(onDownloaded).toHaveBeenCalledWith(
+        expect.objectContaining({ version: "0.1.1" }),
+      );
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("resolves the default nightly manifest URL", () => {
     expect(
       resolveWindowsManifestUrlForTests({
@@ -43,16 +116,44 @@ describe("windows update driver", () => {
     ).toBe(0);
   });
 
-  it("checks manifest and opens installer externally", async () => {
-    const openExternal = vi.fn().mockResolvedValue(undefined);
+  it("checks manifest and downloads installer in-app", async () => {
+    const payload = Buffer.from("windows-installer-payload");
+    const sha256 = createHash("sha256").update(payload).digest("hex");
+    const requestUrls: string[] = [];
+    const server = createServer((req, res) => {
+      if (!req.url) {
+        res.writeHead(404).end();
+        return;
+      }
+      requestUrls.push(req.url);
+      if (req.url === "/installer.exe") {
+        res.writeHead(200, {
+          "Content-Length": String(payload.length),
+          "Content-Type": "application/octet-stream",
+        });
+        res.end(payload);
+        return;
+      }
+      res.writeHead(404).end();
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected test server to bind to a TCP port");
+    }
+    const installerUrl = `http://127.0.0.1:${address.port}/installer.exe`;
+
     const onChecking = vi.fn();
     const onAvailable = vi.fn();
+    const onDownloaded = vi.fn();
     const onUnavailable = vi.fn();
 
     const driver = new WindowsUpdateDriver({
       currentVersion: "0.1.10-nightly.20260408",
       autoDownload: false,
-      openExternal,
+      openExternal: vi.fn().mockResolvedValue(undefined),
       writeLog: vi.fn(),
     });
     driver.configure({
@@ -66,7 +167,7 @@ describe("windows update driver", () => {
       onAvailable,
       onUnavailable,
       onProgress: vi.fn(),
-      onDownloaded: vi.fn(),
+      onDownloaded,
       onError: vi.fn(),
     });
 
@@ -79,7 +180,9 @@ describe("windows update driver", () => {
         arch: "x64",
         releaseDate: "2026-04-09T00:00:00Z",
         installer: {
-          url: "https://desktop-releases.nexu.io/nightly/win32/x64/nexu-latest-nightly-win-x64.exe",
+          url: installerUrl,
+          sha256,
+          size: payload.length,
         },
       }),
       status: 200,
@@ -95,18 +198,120 @@ describe("windows update driver", () => {
       expect(onAvailable).toHaveBeenCalledWith(
         expect.objectContaining({
           version: "0.1.10-nightly.20260409",
-          actionUrl:
-            "https://desktop-releases.nexu.io/nightly/win32/x64/nexu-latest-nightly-win-x64.exe",
+          actionUrl: installerUrl,
         }),
       );
 
-      await driver.downloadUpdate();
-      expect(openExternal).toHaveBeenCalledWith(
-        "https://desktop-releases.nexu.io/nightly/win32/x64/nexu-latest-nightly-win-x64.exe",
+      await expect(driver.downloadUpdate()).resolves.toEqual({ ok: true });
+      expect(onDownloaded).toHaveBeenCalledWith(
+        expect.objectContaining({ version: "0.1.10-nightly.20260409" }),
       );
+      expect(requestUrls).toEqual(["/installer.exe"]);
       expect(onUnavailable).not.toHaveBeenCalled();
     } finally {
       globalThis.fetch = originalFetch;
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+    }
+  });
+
+  it("does not start a second download while one is in progress", async () => {
+    const payload = Buffer.from("dedupe-download-payload");
+    const sha256 = createHash("sha256").update(payload).digest("hex");
+    let downloadRequests = 0;
+    let releaseResponse: (() => void) | null = null;
+    let signalRequestStarted: (() => void) | null = null;
+    const requestStarted = new Promise<void>((resolve) => {
+      signalRequestStarted = resolve;
+    });
+    const server = createServer((req, res) => {
+      if (req.url !== "/installer.exe") {
+        res.writeHead(404).end();
+        return;
+      }
+      downloadRequests += 1;
+      signalRequestStarted?.();
+      res.writeHead(200, {
+        "Content-Length": String(payload.length),
+        "Content-Type": "application/octet-stream",
+      });
+      releaseResponse = () => {
+        res.end(payload);
+      };
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected test server to bind to a TCP port");
+    }
+    const installerUrl = `http://127.0.0.1:${address.port}/installer.exe`;
+
+    const driver = new WindowsUpdateDriver({
+      currentVersion: "0.1.10-nightly.20260408",
+      autoDownload: false,
+      openExternal: vi.fn().mockResolvedValue(undefined),
+      writeLog: vi.fn(),
+    });
+    driver.configure({
+      source: "r2",
+      channel: "nightly",
+      feedUrl:
+        "https://desktop-releases.nexu.io/nightly/win32/x64/latest-win.json",
+    });
+    driver.bindEvents({
+      onChecking: vi.fn(),
+      onAvailable: vi.fn(),
+      onUnavailable: vi.fn(),
+      onProgress: vi.fn(),
+      onDownloaded: vi.fn(),
+      onError: vi.fn(),
+    });
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        version: "0.1.10-nightly.20260409",
+        channel: "nightly",
+        platform: "win32",
+        arch: "x64",
+        releaseDate: "2026-04-09T00:00:00Z",
+        installer: {
+          url: installerUrl,
+          sha256,
+          size: payload.length,
+        },
+      }),
+      status: 200,
+      statusText: "OK",
+    });
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as typeof fetch;
+    try {
+      await driver.checkForUpdates();
+      const first = driver.downloadUpdate();
+      const second = driver.downloadUpdate();
+      await requestStarted;
+      releaseResponse?.();
+      await expect(Promise.all([first, second])).resolves.toEqual([
+        { ok: true },
+        { ok: true },
+      ]);
+      expect(downloadRequests).toBe(1);
+    } finally {
+      globalThis.fetch = originalFetch;
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
     }
   });
 


### PR DESCRIPTION
## What

Add background auto-download support for desktop app updates, surface background update state in settings, and improve local validation tooling for update flows.

## Why

Users should not have to manually start every update download, and the settings UI needs to reflect when an update is already downloading or ready to install. Local test feeds also need better validation coverage so these flows can be exercised safely before release.

## How

- add background auto-download behavior in the desktop updater flow, including user-initiated vs periodic-check handling
- expose updater status to the renderer and update the settings/web UI to reflect checking, downloading, ready, and dismiss states
- enable local-test-feed periodic checks, reduce Windows initial delay, and extend the mock update server plus desktop tests for local validation

## Affected areas

- [x] Desktop app (Electron shell)
- [ ] Controller (backend / API)
- [x] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [x] Build / CI / Tooling

## Checklist

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

## Notes for reviewers

- Local validation confirmed that periodic checks now hit the mock feed and begin background downloads.
- `pnpm vitest tests/desktop/update-manager-full.test.ts --run` still has one pre-existing Windows capability expectation failure unrelated to this local validation commit.
- A local diagnostics text file remains untracked in the working tree and is not part of this PR.