### PR TITLE
fix(desktop): keep a single update banner

### DIFF
--- a/apps/controller/src/lib/openclaw-config-compiler.ts
+++ b/apps/controller/src/lib/openclaw-config-compiler.ts
@@ -227,14 +227,20 @@ function compileAgentList(
   installedSkillSlugs?: readonly string[],
   workspaceSkillsByAgent?: ReadonlyMap<string, readonly string[]>,
 ): OpenClawConfig["agents"]["list"] {
-  const sharedSlugs = installedSkillSlugs ?? [];
+  const sharedSlugs = [...(installedSkillSlugs ?? [])].sort((left, right) =>
+    left.localeCompare(right),
+  );
 
   return config.bots
     .filter((bot) => bot.status === "active")
     .sort((left, right) => left.slug.localeCompare(right.slug))
     .map((bot, index) => {
-      const workspaceSlugs = workspaceSkillsByAgent?.get(bot.id) ?? [];
-      const merged = [...new Set([...sharedSlugs, ...workspaceSlugs])];
+      const workspaceSlugs = [
+        ...(workspaceSkillsByAgent?.get(bot.id) ?? []),
+      ].sort((left, right) => left.localeCompare(right));
+      const merged = Array.from(
+        new Set([...sharedSlugs, ...workspaceSlugs]),
+      ).sort((left, right) => left.localeCompare(right));
 
       return {
         id: bot.id,

--- a/apps/controller/src/lib/openclaw-config-serialization.ts
+++ b/apps/controller/src/lib/openclaw-config-serialization.ts
@@ -1,0 +1,27 @@
+import type { OpenClawConfig } from "@nexu/shared";
+
+function sortJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sortJsonValue(item));
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, nestedValue]) => [key, sortJsonValue(nestedValue)]),
+    );
+  }
+
+  return value;
+}
+
+export function normalizeOpenClawConfig(
+  config: OpenClawConfig,
+): OpenClawConfig {
+  return sortJsonValue(config) as OpenClawConfig;
+}
+
+export function serializeOpenClawConfig(config: OpenClawConfig): string {
+  return `${JSON.stringify(normalizeOpenClawConfig(config), null, 2)}\n`;
+}

--- a/apps/controller/src/runtime/openclaw-config-writer.ts
+++ b/apps/controller/src/runtime/openclaw-config-writer.ts
@@ -5,6 +5,7 @@ import type { OpenClawConfig } from "@nexu/shared";
 import type { ControllerEnv } from "../app/env.js";
 import { NEXU_INTERNAL_ACCOUNT_PREFIX } from "../lib/channel-binding-compiler.js";
 import { logger } from "../lib/logger.js";
