### PR TITLE
fix: align settings model picker and analytics default

### DIFF
--- a/apps/controller/src/lib/openclaw-config-compiler.ts
+++ b/apps/controller/src/lib/openclaw-config-compiler.ts
@@ -278,7 +278,7 @@ function compilePlugins(
   // config omits it, the next write creates a diff that triggers a
   // gateway restart, and the cycle repeats.
   const prewarmedChannelPluginIds = ["feishu", "openclaw-weixin"];
-  const analyticsEnabled = config.desktop.analyticsEnabled === true;
+  const analyticsEnabled = config.desktop.analyticsEnabled !== false;
   const platformPluginIds = [
     "nexu-runtime-model",
     "nexu-credit-guard",

--- a/apps/controller/src/store/nexu-config-store.ts
+++ b/apps/controller/src/store/nexu-config-store.ts
@@ -2013,7 +2013,7 @@ export class NexuConfigStore {
   }
 
   async getDesktopAnalyticsEnabled(): Promise<boolean> {
-    return (await this.getStoredDesktopAnalyticsEnabled()) ?? false;
+    return (await this.getStoredDesktopAnalyticsEnabled()) ?? true;
   }
 
   async setDesktopAnalyticsEnabled(enabled: boolean): Promise<boolean> {

--- a/apps/controller/src/store/nexu-config-store.ts
+++ b/apps/controller/src/store/nexu-config-store.ts
@@ -636,7 +636,9 @@ export class NexuConfigStore {
         integrations: [],
         channels: [],
         templates: {},
-        desktop: {},
+        desktop: {
+          analyticsEnabled: true,
+        },
         secrets: {},
       }),
     );
@@ -2013,7 +2015,12 @@ export class NexuConfigStore {
   }
 
   async getDesktopAnalyticsEnabled(): Promise<boolean> {
-    return (await this.getStoredDesktopAnalyticsEnabled()) ?? true;
+    const storedValue = await this.getStoredDesktopAnalyticsEnabled();
+    if (storedValue !== null) {
+      return storedValue;
+    }
+
+    return this.setDesktopAnalyticsEnabled(true);
   }
 
   async setDesktopAnalyticsEnabled(enabled: boolean): Promise<boolean> {

--- a/apps/web/src/lib/desktop-analytics-preference.ts
+++ b/apps/web/src/lib/desktop-analytics-preference.ts
@@ -1,0 +1,22 @@
+import { ANALYTICS_PREFERENCE_STORAGE_KEY } from "./tracking";
+
+export function readAnalyticsPreferenceFromStorage(
+  storage: Pick<Storage, "getItem"> | null | undefined,
+): boolean | null {
+  if (!storage) {
+    return null;
+  }
+
+  try {
+    const value = storage.getItem(ANALYTICS_PREFERENCE_STORAGE_KEY);
+    if (value === "1") {
+      return true;
+    }
+    if (value === "0") {
+      return false;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -25,9 +25,10 @@ import "./index.css";
 const posthogApiKey = import.meta.env.VITE_POSTHOG_API_KEY;
 const analyticsEnabledByPreference = (() => {
   try {
-    return localStorage.getItem(ANALYTICS_PREFERENCE_STORAGE_KEY) === "1";
+    const value = localStorage.getItem(ANALYTICS_PREFERENCE_STORAGE_KEY);
+    return value === null ? true : value === "1";
   } catch {
-    return false;
+    return true;
   }
 })();
 

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -7,14 +7,19 @@ import React, { useEffect } from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { Toaster } from "sonner";
-import { getApiInternalDesktopCloudStatus } from "../lib/api/sdk.gen";
+import {
+  getApiInternalDesktopCloudStatus,
+  getApiInternalDesktopPreferences,
+} from "../lib/api/sdk.gen";
 import { App } from "./app";
 import { DESKTOP_REWARDS_QUERY_KEY } from "./hooks/use-desktop-rewards";
 import { LocaleProvider } from "./hooks/use-locale";
 import "./lib/api";
 import { getAnalyticsAppMetadata } from "./lib/analytics-app-metadata";
+import { readAnalyticsPreferenceFromStorage } from "./lib/desktop-analytics-preference";
 import {
   ANALYTICS_PREFERENCE_STORAGE_KEY,
+  disableAnalytics,
   identifyAuthenticatedUser,
   initializeAnalytics,
   resetAnalytics,
@@ -23,16 +28,11 @@ import "./i18n";
 import "./index.css";
 
 const posthogApiKey = import.meta.env.VITE_POSTHOG_API_KEY;
-const analyticsEnabledByPreference = (() => {
-  try {
-    const value = localStorage.getItem(ANALYTICS_PREFERENCE_STORAGE_KEY);
-    return value === null ? true : value === "1";
-  } catch {
-    return true;
-  }
-})();
+const analyticsEnabledByPreference = readAnalyticsPreferenceFromStorage(
+  typeof window === "undefined" ? null : window.localStorage,
+);
 
-if (posthogApiKey && analyticsEnabledByPreference) {
+if (posthogApiKey && analyticsEnabledByPreference === true) {
   const { appName, appVersion } = getAnalyticsAppMetadata();
   initializeAnalytics({
     apiKey: posthogApiKey,
@@ -41,6 +41,58 @@ if (posthogApiKey && analyticsEnabledByPreference) {
     appName,
     appVersion,
   });
+}
+
+function DesktopAnalyticsBootstrap() {
+  useEffect(() => {
+    let cancelled = false;
+
+    const syncAnalyticsPreference = async () => {
+      try {
+        const { data } = await getApiInternalDesktopPreferences();
+        if (cancelled || !data) {
+          return;
+        }
+
+        try {
+          localStorage.setItem(
+            ANALYTICS_PREFERENCE_STORAGE_KEY,
+            data.analyticsEnabled ? "1" : "0",
+          );
+        } catch {
+          // Ignore local persistence failures.
+        }
+
+        if (!posthogApiKey) {
+          return;
+        }
+
+        if (data.analyticsEnabled) {
+          const { appName, appVersion } = getAnalyticsAppMetadata();
+          initializeAnalytics({
+            apiKey: posthogApiKey,
+            apiHost: import.meta.env.VITE_POSTHOG_HOST,
+            environment: import.meta.env.MODE,
+            appName,
+            appVersion,
+          });
+          return;
+        }
+
+        disableAnalytics();
+      } catch {
+        // Keep the existing analytics state if preferences cannot be loaded.
+      }
+    };
+
+    void syncAnalyticsPreference();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return null;
 }
 
 function AnalyticsSessionSync() {
@@ -145,6 +197,7 @@ ReactDOM.createRoot(root).render(
     <LocaleProvider>
       <QueryClientProvider client={queryClient}>
         <BrowserRouter>
+          <DesktopAnalyticsBootstrap />
           <AnalyticsSessionSync />
           <DesktopRewardsSync />
           <App />

--- a/apps/web/src/pages/models.tsx
+++ b/apps/web/src/pages/models.tsx
@@ -1,4 +1,5 @@
 import { GitHubStarCta } from "@/components/github-star-cta";
+import { ModelPickerDropdown } from "@/components/model-picker-dropdown";
 import { ModelLogo, ProviderLogo } from "@/components/provider-logo";
 import { useAutoUpdate } from "@/hooks/use-auto-update";
 import {
@@ -1000,7 +1001,7 @@ function _GeneralSettings() {
               </div>
             </div>
             <Switch
-              checked={desktopPreferences?.analyticsEnabled ?? false}
+              checked={desktopPreferences?.analyticsEnabled ?? true}
               disabled={updateDesktopPreferences.isPending}
               onCheckedChange={(checked) => {
                 void updateDesktopPreferences.mutateAsync({
@@ -1833,50 +1834,27 @@ export function ModelsPage() {
                     </div>
                   </div>
                 </div>
-                <Select
-                  value={activeProvider?.id}
-                  onValueChange={(value) => {
-                    setSelectedProviderId(value);
+                <ModelPickerDropdown
+                  compact
+                  dropdownAlign="end"
+                  models={models}
+                  currentModelId={currentModelId}
+                  emptyLabel={t("models.noModelConfigured")}
+                  onSelectModel={(modelId) => {
+                    const providerId = getProviderIdFromModelId(
+                      models,
+                      modelId,
+                    );
+                    if (providerId) {
+                      setSelectedProviderId(providerId);
+                    }
                     clearSetupParam();
+                    updateModel.mutate(modelId);
                   }}
-                >
-                  <SelectTrigger className="inline-flex h-auto w-[180px] items-center gap-2 rounded-lg border-border bg-surface-0 px-3 py-1.5 text-[12px] font-medium text-text-primary shadow-none hover:bg-surface-1">
-                    {activeProvider ? (
-                      <div className="flex min-w-0 items-center gap-2">
-                        <ProviderLogo
-                          provider={
-                            activeProvider.registryEntry?.id ??
-                            activeProvider.id
-                          }
-                          size={14}
-                        />
-                        <span className="truncate">{activeProvider.name}</span>
-                      </div>
-                    ) : (
-                      <span>{t("models.selectProvider")}</span>
-                    )}
-                  </SelectTrigger>
-                  <SelectContent
-                    align="end"
-                    className="rounded-xl border-border bg-surface-0 text-text-primary shadow-[0_12px_32px_rgba(0,0,0,0.12)]"
-                  >
-                    {sidebarItems.map((item) => (
-                      <SelectItem
-                        key={item.id}
-                        value={item.id}
-                        className="rounded-lg px-3 py-2 text-[12px] text-text-secondary focus:bg-surface-2 focus:text-text-primary data-[state=checked]:bg-surface-2 data-[state=checked]:text-text-primary"
-                      >
-                        <div className="flex min-w-0 items-center gap-2">
-                          <ProviderLogo
-                            provider={item.registryEntry?.id ?? item.id}
-                            size={14}
-                          />
-                          <span className="truncate">{item.name}</span>
-                        </div>
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  className="shrink-0"
+                  triggerClassName="min-w-[220px] justify-between"
+                  dropdownClassName="shadow-[0_12px_32px_rgba(0,0,0,0.12)]"
+                />
               </div>
             </div>
 

--- a/apps/web/src/pages/models.tsx
+++ b/apps/web/src/pages/models.tsx
@@ -316,6 +316,31 @@ function getProviderIdFromModelId(
   return provider || null;
 }
 
+export function getSettingsProviderSelectionIdForModel(
+  providerIds: string[],
+  models: Array<{ id: string; provider: string }>,
+  modelId: string,
+): string | null {
+  const providerId = getProviderIdFromModelId(models, modelId);
+  if (!providerId) {
+    return null;
+  }
+
+  const normalizedProviderId = normalizeProviderId(providerId) ?? providerId;
+  if (providerIds.includes(providerId)) {
+    return providerId;
+  }
+  if (providerIds.includes(normalizedProviderId)) {
+    return normalizedProviderId;
+  }
+
+  return (
+    providerIds.find((candidateId) =>
+      getProviderAliasCandidates(candidateId).includes(providerId),
+    ) ?? normalizedProviderId
+  );
+}
+
 type SettingsTab = "general" | "providers";
 
 function isSettingsTab(value: string | null): value is SettingsTab {
@@ -1841,7 +1866,8 @@ export function ModelsPage() {
                   currentModelId={currentModelId}
                   emptyLabel={t("models.noModelConfigured")}
                   onSelectModel={(modelId) => {
-                    const providerId = getProviderIdFromModelId(
+                    const providerId = getSettingsProviderSelectionIdForModel(
+                      sidebarItems.map((item) => item.id),
                       models,
                       modelId,
                     );

--- a/tests/controller/nexu-config-store-analytics.test.ts
+++ b/tests/controller/nexu-config-store-analytics.test.ts
@@ -1,0 +1,119 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ControllerEnv } from "#controller/app/env";
+import { NexuConfigStore } from "#controller/store/nexu-config-store";
+
+function makeTempDir(): string {
+  const dir = resolve(tmpdir(), `nexu-config-analytics-test-${Date.now()}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function createEnv(homeDir: string): ControllerEnv {
+  const openclawStateDir = resolve(homeDir, "runtime", "openclaw", "state");
+  return {
+    nodeEnv: "test",
+    port: 3010,
+    host: "127.0.0.1",
+    webUrl: "http://localhost:5173",
+    nexuCloudUrl: "https://nexu.io",
+    nexuLinkUrl: null,
+    nexuHomeDir: homeDir,
+    nexuConfigPath: resolve(homeDir, "config.json"),
+    artifactsIndexPath: resolve(homeDir, "artifacts", "index.json"),
+    compiledOpenclawSnapshotPath: resolve(homeDir, "compiled-openclaw.json"),
+    openclawStateDir,
+    openclawConfigPath: resolve(openclawStateDir, "openclaw.json"),
+    openclawSkillsDir: resolve(openclawStateDir, "skills"),
+    userSkillsDir: "/tmp/.agents/skills",
+    openclawExtensionsDir: resolve(openclawStateDir, "extensions"),
+    runtimePluginTemplatesDir: resolve(homeDir, "runtime-plugins"),
+    openclawRuntimeModelStatePath: resolve(
+      openclawStateDir,
+      "nexu-runtime-model.json",
+    ),
+    skillhubCacheDir: resolve(homeDir, "skillhub-cache"),
+    skillDbPath: resolve(homeDir, "skill-ledger.json"),
+    staticSkillsDir: undefined,
+    platformTemplatesDir: undefined,
+    openclawWorkspaceTemplatesDir: resolve(
+      openclawStateDir,
+      "workspace-templates",
+    ),
+    openclawBin: "openclaw",
+    litellmBaseUrl: null,
+    litellmApiKey: null,
+    openclawGatewayPort: 18789,
+    openclawGatewayToken: undefined,
+    manageOpenclawProcess: false,
+    gatewayProbeEnabled: true,
+    runtimeSyncIntervalMs: 2000,
+    runtimeHealthIntervalMs: 5000,
+    defaultModelId: "anthropic/claude-sonnet-4",
+    analyticsStatePath: resolve(homeDir, "analytics-state.json"),
+  };
+}
+
+describe("NexuConfigStore desktop analytics defaults", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("persists analytics enabled in the default config", async () => {
+    const env = createEnv(tempDir);
+    const store = new NexuConfigStore(env);
+
+    const config = await store.getConfig();
+    const rawConfig = JSON.parse(readFileSync(env.nexuConfigPath, "utf8")) as {
+      desktop?: { analyticsEnabled?: boolean };
+    };
+
+    expect(config.desktop.analyticsEnabled).toBe(true);
+    expect(rawConfig.desktop?.analyticsEnabled).toBe(true);
+  });
+
+  it("backfills analytics enabled when reading an older config without the key", async () => {
+    const env = createEnv(tempDir);
+    const legacyConfig = {
+      $schema: "https://nexu.io/config.json",
+      schemaVersion: 2,
+      app: {},
+      bots: [],
+      runtime: {
+        gateway: { port: 18789, bind: "loopback", authMode: "none" },
+        defaultModelId: "anthropic/claude-sonnet-4",
+      },
+      models: {
+        mode: "merge",
+        providers: {},
+      },
+      integrations: [],
+      channels: [],
+      templates: {},
+      desktop: {},
+      secrets: {},
+    };
+    writeFileSync(
+      env.nexuConfigPath,
+      `${JSON.stringify(legacyConfig, null, 2)}\n`,
+      "utf8",
+    );
+
+    const store = new NexuConfigStore(env);
+
+    expect(await store.getDesktopAnalyticsEnabled()).toBe(true);
+
+    const rawConfig = JSON.parse(readFileSync(env.nexuConfigPath, "utf8")) as {
+      desktop?: { analyticsEnabled?: boolean };
+    };
+    expect(rawConfig.desktop?.analyticsEnabled).toBe(true);
+  });
+});

--- a/tests/desktop/openclaw-config-compiler.test.ts
+++ b/tests/desktop/openclaw-config-compiler.test.ts
@@ -94,7 +94,7 @@ describe("compileOpenClawConfig", () => {
     });
     // Prewarm allowlist: prevents first-connect SIGUSR1 + drain window.
     expect(compiled.plugins?.allow).toContain("openclaw-weixin");
-    expect(compiled.plugins?.allow).not.toContain("langfuse-tracer");
+    expect(compiled.plugins?.allow).toContain("langfuse-tracer");
     expect(compiled.channels?.feishu?.enabled).toBe(true);
     expect(compiled.channels?.feishu?.accounts).toEqual({
       __nexu_internal_feishu_prewarm__: {
@@ -107,28 +107,28 @@ describe("compileOpenClawConfig", () => {
     expect(compiled.bindings).toEqual([]);
   });
 
-  it("only enables Langfuse tracer when desktop analytics is enabled", () => {
-    const disabledCompiled = compileOpenClawConfig(
+  it("enables Langfuse tracer by default and disables it when analytics is explicitly off", () => {
+    const defaultCompiled = compileOpenClawConfig(
       createBaseConfig(),
       createEnv(),
     );
+
+    expect(defaultCompiled.plugins?.allow).toContain("langfuse-tracer");
+    expect(defaultCompiled.plugins?.entries?.["langfuse-tracer"]).toEqual({
+      enabled: true,
+    });
+
+    const disabledConfig = createBaseConfig();
+    disabledConfig.desktop = {
+      analyticsEnabled: false,
+    };
+
+    const disabledCompiled = compileOpenClawConfig(disabledConfig, createEnv());
 
     expect(disabledCompiled.plugins?.allow).not.toContain("langfuse-tracer");
     expect(
       disabledCompiled.plugins?.entries?.["langfuse-tracer"],
     ).toBeUndefined();
-
-    const enabledConfig = createBaseConfig();
-    enabledConfig.desktop = {
-      analyticsEnabled: true,
-    };
-
-    const enabledCompiled = compileOpenClawConfig(enabledConfig, createEnv());
-
-    expect(enabledCompiled.plugins?.allow).toContain("langfuse-tracer");
-    expect(enabledCompiled.plugins?.entries?.["langfuse-tracer"]).toEqual({
-      enabled: true,
-    });
   });
 
   it("uses the real Feishu account once connected and does not keep the prewarm account", () => {

--- a/tests/web/desktop-analytics-preference.test.ts
+++ b/tests/web/desktop-analytics-preference.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+import { readAnalyticsPreferenceFromStorage } from "#web/lib/desktop-analytics-preference";
+
+describe("readAnalyticsPreferenceFromStorage", () => {
+  it("returns null when the preference key is missing", () => {
+    expect(
+      readAnalyticsPreferenceFromStorage({
+        getItem: vi.fn(() => null),
+      }),
+    ).toBeNull();
+  });
+
+  it("returns true for an enabled preference", () => {
+    expect(
+      readAnalyticsPreferenceFromStorage({
+        getItem: vi.fn(() => "1"),
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for a disabled preference", () => {
+    expect(
+      readAnalyticsPreferenceFromStorage({
+        getItem: vi.fn(() => "0"),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns null when storage access throws", () => {
+    expect(
+      readAnalyticsPreferenceFromStorage({
+        getItem: vi.fn(() => {
+          throw new Error("storage unavailable");
+        }),
+      }),
+    ).toBeNull();
+  });
+});

--- a/tests/web/models-selection.test.ts
+++ b/tests/web/models-selection.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { isModelSelected } from "#web/pages/models";
+import {
+  getSettingsProviderSelectionIdForModel,
+  isModelSelected,
+} from "#web/pages/models";
 
 describe("isModelSelected", () => {
   it("keeps legacy short default ids mapped to their full managed model ids only", () => {
@@ -19,5 +22,15 @@ describe("isModelSelected", () => {
 
   it("does not cross-match fully qualified ids from different providers", () => {
     expect(isModelSelected("openai/gpt-4.1", "ollama/gpt-4.1")).toBe(false);
+  });
+
+  it("normalizes aliased provider ids for the settings details pane", () => {
+    expect(
+      getSettingsProviderSelectionIdForModel(
+        ["kimi"],
+        [{ id: "moonshot/kimi-k2", provider: "moonshot", name: "Kimi K2" }],
+        "moonshot/kimi-k2",
+      ),
+    ).toBe("kimi");
   });
 });


### PR DESCRIPTION
## What

Align the settings page model switcher with the Home page model picker, and default desktop analytics to enabled on first launch.

## Why

The settings page was still using a provider-level dropdown instead of the model picker interaction used on Home, which made model switching inconsistent. Analytics was also defaulting off for fresh installs, while the intended behavior is to have it enabled by default.

## How

- Replace the settings header provider `Select` with the shared `ModelPickerDropdown` used on Home
- Switch the selected default model directly from that dropdown and sync the provider details pane to the chosen model's provider
- Change desktop analytics fallback defaults to `true` in the controller store, settings UI fallback, and frontend startup preference bootstrap

## Affected areas

- [ ] Desktop app (Electron shell)
- [ ] Controller (backend / API)
- [x] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [ ] Build / CI / Tooling

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

## Notes for reviewers

The settings page top-right control now reuses the same model-picker interaction as Home. Selecting a model there also updates the active provider detail pane so the rest of the page stays in sync.
