### PR TITLE
fix: preserve dingtalk bundled plugin dependencies

### DIFF
--- a/apps/controller/scripts/bundle-runtime-plugins.mjs
+++ b/apps/controller/scripts/bundle-runtime-plugins.mjs
@@ -56,6 +56,23 @@ function getPackageNodeModules(packageRoot) {
   }
 }
 
+function hasRealPackages(nodeModulesDir) {
+  try {
+    return listPackages(nodeModulesDir).length > 0;
+  } catch {
+    return false;
+  }
+}
+
+export function resolveDependencyNodeModules(packageRoot) {
+  const packageNodeModules = getPackageNodeModules(packageRoot);
+  if (packageNodeModules && hasRealPackages(packageNodeModules)) {
+    return packageNodeModules;
+  }
+
+  return getVirtualStoreNodeModules(packageRoot);
+}
+
 function listPackages(nodeModulesDir) {
   const result = [];
 
@@ -177,8 +194,7 @@ async function bundlePlugin({ id, npmName }) {
   await maybeFixPluginManifest(outputDir);
 
   const rootDependencyNodeModules =
-    getPackageNodeModules(sourcePackageRoot) ??
-    getVirtualStoreNodeModules(sourcePackageRoot);
+    resolveDependencyNodeModules(sourcePackageRoot);
   if (!rootDependencyNodeModules) {
     throw new Error(`Unable to resolve node_modules for ${npmName}`);
   }
@@ -255,4 +271,6 @@ async function main() {
   }
 }
 
-await main();
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/apps/controller/tests/bundle-runtime-plugins.test.ts
+++ b/apps/controller/tests/bundle-runtime-plugins.test.ts
@@ -1,0 +1,78 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveDependencyNodeModules } from "../scripts/bundle-runtime-plugins.mjs";
+
+describe("resolveDependencyNodeModules", () => {
+  const tempRoots: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempRoots.map((rootDir) => rm(rootDir, { recursive: true, force: true })),
+    );
+    tempRoots.length = 0;
+  });
+
+  it("falls back to the pnpm virtual-store node_modules when the package-local directory only contains .bin", async () => {
+    const rootDir = await mkdtemp(
+      path.join(tmpdir(), "nexu-bundle-runtime-plugins-"),
+    );
+    tempRoots.push(rootDir);
+
+    const packageRoot = path.join(
+      rootDir,
+      "node_modules",
+      ".pnpm",
+      "@scope+plugin@1.0.0",
+      "node_modules",
+      "@scope",
+      "plugin",
+    );
+    const packageLocalNodeModules = path.join(packageRoot, "node_modules");
+    const virtualStoreNodeModules = path.join(
+      rootDir,
+      "node_modules",
+      ".pnpm",
+      "@scope+plugin@1.0.0",
+      "node_modules",
+    );
+    const dependencyDir = path.join(virtualStoreNodeModules, "dingtalk-stream");
+
+    await mkdir(path.join(packageLocalNodeModules, ".bin"), {
+      recursive: true,
+    });
+    await mkdir(dependencyDir, { recursive: true });
+    await writeFile(
+      path.join(dependencyDir, "package.json"),
+      '{ "name": "dingtalk-stream" }\n',
+      "utf8",
+    );
+
+    expect(resolveDependencyNodeModules(packageRoot)).toBe(
+      virtualStoreNodeModules,
+    );
+  });
+
+  it("prefers the package-local node_modules when it contains real dependencies", async () => {
+    const rootDir = await mkdtemp(
+      path.join(tmpdir(), "nexu-bundle-runtime-plugins-"),
+    );
+    tempRoots.push(rootDir);
+
+    const packageRoot = path.join(rootDir, "plugin");
+    const packageLocalNodeModules = path.join(packageRoot, "node_modules");
+    const dependencyDir = path.join(packageLocalNodeModules, "silk-wasm");
+
+    await mkdir(dependencyDir, { recursive: true });
+    await writeFile(
+      path.join(dependencyDir, "package.json"),
+      '{ "name": "silk-wasm" }\n',
+      "utf8",
+    );
+
+    expect(resolveDependencyNodeModules(packageRoot)).toBe(
+      packageLocalNodeModules,
+    );
+  });
+});

--- a/apps/desktop/scripts/dist-mac.mjs
+++ b/apps/desktop/scripts/dist-mac.mjs
@@ -472,7 +472,20 @@ async function stapleNotarizedAppBundles() {
   }
 }
 