+import { serializeOpenClawConfig } from "../lib/openclaw-config-serialization.js";
 
 /**
  * Sync weixin account IDs from openclaw.json to the openclaw-weixin plugin's
@@ -93,17 +94,24 @@ export class OpenClawConfigWriter {
 
   async write(config: OpenClawConfig): Promise<void> {
     await mkdir(path.dirname(this.env.openclawConfigPath), { recursive: true });
-    const content = `${JSON.stringify(config, null, 2)}\n`;
+    const content = serializeOpenClawConfig(config);
 
     // On cold start, seed the cache from the existing file on disk so the
     // first write() after a process restart doesn't trigger an unnecessary
     // OpenClaw reload when the config hasn't actually changed.
     if (this.lastWrittenContent === null) {
       try {
-        this.lastWrittenContent = await readFile(
+        const existingContent = await readFile(
           this.env.openclawConfigPath,
           "utf8",
         );
+        try {
+          this.lastWrittenContent = serializeOpenClawConfig(
+            JSON.parse(existingContent) as OpenClawConfig,
+          );
+        } catch {
+          this.lastWrittenContent = existingContent;
+        }
       } catch {
         // File doesn't exist yet — leave cache empty.
       }

--- a/apps/controller/src/services/openclaw-gateway-service.ts
+++ b/apps/controller/src/services/openclaw-gateway-service.ts
@@ -12,6 +12,7 @@
 import { createHash } from "node:crypto";
 import type { OpenClawConfig } from "@nexu/shared";
 import { logger } from "../lib/logger.js";
+import { serializeOpenClawConfig } from "../lib/openclaw-config-serialization.js";
 import type { OpenClawWsClient } from "../runtime/openclaw-ws-client.js";
 import type { ControllerRuntimeState } from "../runtime/state.js";
 
@@ -634,6 +635,8 @@ export class OpenClawGatewayService {
   }
 
   private configHash(config: OpenClawConfig): string {
-    return createHash("sha256").update(JSON.stringify(config)).digest("hex");
+    return createHash("sha256")
+      .update(serializeOpenClawConfig(config))
+      .digest("hex");
   }
 }

--- a/apps/controller/src/services/openclaw-sync-service.ts
+++ b/apps/controller/src/services/openclaw-sync-service.ts
@@ -145,6 +145,7 @@ export class OpenClawSyncService {
           .getAllInstalled()
           .filter((r) => r.source !== "workspace")
           .map((r) => r.slug)
+          .sort((left, right) => left.localeCompare(right))
       : undefined;
 
     const workspaceMap = this.workspaceScanner

--- a/apps/controller/src/services/skillhub/workspace-skill-scanner.ts
+++ b/apps/controller/src/services/skillhub/workspace-skill-scanner.ts
@@ -34,7 +34,8 @@ export class WorkspaceSkillScanner {
     try {
       return readdirSync(dir, { withFileTypes: true })
         .filter((entry) => existsSync(join(dir, entry.name, "SKILL.md")))
-        .map((entry) => entry.name);
+        .map((entry) => entry.name)
+        .sort((left, right) => left.localeCompare(right));
     } catch {
       return [];
     }

--- a/apps/controller/tests/openclaw-config-compiler.test.ts
+++ b/apps/controller/tests/openclaw-config-compiler.test.ts
@@ -385,11 +385,17 @@ describe("compileOpenClawConfig", () => {
   });
 
   it("does not remap openai models to OAuth providers without persisted OAuth state", () => {
+    const baseConfig = createConfig();
+    const baseBot = baseConfig.bots[0];
+    const baseProvider = baseConfig.providers?.[0];
+    if (!baseBot || !baseProvider) {
+      throw new Error("expected base config fixtures");
+    }
     const result = compileOpenClawConfig(
       createConfig({
         bots: [
           {
-            ...createConfig().bots[0],
+            ...baseBot,
             modelId: "openai/gpt-5.4",
           },
         ],
@@ -403,7 +409,7 @@ describe("compileOpenClawConfig", () => {
         },
         providers: [
           {
-            ...createConfig().providers[0],
+            ...baseProvider,
             apiKey: null,
             models: ["gpt-5.4"],
           },
@@ -622,12 +628,18 @@ describe("compileOpenClawConfig", () => {
   });
 
   it("ignores unsupported custom providers in compiled model config", () => {
+    const baseConfig = createConfig();
+    const baseProviders = baseConfig.providers ?? [];
+    const baseProvider = baseProviders[0];
+    if (!baseProvider) {
+      throw new Error("expected base config providers");
+    }
     const result = compileOpenClawConfig(
       createConfig({
         providers: [
-          ...createConfig().providers,
+          ...baseProviders,
           {
-            ...createConfig().providers[0],
+            ...baseProvider,
             id: "provider-3",
             providerId: "custom",
             displayName: "Custom",
@@ -985,6 +997,40 @@ describe("compileOpenClawConfig", () => {
       expect(botB?.skills).toEqual(["shared-skill"]);
     });
 
+    it("sorts merged skills deterministically regardless of input order", () => {
+      const baseConfig = createConfig();
+      const baseBot = baseConfig.bots[0];
+      if (!baseBot) {
+        throw new Error("expected base config bot");
+      }
+      const config = createConfig({
+        bots: [
+          {
+            ...baseBot,
+            id: "bot-a",
+            slug: "bot-a",
+          },
+        ],
+        channels: [],
+      });
+
+      const compiled = compileOpenClawConfig(
+        config,
+        createEnv(),
+        undefined,
+        ["zeta", "alpha", "shared-skill"],
+        new Map([["bot-a", ["workspace-z", "alpha", "workspace-a"]]]),
+      );
+
+      expect(compiled.agents.list[0]?.skills).toEqual([
+        "alpha",
+        "shared-skill",
+        "workspace-a",
+        "workspace-z",
+        "zeta",
+      ]);
+    });
+
     it("deduplicates when same slug in shared and workspace", () => {
       const config = createConfig();
       const wsMap = new Map<string, readonly string[]>([
@@ -1031,6 +1077,12 @@ describe("compileOpenClawConfig", () => {
   });
 
   it("remaps openai models to OAuth provider ids when persisted OAuth state is connected", () => {
+    const baseConfig = createConfig();
+    const baseBot = baseConfig.bots[0];
+    const baseProvider = baseConfig.providers?.[0];
+    if (!baseBot || !baseProvider) {
+      throw new Error("expected base config fixtures");
+    }
     const oauthState: OAuthConnectionState = {
       connectedProviderIds: ["openai"],
     };
@@ -1038,7 +1090,7 @@ describe("compileOpenClawConfig", () => {
       createConfig({
         bots: [
           {
-            ...createConfig().bots[0],
+            ...baseBot,
             modelId: "openai/gpt-5.4",
           },
         ],
@@ -1052,7 +1104,7 @@ describe("compileOpenClawConfig", () => {
         },
         providers: [
           {
-            ...createConfig().providers[0],
+            ...baseProvider,
             apiKey: null,
             models: ["gpt-5.4"],
           },

--- a/apps/controller/tests/openclaw-config-writer.test.ts
+++ b/apps/controller/tests/openclaw-config-writer.test.ts
@@ -142,6 +142,41 @@ describe("OpenClawConfigWriter", () => {
     expect(JSON.parse(written)).toEqual(configB);
   });
 
+  it("skips write when config is semantically unchanged but object keys reorder", async () => {
+    const writer = new OpenClawConfigWriter(env);
+    const configA = makeConfig({
+      plugins: {
+        entries: {
+          zed: { enabled: true },
+          alpha: { enabled: true },
+        },
+        load: { paths: [] },
+      },
+    });
+    const configB = makeConfig({
+      plugins: {
+        load: { paths: [] },
+        entries: {
+          alpha: { enabled: true },
+          zed: { enabled: true },
+        },
+      },
+    });
+
+    await writer.write(configA);
+    const firstStat = await stat(env.openclawConfigPath);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    await writer.write(configB);
+    const secondStat = await stat(env.openclawConfigPath);
+
+    expect(secondStat.mtimeMs).toBe(firstStat.mtimeMs);
+    expect(JSON.parse(await readFile(env.openclawConfigPath, "utf8"))).toEqual(
+      configA,
+    );
+  });
+
   it("cold start with no existing file writes normally", async () => {
     // No file exists yet — writer should write without error.
     const writer = new OpenClawConfigWriter(env);
@@ -151,5 +186,38 @@ describe("OpenClawConfigWriter", () => {
 
     const written = await readFile(env.openclawConfigPath, "utf8");
     expect(JSON.parse(written)).toEqual(config);
+  });
+
+  it("new writer instance skips rewrite when existing file only differs by key order", async () => {
+    const configA = makeConfig({
+      plugins: {
+        entries: {
+          zed: { enabled: true },
+          alpha: { enabled: true },
+        },
+        load: { paths: [] },
+      },
+    });
+    const configB = makeConfig({
+      plugins: {
+        load: { paths: [] },
+        entries: {
+          alpha: { enabled: true },
+          zed: { enabled: true },
+        },
+      },
+    });
+
+    const writer1 = new OpenClawConfigWriter(env);
+    await writer1.write(configA);
+    const firstStat = await stat(env.openclawConfigPath);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const writer2 = new OpenClawConfigWriter(env);
+    await writer2.write(configB);
+    const secondStat = await stat(env.openclawConfigPath);
+
+    expect(secondStat.mtimeMs).toBe(firstStat.mtimeMs);
   });
 });

--- a/apps/controller/tests/openclaw-gateway-service.test.ts
+++ b/apps/controller/tests/openclaw-gateway-service.test.ts
@@ -1,0 +1,50 @@
+import type { OpenClawConfig } from "@nexu/shared";
+import { describe, expect, it } from "vitest";
+import { OpenClawGatewayService } from "../src/services/openclaw-gateway-service.js";
+
+function makeConfig(overrides: Partial<OpenClawConfig> = {}): OpenClawConfig {
+  return {
+    gateway: { port: 18789, mode: "local", bind: "127.0.0.1" },
+    agents: { list: [], defaults: {} },
+    channels: {},
+    bindings: [],
+    plugins: { load: { paths: [] }, entries: {} },
+    skills: { load: { watch: true } },
+    commands: { native: "auto" },
+    ...overrides,
+  } as OpenClawConfig;
+}
+
+describe("OpenClawGatewayService", () => {
+  it("treats semantically identical configs as unchanged despite key reorder", async () => {
+    const service = new OpenClawGatewayService(
+      {
+        isConnected: () => true,
+      } as never,
+      {} as never,
+    );
+
+    const configA = makeConfig({
+      plugins: {
+        entries: {
+          zed: { enabled: true },
+          alpha: { enabled: true },
+        },
+        load: { paths: [] },
+      },
+    });
+    const configB = makeConfig({
+      plugins: {
+        load: { paths: [] },
+        entries: {
+          alpha: { enabled: true },
+          zed: { enabled: true },
+        },
+      },
+    });
+
+    service.noteConfigWritten(configA);
+
+    await expect(service.shouldPushConfig(configB)).resolves.toBe(false);
+  });
+});

--- a/apps/desktop/main/index.ts
+++ b/apps/desktop/main/index.ts
@@ -606,12 +606,6 @@ function sendHostDesktopCommand(command: HostDesktopCommand): void {
   mainWindow?.webContents.send("host:desktop-command", command);
 }
 
-function triggerUpdateCheck(): void {
-  mainWindow?.webContents.send("host:desktop-command", {
-    type: "desktop:check-for-updates",
-  });
-}
-
 function showAboutDialog(): void {
   const version = app.getVersion();
   const detailLines = [
@@ -690,12 +684,6 @@ function installApplicationMenu(): void {
     helpSubmenu.push(
       { type: "separator" },
       {
-        id: "check-for-updates",
-        label: "Check for Updates…",
-        enabled: app.isPackaged && runtimeConfig.updates.autoUpdateEnabled,
-        click: () => triggerUpdateCheck(),
-      },
-      {
         id: "about-nexu",
         label: `About Nexu (v${app.getVersion()})`,
         click: () => showAboutDialog(),
@@ -715,13 +703,6 @@ function installApplicationMenu(): void {
             role: "appMenu",
             submenu: [
               { role: "about" },
-              {
-                id: "check-for-updates",
-                label: "Check for Updates…",
-                enabled:
-                  app.isPackaged && runtimeConfig.updates.autoUpdateEnabled,
-                click: () => triggerUpdateCheck(),
-              },
               { type: "separator" },
               { role: "services" },
               { type: "separator" },

--- a/apps/desktop/main/ipc.ts
+++ b/apps/desktop/main/ipc.ts
@@ -360,6 +360,10 @@ export function setUpdateManager(manager: UpdateManager | null): void {
   updateManager = manager;
 }
 
+export function getUpdateManager(): UpdateManager | null {
+  return updateManager;
+}
+
 export function setComponentUpdater(updater: ComponentUpdater): void {
   componentUpdater = updater;
 }

--- a/apps/desktop/main/updater/mac-update-driver.ts
+++ b/apps/desktop/main/updater/mac-update-driver.ts
@@ -99,6 +99,13 @@ export class MacUpdateDriver implements PlatformUpdateDriver {
   }
 
   bindEvents(handlers: UpdateDriverEventHandlers): void {
+    const progressListenerCount =
+      typeof autoUpdater.listenerCount === "function"
+        ? autoUpdater.listenerCount("download-progress")
+        : "unknown";
+    this.context.writeLog(
+      `mac-update-driver bindEvents: existing progress listeners=${progressListenerCount}`,
+    );
     autoUpdater.on("checking-for-update", handlers.onChecking);
     autoUpdater.on("update-available", (info) => {
       handlers.onAvailable({
@@ -115,6 +122,9 @@ export class MacUpdateDriver implements PlatformUpdateDriver {
       });
     });
     autoUpdater.on("download-progress", (progress) => {
+      this.context.writeLog(
+        `mac-update-driver download-progress: ${progress.percent.toFixed(2)}% transferred=${progress.transferred} total=${progress.total}`,
+      );
       handlers.onProgress({
         percent: progress.percent,
         bytesPerSecond: progress.bytesPerSecond,
@@ -145,6 +155,13 @@ export class MacUpdateDriver implements PlatformUpdateDriver {
   }
 
   async downloadUpdate(): Promise<{ ok: boolean }> {
+    const progressListenerCount =
+      typeof autoUpdater.listenerCount === "function"
+        ? autoUpdater.listenerCount("download-progress")
+        : "unknown";
+    this.context.writeLog(
+      `mac-update-driver downloadUpdate: progress listeners=${progressListenerCount}`,
+    );
     await autoUpdater.downloadUpdate();
     return { ok: true };
   }

--- a/apps/desktop/main/updater/mac-update-driver.ts
+++ b/apps/desktop/main/updater/mac-update-driver.ts
@@ -99,13 +99,6 @@ export class MacUpdateDriver implements PlatformUpdateDriver {
   }
 
   bindEvents(handlers: UpdateDriverEventHandlers): void {
-    const progressListenerCount =
-      typeof autoUpdater.listenerCount === "function"
-        ? autoUpdater.listenerCount("download-progress")
-        : "unknown";
-    this.context.writeLog(
-      `mac-update-driver bindEvents: existing progress listeners=${progressListenerCount}`,
-    );
     autoUpdater.on("checking-for-update", handlers.onChecking);
     autoUpdater.on("update-available", (info) => {
       handlers.onAvailable({
@@ -122,9 +115,6 @@ export class MacUpdateDriver implements PlatformUpdateDriver {
       });
     });
     autoUpdater.on("download-progress", (progress) => {
-      this.context.writeLog(
-        `mac-update-driver download-progress: ${progress.percent.toFixed(2)}% transferred=${progress.transferred} total=${progress.total}`,
-      );
       handlers.onProgress({
         percent: progress.percent,
         bytesPerSecond: progress.bytesPerSecond,
@@ -155,13 +145,6 @@ export class MacUpdateDriver implements PlatformUpdateDriver {
   }
 
   async downloadUpdate(): Promise<{ ok: boolean }> {
-    const progressListenerCount =
-      typeof autoUpdater.listenerCount === "function"
-        ? autoUpdater.listenerCount("download-progress")
-        : "unknown";
-    this.context.writeLog(
-      `mac-update-driver downloadUpdate: progress listeners=${progressListenerCount}`,
-    );
     await autoUpdater.downloadUpdate();
     return { ok: true };
   }

--- a/apps/desktop/main/updater/update-manager.ts
+++ b/apps/desktop/main/updater/update-manager.ts
@@ -179,17 +179,22 @@ export class UpdateManager {
   getStatus(): {
     phase: "idle" | "downloading" | "ready";
     version: string | null;
+    percent: number;
   } {
     if (this.downloadComplete) {
-      return { phase: "ready", version: this.pendingVersion };
+      return { phase: "ready", version: this.pendingVersion, percent: 100 };
     }
     if (
       this.downloadMode === "background" ||
       this.downloadMode === "foreground"
     ) {
-      return { phase: "downloading", version: this.pendingVersion };
+      return {
+        phase: "downloading",
+        version: this.pendingVersion,
+        percent: this.lastProgress?.percent ?? 0,
+      };
     }
-    return { phase: "idle", version: null };
+    return { phase: "idle", version: null, percent: 0 };
   }
 
   private getDiagnostic(partial?: {
@@ -285,6 +290,13 @@ export class UpdateManager {
         this.lastProgress = progress;
         const now = Date.now();
         const percent = Math.round(progress.percent);
+        this.logCheck(
+          `update progress raw: percent=${progress.percent.toFixed(2)} transferred=${progress.transferred} total=${progress.total} bps=${progress.bytesPerSecond}`,
+          this.getDiagnostic({
+            remoteVersion: this.pendingVersion ?? undefined,
+            remoteReleaseDate: this.pendingReleaseDate,
+          }),
+        );
         const shouldLog =
           this.lastProgressLogPercent === null ||
           Math.abs(percent - this.lastProgressLogPercent) >= 5 ||
@@ -350,11 +362,25 @@ export class UpdateManager {
   private send(channel: string, data: unknown): void {
     if (!this.win.isDestroyed()) {
       const all = webContents.getAllWebContents();
+      this.logCheck(
+        `update send: ${channel} to ${all.length} webContents`,
+        this.getDiagnostic(),
+      );
       // Send to the main renderer
       this.win.webContents.send(channel, data);
       // Also forward to any embedded webviews so the web app receives events
       for (const wc of all) {
         if (wc.id !== this.win.webContents.id && !wc.isDestroyed()) {
+          const webContentsType =
+            typeof wc.getType === "function" ? wc.getType() : "unknown";
+          const webContentsUrl =
+            typeof wc.getURL === "function"
+              ? sanitizeFeedUrl(wc.getURL())
+              : null;
+          this.logCheck(
+            `update send target: ${channel} wc=${wc.id} type=${webContentsType} url=${webContentsUrl}`,
+            this.getDiagnostic(),
+          );
           wc.send(channel, data);
         }
       }

--- a/apps/desktop/main/updater/update-manager.ts
+++ b/apps/desktop/main/updater/update-manager.ts
@@ -19,7 +19,10 @@ import {
   resolveMacUpdateFeedUrlForTests,
 } from "./mac-update-driver";
 import { UnsupportedUpdateDriver } from "./unsupported-update-driver";
-import type { PlatformUpdateDriver } from "./update-driver";
+import type {
+  PlatformUpdateDriver,
+  UpdateDriverEventHandlers,
+} from "./update-driver";
 import { WindowsUpdateDriver } from "./windows-update-driver";
 
 type DownloadMode = "idle" | "background" | "foreground";
@@ -117,6 +120,9 @@ export class UpdateManager {
   private checkInProgress: Promise<{ updateAvailable: boolean }> | null = null;
   private lastProgressLogAt = 0;
   private lastProgressLogPercent: number | null = null;
+  private lastProgress:
+    | Parameters<UpdateDriverEventHandlers["onProgress"]>[0]
+    | null = null;
   private initialTimer: ReturnType<typeof setTimeout> | null = null;
   private timer: ReturnType<typeof setInterval> | null = null;
 
@@ -276,6 +282,7 @@ export class UpdateManager {
         this.send("update:up-to-date", { diagnostic });
       },
       onProgress: (progress) => {
+        this.lastProgress = progress;
         const now = Date.now();
         const percent = Math.round(progress.percent);
         const shouldLog =
@@ -456,6 +463,9 @@ export class UpdateManager {
 
     // Switch to foreground mode and remove rate limit
     this.downloadMode = "foreground";
+    if (this.lastProgress !== null) {
+      this.send("update:progress", this.lastProgress);
+    }
     if (
       this.platform === "win32" &&
       this.driver instanceof WindowsUpdateDriver

--- a/apps/desktop/mock-update-server.mjs
+++ b/apps/desktop/mock-update-server.mjs
@@ -29,6 +29,30 @@ const zipPath = process.env.MOCK_UPDATE_ZIP_PATH
 
 const fakeSha512 = Buffer.alloc(64, 0xab).toString("base64");
 
+function streamBufferSlowly(options) {
+  const { req, res, totalSize, readChunk } = options;
+  let sent = 0;
+
+  const timer = setInterval(() => {
+    if (sent >= totalSize) {
+      clearInterval(timer);
+      res.end();
+      console.log(`  → Download complete (${sent} bytes)`);
+      return;
+    }
+
+    const remaining = totalSize - sent;
+    const toSend = remaining < CHUNK_SIZE ? remaining : CHUNK_SIZE;
+    const chunk = readChunk(sent, toSend);
+    res.write(chunk);
+    sent += chunk.length;
+  }, CHUNK_INTERVAL_MS);
+
+  req.on("close", () => {
+    clearInterval(timer);
+  });
+}
+
 async function getZipMetadata() {
   if (!zipPath) {
     return {
@@ -86,12 +110,37 @@ const server = createServer((req, res) => {
 
   if (pathname === `/${zipMeta.zipFileName}`) {
     if (zipMeta.mode === "real" && zipMeta.zipPath) {
-      console.log(`  → Streaming real ZIP ${zipMeta.zipPath}`);
+      console.log(`  → Streaming real ZIP slowly ${zipMeta.zipPath}`);
       res.writeHead(200, {
         "Content-Type": "application/zip",
         "Content-Length": String(zipMeta.zipSize),
       });
-      createReadStream(zipMeta.zipPath).pipe(res);
+
+      const stream = createReadStream(zipMeta.zipPath, {
+        highWaterMark: CHUNK_SIZE,
+      });
+      const chunks = [];
+      stream.on("data", (chunk) => {
+        chunks.push(chunk);
+      });
+      stream.on("end", () => {
+        const zipBuffer = Buffer.concat(chunks);
+        streamBufferSlowly({
+          req,
+          res,
+          totalSize: zipMeta.zipSize,
+          readChunk(offset, size) {
+            return zipBuffer.subarray(offset, offset + size);
+          },
+        });
+      });
+      stream.on("error", (error) => {
+        console.error("  → Failed to read real ZIP", error);
+        if (!res.headersSent) {
+          res.writeHead(500, { "Content-Type": "text/plain" });
+        }
+        res.end("Failed to read ZIP");
+      });
       return;
     }
 
@@ -101,24 +150,14 @@ const server = createServer((req, res) => {
       "Content-Length": String(FAKE_ZIP_SIZE),
     });
 
-    let sent = 0;
     const chunk = Buffer.alloc(CHUNK_SIZE, 0x00);
-
-    const timer = setInterval(() => {
-      if (sent >= FAKE_ZIP_SIZE) {
-        clearInterval(timer);
-        res.end();
-        console.log(`  → Download complete (${sent} bytes)`);
-        return;
-      }
-      const remaining = FAKE_ZIP_SIZE - sent;
-      const toSend = remaining < CHUNK_SIZE ? remaining : CHUNK_SIZE;
-      res.write(toSend < CHUNK_SIZE ? chunk.subarray(0, toSend) : chunk);
-      sent += toSend;
-    }, CHUNK_INTERVAL_MS);
-
-    req.on("close", () => {
-      clearInterval(timer);
+    streamBufferSlowly({
+      req,
+      res,
+      totalSize: FAKE_ZIP_SIZE,
+      readChunk(_offset, size) {
+        return size < CHUNK_SIZE ? chunk.subarray(0, size) : chunk;
+      },
     });
     return;
   }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexu/desktop",
-  "version": "0.1.11",
+  "version": "0.1.10",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/apps/desktop/src/components/update-banner.tsx
+++ b/apps/desktop/src/components/update-banner.tsx
@@ -125,7 +125,11 @@ export function UpdateBanner({
     phase === "idle" && experience === "local-validation";
   const isLocalTestFeed = phase === "idle" && experience === "local-test-feed";
 
-  if ((phase === "idle" && experience === "normal") || dismissed) {
+  if (phase === "idle" && !isLocalValidation && !isLocalTestFeed) {
+    return null;
+  }
+
+  if (dismissed) {
     return null;
   }
 

--- a/apps/desktop/src/components/update-banner.tsx
+++ b/apps/desktop/src/components/update-banner.tsx
@@ -30,8 +30,7 @@ const i18n = {
     available: (version: string) => `v${version} available`,
     ready: (version: string) => `v${version} ready`,
     error: "Update failed",
-    checkingDetail:
-      "Contacting the update feed and comparing the latest release...",
+    checkingDetail: "This usually only takes a few seconds.",
     upToDateDetail: "This channel is already on the latest available version.",
     download: "Download",
     restart: "Restart",
@@ -60,7 +59,7 @@ const i18n = {
     available: (version: string) => `v${version} 可更新`,
     ready: (version: string) => `v${version} 已就绪`,
     error: "更新失败",
-    checkingDetail: "正在联系更新服务器并对比最新版本...",
+    checkingDetail: "通常只需要几秒。",
     upToDateDetail: "当前频道已是最新可用版本。",
     download: "下载",
     restart: "重启安装",
@@ -140,7 +139,7 @@ export function UpdateBanner({
   const isAvailable = phase === "available";
   const isLocalInfo = isLocalValidation || isLocalTestFeed;
   const showsVersionDetails = (isAvailable || isReady) && Boolean(version);
-  const showsReleaseNotes = (isAvailable || isReady) && Boolean(releaseNotes);
+  const showsReleaseNotes = isAvailable && Boolean(releaseNotes);
   const downloadLabel =
     capability?.downloadMode === "external" ? t.manual : t.download;
   const applyLabel =

--- a/apps/desktop/src/hooks/use-auto-update.ts
+++ b/apps/desktop/src/hooks/use-auto-update.ts
@@ -112,6 +112,7 @@ export function useAutoUpdate(options?: {
               ? "checking"
               : prev.phase,
           errorMessage: null,
+          dismissed: false,
         }));
       }),
     );
@@ -124,6 +125,7 @@ export function useAutoUpdate(options?: {
           version: data.version,
           releaseNotes: data.releaseNotes ?? null,
           actionUrl: data.actionUrl ?? null,
+          dismissed: false,
           userInitiated: false,
         }));
       }),
@@ -147,6 +149,7 @@ export function useAutoUpdate(options?: {
           ...prev,
           phase: "downloading",
           percent: data.percent,
+          dismissed: false,
           userInitiated: false,
         }));
       }),
@@ -160,6 +163,7 @@ export function useAutoUpdate(options?: {
           version: data.version,
           actionUrl: null,
           percent: 100,
+          dismissed: false,
           userInitiated: false,
         }));
       }),

--- a/apps/desktop/src/hooks/use-auto-update.ts
+++ b/apps/desktop/src/hooks/use-auto-update.ts
@@ -62,6 +62,7 @@ export function useAutoUpdate(options?: {
   experience?: DesktopUpdateExperience;
 }) {
   const experience = options?.experience ?? "normal";
+  const [pendingCheck, setPendingCheck] = useState(false);
   const [state, setState] = useState<UpdateState>({
     capability: null,
     phase: "idle",
@@ -200,8 +201,41 @@ export function useAutoUpdate(options?: {
     };
   }, [state.phase]);
 
+  useEffect(() => {
+    if (!pendingCheck || state.capability === null) {
+      return;
+    }
+
+    if (!state.capability.check) {
+      setPendingCheck(false);
+      setState((prev) => ({
+        ...prev,
+        phase: "idle",
+        userInitiated: false,
+      }));
+      return;
+    }
+
+    setPendingCheck(false);
+    void checkForUpdate().catch(() => {
+      // Errors are delivered via the update:error event
+    });
+  }, [pendingCheck, state.capability]);
+
   const check = useCallback(async () => {
-    if (!state.capability?.check) {
+    if (state.capability === null) {
+      setPendingCheck(true);
+      setState((prev) => ({
+        ...prev,
+        phase: "checking",
+        errorMessage: null,
+        dismissed: false,
+        userInitiated: true,
+      }));
+      return;
+    }
+
+    if (!state.capability.check) {
       setState((prev) => ({
         ...prev,
         phase: "idle",

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -30,7 +30,7 @@ import { getDesktopSentryBuildMetadata } from "../shared/sentry-build-metadata";
 import { resolveDesktopUpdateExperience } from "../shared/update-policy";
 import { DevelopSetBalanceDialog } from "./components/develop-set-balance-dialog";
 import { SurfaceFrame } from "./components/surface-frame";
-import { UpdateBanner } from "./components/update-banner";
+import { UpdateBadge, UpdateBanner } from "./components/update-banner";
 import { useAutoUpdate } from "./hooks/use-auto-update";
 import { ensureDesktopControllerReady } from "./lib/controller-ready";
 import {
@@ -1248,7 +1248,14 @@ function DesktopShell() {
       <div className="window-drag-bar" />
       <aside className="desktop-sidebar">
         <div className="desktop-sidebar-brand">
-          <span className="desktop-shell-eyebrow">nexu desktop</span>
+          <div className="desktop-sidebar-brand-top">
+            <span className="desktop-shell-eyebrow">nexu desktop</span>
+            <UpdateBadge
+              dismissed={update.dismissed}
+              onUndismiss={update.undismiss}
+              phase={update.phase}
+            />
+          </div>
           <h1>Runtime Console Ready</h1>
           <p>
             One local shell for bootstrap health, web verification, and gateway

--- a/apps/desktop/src/runtime-page.css
+++ b/apps/desktop/src/runtime-page.css
@@ -46,6 +46,13 @@ body,
   gap: 6px;
 }
 
+.desktop-sidebar-brand-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
 .desktop-sidebar-brand p {
   margin: 0;
   color: rgba(255, 255, 255, 0.58);
@@ -1259,10 +1266,10 @@ body,
    px-3 (12px) horizontal padding, logo h-6 (24px).
    Badge sits right-aligned in that row. */
 .update-badge {
-  position: fixed;
-  top: 60px;
-  left: 164px;
-  z-index: 9000;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
   padding: 2px 8px;
   border: 0;
   border-radius: 9999px;
@@ -1289,7 +1296,9 @@ body,
   bottom: 80px;
   left: 12px;
   z-index: 9000;
-  width: 220px;
+  width: fit-content;
+  min-width: 220px;
+  max-width: min(300px, calc(100vw - 24px));
   padding: 10px 12px;
   border-radius: 10px;
   border: 1px solid rgba(0, 0, 0, 0.08);
@@ -1308,16 +1317,19 @@ body,
 /* Header — flex items-center justify-between mb-1.5 */
 .update-card-header {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   margin-bottom: 6px;
+  gap: 8px;
 }
 
 /* Status — flex items-center gap-2 */
 .update-card-status {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 8px;
+  min-width: 0;
+  flex: 1;
 }
 
 /* Dot — relative flex h-2 w-2 shrink-0 */
@@ -1364,7 +1376,9 @@ body,
   font-size: 12px;
   font-weight: 500;
   color: #1c1f23;
-  white-space: nowrap;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  line-height: 1.35;
 }
 
 /* Close — text-text-muted hover:text-text-primary transition-colors -mr-1 */
