### PR TITLE
fix: keep windows tray menu open on click

### DIFF
--- a/apps/desktop/main/index.ts
+++ b/apps/desktop/main/index.ts
@@ -1157,6 +1157,14 @@ function destroyResidentTray(): void {
   residentTray = null;
 }
 
+function showResidentTrayMenu(): void {
+  if (!residentTray) {
+    return;
+  }
+
+  residentTray.popUpContextMenu();
+}
+
 function ensureResidentTray(): void {
   if (residentTray) {
     return;
@@ -1206,7 +1214,10 @@ function ensureResidentTray(): void {
     ]),
   );
   tray.on("click", () => {
-    showMainWindowFromResidentEntry();
+    showResidentTrayMenu();
+  });
+  tray.on("right-click", () => {
+    showResidentTrayMenu();
   });
 }
 

--- a/apps/desktop/main/index.ts
+++ b/apps/desktop/main/index.ts
@@ -1124,6 +1124,15 @@ function updateSystemTrayMenu(): void {
   );
 }
 
+function showSystemTrayMenu(): void {
+  if (!systemTray) {
+    return;
+  }
+
+  updateSystemTrayMenu();
+  systemTray.popUpContextMenu();
+}
+
 function showMainWindowFromResidentEntry(): void {
   const preferences = getDesktopShellPreferences();
 
@@ -1218,16 +1227,11 @@ async function ensureWindowsTray(): Promise<void> {
   updateSystemTrayMenu();
 
   systemTray.on("click", () => {
-    if (mainWindow?.isVisible()) {
-      hideMainWindowToBackground();
-      return;
-    }
-
-    showMainWindowFromResidentEntry();
+    showSystemTrayMenu();
   });
 
   systemTray.on("right-click", () => {
-    updateSystemTrayMenu();
+    showSystemTrayMenu();
   });
 }
 


### PR DESCRIPTION
## What

Fix the Windows tray icon interaction so clicking the tray icon reliably opens the tray menu instead of immediately dismissing it when the Nexu window is already focused.

## Why

When the main Nexu window was already visible and focused, clicking the tray icon could trigger the show/hide toggle at the same time as the native tray context menu. That caused the menu to flash and disappear before users could choose `Open` or `Quit`.

## How

Keep the existing tray menu contents, but route both left-click and right-click through a shared `showSystemTrayMenu()` helper that refreshes and explicitly pops up the context menu.
Remove the direct left-click visibility toggle from the tray icon so the `Open` action only happens from the tray menu itself.

## Affected areas

- [x] Desktop app (Electron shell)
- [ ] Controller (backend / API)
- [ ] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [ ] Build / CI / Tooling

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

## Notes for reviewers

`pnpm test` still reports an existing unrelated failure in `tests/desktop/skill-dir-watcher-workspace.test.ts` (`ignores non-skill workspace writes under openclawStateDir`). This tray change does not touch that area.