-async function validatePackagedQqbotDependencies(releaseRoot) {
+const requiredBundledPluginArtifacts = [
+  {
+    pluginId: "openclaw-qqbot",
+    requiredPath: ["node_modules", "silk-wasm", "package.json"],
+    label: "silk-wasm",
+  },
+  {
+    pluginId: "dingtalk-connector",
+    requiredPath: ["node_modules", "dingtalk-stream", "package.json"],
+    label: "dingtalk-stream",
+  },
+];
+
+async function validatePackagedBundledPluginDependencies(releaseRoot) {
   const appBundleDirs = await readdir(releaseRoot, { withFileTypes: true });
   const packagedMacBundles = appBundleDirs.filter(
     (entry) =>
@@ -488,32 +501,29 @@ async function validatePackagedQqbotDependencies(releaseRoot) {
 
   for (const entry of packagedMacBundles) {
     const appRoot = resolve(releaseRoot, entry.name, "Nexu.app");
-    const qqbotPluginRoot = resolve(
-      appRoot,
-      "Contents",
-      "Resources",
-      "runtime",
-      "controller",
-      "plugins",
-      "openclaw-qqbot",
-    );
-    const silkWasmPackagePath = resolve(
-      qqbotPluginRoot,
-      "node_modules",
-      "silk-wasm",
-      "package.json",
-    );
-
-    if (!(await pathExists(qqbotPluginRoot))) {
-      throw new Error(
-        `[dist:mac] packaged app is missing openclaw-qqbot: ${qqbotPluginRoot}`,
+    for (const artifact of requiredBundledPluginArtifacts) {
+      const pluginRoot = resolve(
+        appRoot,
+        "Contents",
+        "Resources",
+        "runtime",
+        "controller",
+        "plugins",
+        artifact.pluginId,
       );
-    }
+      const dependencyPath = resolve(pluginRoot, ...artifact.requiredPath);
 
-    if (!(await pathExists(silkWasmPackagePath))) {
-      throw new Error(
-        `[dist:mac] packaged app is missing openclaw-qqbot dependency silk-wasm: ${silkWasmPackagePath}`,
-      );
+      if (!(await pathExists(pluginRoot))) {
+        throw new Error(
+          `[dist:mac] packaged app is missing ${artifact.pluginId}: ${pluginRoot}`,
+        );
+      }
+
+      if (!(await pathExists(dependencyPath))) {
+        throw new Error(
+          `[dist:mac] packaged app is missing ${artifact.pluginId} dependency ${artifact.label}: ${dependencyPath}`,
+        );
+      }
     }
   }
 }
@@ -921,8 +931,8 @@ async function main() {
     timings,
   );
   await timedStep(
-    "validate packaged qqbot dependencies",
-    async () => validatePackagedQqbotDependencies(releaseRoot),
+    "validate packaged bundled plugin dependencies",
+    async () => validatePackagedBundledPluginDependencies(releaseRoot),
     timings,
   );
   await timedStep(

--- a/apps/desktop/scripts/dist-win-stage.mjs
+++ b/apps/desktop/scripts/dist-win-stage.mjs
@@ -457,33 +457,44 @@ async function validateWinUnpackedReuse(releaseRoot) {
   }
 }
 
-async function validatePackagedQqbotDependencies(releaseRoot) {
+const requiredBundledPluginArtifacts = [
+  {
+    pluginId: "openclaw-qqbot",
+    requiredPath: ["node_modules", "silk-wasm", "package.json"],
+    label: "silk-wasm",
+  },
+  {
+    pluginId: "dingtalk-connector",
+    requiredPath: ["node_modules", "dingtalk-stream", "package.json"],
+    label: "dingtalk-stream",
+  },
+];
+
+async function validatePackagedBundledPluginDependencies(releaseRoot) {
   const winUnpackedRoot = resolve(releaseRoot, "win-unpacked");
-  const qqbotPluginRoot = resolve(
-    winUnpackedRoot,
-    "resources",
-    "runtime",
-    "controller",
-    "plugins",
-    "openclaw-qqbot",
-  );
-  const silkWasmPackagePath = resolve(
-    qqbotPluginRoot,
-    "node_modules",
-    "silk-wasm",
-    "package.json",
-  );
 
-  if (!(await pathExists(qqbotPluginRoot))) {
-    throw new Error(
-      `[dist:win] packaged app is missing openclaw-qqbot: ${qqbotPluginRoot}`,
+  for (const artifact of requiredBundledPluginArtifacts) {
+    const pluginRoot = resolve(
+      winUnpackedRoot,
+      "resources",
+      "runtime",
+      "controller",
+      "plugins",
+      artifact.pluginId,
     );
-  }
+    const dependencyPath = resolve(pluginRoot, ...artifact.requiredPath);
 
-  if (!(await pathExists(silkWasmPackagePath))) {
-    throw new Error(
-      `[dist:win] packaged app is missing openclaw-qqbot dependency silk-wasm: ${silkWasmPackagePath}`,
-    );
+    if (!(await pathExists(pluginRoot))) {
+      throw new Error(
+        `[dist:win] packaged app is missing ${artifact.pluginId}: ${pluginRoot}`,
+      );
+    }
+
+    if (!(await pathExists(dependencyPath))) {
+      throw new Error(
+        `[dist:win] packaged app is missing ${artifact.pluginId} dependency ${artifact.label}: ${dependencyPath}`,
+      );
+    }
   }
 }
 
@@ -1324,8 +1335,8 @@ async function main() {
     timings,
   );
   await timedStep(
-    "validate packaged qqbot dependencies",
-    async () => validatePackagedQqbotDependencies(releaseRoot),
+    "validate packaged bundled plugin dependencies",
+    async () => validatePackagedBundledPluginDependencies(releaseRoot),
     timings,
   );
 

--- a/apps/desktop/scripts/prepare-controller-sidecar.mjs
+++ b/apps/desktop/scripts/prepare-controller-sidecar.mjs
@@ -31,37 +31,45 @@ const sidecarPackageJsonPath = resolve(sidecarRoot, "package.json");
 const diagnosticsEnabled =
   process.env.NEXU_DESKTOP_DIST_DIAGNOSTICS === "1" ||
   process.env.NEXU_DESKTOP_DIST_DIAGNOSTICS?.toLowerCase() === "true";
-const qqbotPluginRelativeRoot = "openclaw-qqbot";
-const qqbotSilkWasmPackageRelativePath = join(
-  qqbotPluginRelativeRoot,
-  "node_modules",
-  "silk-wasm",
-  "package.json",
-);
+const requiredBundledPluginArtifacts = [
+  {
+    pluginId: "openclaw-qqbot",
+    requiredPath: join("node_modules", "silk-wasm", "package.json"),
+    label: "silk-wasm",
+  },
+  {
+    pluginId: "dingtalk-connector",
+    requiredPath: join("node_modules", "dingtalk-stream", "package.json"),
+    label: "dingtalk-stream",
+  },
+];
 
 function formatDurationMs(durationMs) {
   return `${(durationMs / 1000).toFixed(3)}s`;
 }
 
-async function ensureQqbotPluginDependencyTree(rootDir, label) {
-  const pluginDir = resolve(rootDir, qqbotPluginRelativeRoot);
-  const silkWasmPackagePath = resolve(
-    rootDir,
-    qqbotSilkWasmPackageRelativePath,
-  );
+async function ensureBundledPluginDependencyTree(rootDir, label) {
   const missing = [];
 
-  if (!(await pathExists(pluginDir))) {
-    missing.push(pluginDir);
-  }
-
-  if (!(await pathExists(silkWasmPackagePath))) {
-    missing.push(silkWasmPackagePath);
+  for (const artifact of requiredBundledPluginArtifacts) {
+    const pluginDir = resolve(rootDir, artifact.pluginId);
+    const requiredPath = resolve(
+      rootDir,
+      artifact.pluginId,
+      artifact.requiredPath,
+    );
+    if (!(await pathExists(pluginDir))) {
+      missing.push(pluginDir);
+      continue;
+    }
+    if (!(await pathExists(requiredPath))) {
+      missing.push(`${artifact.pluginId}:${artifact.label}:${requiredPath}`);
+    }
   }
 
   if (missing.length > 0) {
     throw new Error(
-      `[controller-sidecar] ${label} is missing bundled QQ plugin dependencies: ${missing.join(", ")}`,
+      `[controller-sidecar] ${label} is missing bundled plugin dependencies: ${missing.join(", ")}`,
     );
   }
 }
@@ -108,7 +116,7 @@ async function prepareControllerSidecar() {
   }
 
   if (await pathExists(controllerBundledPluginsRoot)) {
-    await ensureQqbotPluginDependencyTree(
+    await ensureBundledPluginDependencyTree(
       controllerBundledPluginsRoot,
       "controller bundled plugins",
     );
@@ -116,7 +124,7 @@ async function prepareControllerSidecar() {
       recursive: true,
       dereference: true,
     });
-    await ensureQqbotPluginDependencyTree(
+    await ensureBundledPluginDependencyTree(
       sidecarPluginsRoot,
       "controller sidecar plugins",
     );


### PR DESCRIPTION
## What

Repair bundled runtime plugin dependency resolution so packaged builds keep `dingtalk-stream` for `dingtalk-connector` without regressing `silk-wasm` for `openclaw-qqbot`.

## Why

PR #1001 fixed qqbot by preferring a plugin package's local `node_modules`, but that breaks pnpm-installed plugins like `dingtalk-connector` whose package-local `node_modules` only contains `.bin`. Packaged Windows builds could then ship a `dingtalk-connector` plugin without `dingtalk-stream`, causing `Cannot find module 'dingtalk-stream'` after gateway restarts.

## How

- Teach `bundle-runtime-plugins` to prefer package-local `node_modules` only when it contains real dependencies, otherwise fall back to the pnpm virtual-store dependency root.
- Add a regression test covering both layouts: qqbot-style local dependencies and dingtalk-style pnpm virtual-store dependencies.
- Expand controller sidecar and packaged artifact validation so both `openclaw-qqbot/silk-wasm` and `dingtalk-connector/dingtalk-stream` must exist.

## Affected areas

- [x] Desktop app (Electron shell)
- [x] Controller (backend / API)
- [ ] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [x] Build / CI / Tooling

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

## Notes for reviewers

- Targeted tests run: `pnpm --filter @nexu/controller exec vitest run tests/bundle-runtime-plugins.test.ts tests/openclaw-runtime-plugin-writer.test.ts`.
- I also reran `pnpm --filter @nexu/controller bundle-runtime-plugins` and `pnpm --filter @nexu/desktop prepare:controller-sidecar` and confirmed both packaged plugin trees now contain `dingtalk-stream` and `silk-wasm`.
