### PR TITLE
fix(desktop): restore version to 0.1.11

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexu/desktop",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## What
Restore desktop package version from 0.1.10 back to 0.1.11.

## Why
The version was accidentally downgraded to 0.1.10 for local nightly update testing in #1033 and merged to main.

## How
Single line change in `apps/desktop/package.json`.

## Affected areas
- Desktop version number only

## Checklist
- [x] No functional changes