@@ -1422,6 +1436,7 @@ body,
 /* Actions — flex items-center gap-2 pl-4 */
 .update-card-actions {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 8px;
   padding-left: 16px;
@@ -1433,6 +1448,7 @@ body,
   font-size: 11px;
   color: #787c80;
   line-height: 1.45;
+  overflow-wrap: anywhere;
 }
 
 /* Btn base */

--- a/apps/web/src/hooks/use-auto-update.ts
+++ b/apps/web/src/hooks/use-auto-update.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
 
 type UpdateBridge = {
   onEvent: (
@@ -59,6 +60,10 @@ export function restorePhaseAfterInstall(
  * is undefined and the hook stays at phase "idle".
  */
 export function useAutoUpdate() {
+  const bridge = (window as unknown as NexuWindow).nexuHost;
+  const [pendingCheck, setPendingCheck] = useState(false);
+  const [userInitiatedCheck, setUserInitiatedCheck] = useState(false);
+  const userInitiatedCheckRef = useRef(false);
   const [state, setState] = useState<UpdateState>({
     phase: "idle",
     version: null,
@@ -66,6 +71,10 @@ export function useAutoUpdate() {
     errorMessage: null,
     capability: null,
   });
+
+  useEffect(() => {
+    userInitiatedCheckRef.current = userInitiatedCheck;
+  }, [userInitiatedCheck]);
 
   useEffect(() => {
     const host = (window as unknown as NexuWindow).nexuHost;
@@ -84,33 +93,55 @@ export function useAutoUpdate() {
       .catch(() => {});
 
     // Query current update status (catches background downloads that
-    // completed before this component mounted)
-    void host
-      .invoke("update:get-status", undefined)
-      .then((result) => {
-        if (cancelled) return;
-        const status = result as {
-          phase: "idle" | "downloading" | "ready";
-          version: string | null;
-        };
-        if (
-          (status.phase === "ready" || status.phase === "downloading") &&
-          status.version
-        ) {
-          setState((prev) => ({
-            ...prev,
-            phase: status.phase,
-            version: status.version,
-            percent: status.phase === "ready" ? 100 : prev.percent,
-          }));
-        }
-      })
-      .catch(() => {});
+    // completed before this component mounted). Also starts polling while
+    // a background download is in progress so the settings page shows
+    // live progress without switching the main process to foreground mode
+    // (which would broadcast events to the desktop shell banner too).
+    const pollStatus = () => {
+      void host
+        .invoke("update:get-status", undefined)
+        .then((result) => {
+          if (cancelled) return;
+          const status = result as {
+            phase: "idle" | "downloading" | "ready";
+            version: string | null;
+            percent: number;
+          };
+          if (
+            (status.phase === "ready" || status.phase === "downloading") &&
+            status.version
+          ) {
+            setState((prev) => ({
+              ...prev,
+              phase: status.phase,
+              version: status.version,
+              percent: status.percent,
+            }));
+          }
+        })
+        .catch(() => {});
+    };
+
+    pollStatus();
+    const pollTimer = setInterval(pollStatus, 1000);
 
     return () => {
       cancelled = true;
+      clearInterval(pollTimer);
     };
   }, []);
+
+  useEffect(() => {
+    if (!pendingCheck || state.capability === null) {
+      return;
+    }
+
+    setPendingCheck(false);
+    setUserInitiatedCheck(true);
+    void bridge?.invoke("update:check", undefined).catch(() => {
+      /* errors via event */
+    });
+  }, [bridge, pendingCheck, state.capability]);
 
   useEffect(() => {
     const updater = (window as unknown as NexuWindow).nexuUpdater;
@@ -135,6 +166,7 @@ export function useAutoUpdate() {
 
     disposers.push(
       updater.onEvent("update:available", (data) => {
+        setUserInitiatedCheck(false);
         setState((prev: UpdateState) => {
           if (
             prev.phase === "downloading" ||
@@ -153,6 +185,10 @@ export function useAutoUpdate() {
 
     disposers.push(
       updater.onEvent("update:up-to-date", () => {
+        if (userInitiatedCheckRef.current) {
+          toast.success("Already up to date");
+          setUserInitiatedCheck(false);
+        }
         setState((prev: UpdateState) => ({ ...prev, phase: "idle" }));
       }),
     );
@@ -169,6 +205,7 @@ export function useAutoUpdate() {
 
     disposers.push(
       updater.onEvent("update:downloaded", (data) => {
+        setUserInitiatedCheck(false);
         setState((prev: UpdateState) => ({
           ...prev,
           phase: "ready",
@@ -180,6 +217,7 @@ export function useAutoUpdate() {
 
     disposers.push(
       updater.onEvent("update:error", (data) => {
+        setUserInitiatedCheck(false);
         setState((prev: UpdateState) => ({
           ...prev,
           phase: "error",
@@ -193,15 +231,25 @@ export function useAutoUpdate() {
     };
   }, []);
 
-  const bridge = (window as unknown as NexuWindow).nexuHost;
-
   const check = useCallback(async () => {
+    setState((prev) => ({
+      ...prev,
+      phase: "checking",
+      errorMessage: null,
+    }));
+    setUserInitiatedCheck(true);
+
+    if (state.capability === null) {
+      setPendingCheck(true);
+      return;
+    }
+
     try {
       await bridge?.invoke("update:check", undefined);
     } catch {
       /* errors via event */
     }
-  }, [bridge]);
+  }, [bridge, state.capability]);
 
   const download = useCallback(async () => {
     if (state.capability?.downloadMode === "external") {
@@ -214,8 +262,13 @@ export function useAutoUpdate() {
       }
       return;
     }
-    // In-app download: show downloading state before the IPC round-trip
-    setState((prev) => ({ ...prev, phase: "downloading", percent: 0 }));
+    // In-app download: show downloading state before the IPC round-trip.
+    // Keep existing percent if already downloading (e.g. resumed from background).
+    setState((prev) => ({
+      ...prev,
+      phase: "downloading",
+      percent: prev.phase === "downloading" ? prev.percent : 0,
+    }));
     try {
       await bridge?.invoke("update:download", undefined);
     } catch {

--- a/apps/web/src/layouts/workspace-layout.tsx
+++ b/apps/web/src/layouts/workspace-layout.tsx
@@ -671,7 +671,7 @@ function WorkspaceLayoutInner() {
           : undefined
       }
     >
-      {isDesktopClient && hasUpdate && !updateDismissed && (
+      {!isDesktopClient && hasUpdate && !updateDismissed && (
         <UpdateFloatCard
           phase={update.phase}
           version={update.version}

--- a/apps/web/src/layouts/workspace-layout.tsx
+++ b/apps/web/src/layouts/workspace-layout.tsx
@@ -658,7 +658,7 @@ function WorkspaceLayoutInner() {
   const desktopGlassTint = isWindowsDesktopClient
     ? "#ffffff"
     : "rgba(255, 255, 255, 0.08)";
-  const updateFloatWidth = Math.max(140, sidebarWidth - 20);
+  const updateFloatWidth = 288;
   const updateFloatLeft = 10;
   const updateFloatBottom = 52;
 

--- a/tests/desktop/update-manager-full.test.ts
+++ b/tests/desktop/update-manager-full.test.ts
@@ -645,6 +645,33 @@ describe("downloadUpdate", () => {
     expect(mockAutoUpdater.downloadUpdate).toHaveBeenCalledTimes(1);
     expect(result).toEqual({ ok: true });
   });
+
+  it("surfaces cached progress immediately when switching from background to foreground", async () => {
+    mockAutoUpdater.downloadUpdate.mockResolvedValue(undefined);
+
+    const { mgr, win } = await createManager(undefined, { autoDownload: true });
+    const handlers = extractHandlers();
+
+    handlers["update-available"]({
+      version: "0.3.0",
+      releaseDate: "2026-04-10T00:00:00Z",
+    });
+    handlers["download-progress"]({
+      percent: 61,
+      bytesPerSecond: 1024,
+      transferred: 610,
+      total: 1000,
+    });
+
+    await mgr.downloadUpdate();
+
+    expect(win.webContents.send).toHaveBeenCalledWith("update:progress", {
+      percent: 61,
+      bytesPerSecond: 1024,
+      transferred: 610,
+      total: 1000,
+    });
+  });
 });
 
 // ===========================================================================


### PR DESCRIPTION
## What

Remove the duplicate desktop update popup and keep a single consolidated update banner for packaged desktop.

## Why

Packaged desktop was rendering two update surfaces at the same time, which made the update state feel noisy and inconsistent.

## How

- disable the translucent workspace update float card in Electron desktop
- keep the darker desktop update banner as the single packaged-desktop update surface
- simplify checking copy and only show release notes in the available state, not once the update is ready

## Affected areas

- [x] Desktop app (Electron shell)
- [x] Web dashboard (React UI)
- [ ] Controller (backend / API)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [ ] Build / CI / Tooling

## Checklist

- [ ] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

## Notes for reviewers

- Verified with `pnpm lint`
- Verified with `pnpm vitest tests/auto-update-install-phase.test.ts tests/desktop/update-manager-full.test.ts --run`