### PR TITLE
fix: add missing i18n translations for Home and Conversation pages

### DIFF
--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -200,6 +200,7 @@ const en = {
   "home.minutesAgo": "Active {{count}} min ago",
   "home.hoursAgo": "Active {{count}} hr ago",
   "home.daysAgo": "Active {{count}} days ago",
+  "home.chat": "Chat",
   "home.feishu": "Feishu",
   "home.channel.feishu": "Feishu / Feishu",
   "home.channel.slack": "Slack",
@@ -688,6 +689,13 @@ const en = {
   "channels.openTelegramDesc":
     "Open your bot profile, start a direct chat, or add it to a group. Group replies work when the bot is mentioned.",
   "channels.openTelegramBot": "Open Bot",
+  "channels.open": "Open",
+  "channels.openInDiscord": "Open in Discord",
+  "channels.openInWhatsApp": "Open in WhatsApp",
+  "channels.openInDingTalk": "Open in DingTalk",
+  "channels.openInWeCom": "Open in WeCom",
+  "channels.openInQQ": "Open in QQ",
+  "channels.openInWeChat": "Open in WeChat",
   "channels.webhookUrl": "Webhook URL",
   "channels.credentials": "Credentials",
   "channels.accountId": "Account ID",
@@ -862,6 +870,7 @@ const en = {
   "sessions.chat.replyLabel": "Reply",
   "sessions.chat.toolActivity": "Tool",
   "sessions.chat.toolCompleted": "Completed",
+  "sessions.openFolder": "Open Folder",
 
   // ── Integrations Page ──
   "integrations.pageTitle": "Integrations",

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -197,6 +197,7 @@ const zhCN = {
   "home.minutesAgo": "{{count}} 分钟前活跃",
   "home.hoursAgo": "{{count}} 小时前活跃",
   "home.daysAgo": "{{count}} 天前活跃",
+  "home.chat": "对话",
   "home.feishu": "飞书",
   "home.channel.feishu": "飞书 / Feishu",
   "home.channel.slack": "Slack",
@@ -650,6 +651,13 @@ const zhCN = {
   "channels.openTelegramDesc":
     "打开你的 Bot 主页，发起私聊，或将它加入群组。群内只有在 @ 提及时才会回复。",
   "channels.openTelegramBot": "打开 Bot",
+  "channels.open": "打开",
+  "channels.openInDiscord": "在 Discord 中打开",
+  "channels.openInWhatsApp": "在 WhatsApp 中打开",
+  "channels.openInDingTalk": "在钉钉中打开",
+  "channels.openInWeCom": "在企微中打开",
+  "channels.openInQQ": "在 QQ 中打开",
+  "channels.openInWeChat": "在微信中打开",
   "channels.webhookUrl": "Webhook URL",
   "channels.credentials": "凭证",
   "channels.accountId": "账号 ID",
@@ -816,6 +824,7 @@ const zhCN = {
   "sessions.chat.replyLabel": "回复",
   "sessions.chat.toolActivity": "工具",
   "sessions.chat.toolCompleted": "已完成",
+  "sessions.openFolder": "打开文件夹",
 
   // ── Integrations Page ──
   "integrations.pageTitle": "集成",

--- a/apps/web/src/pages/home.tsx
+++ b/apps/web/src/pages/home.tsx
@@ -1199,7 +1199,7 @@ export function HomePage() {
                           }}
                           className="inline-flex items-center gap-1 text-[12px] font-medium text-text-secondary hover:text-text-primary transition-colors ml-3 shrink-0 leading-none"
                         >
-                          Chat
+                          {t("home.chat")}
                           <ArrowUpRight size={12} className="-mt-px" />
                         </a>
                       )}

--- a/apps/web/src/pages/sessions.tsx
+++ b/apps/web/src/pages/sessions.tsx
@@ -264,7 +264,7 @@ const DEFAULT_PLATFORM_CONFIG: PlatformConfig = {
   badgeClass:
     "border-[rgba(107,114,128,0.14)] bg-[rgba(107,114,128,0.08)] text-[#6B7280]",
   label: "Web",
-  openLabel: "Open",
+  openLabel: "channels.open",
 };
 
 const PLATFORM_CONFIG: Record<Platform, PlatformConfig> = {
@@ -272,55 +272,55 @@ const PLATFORM_CONFIG: Record<Platform, PlatformConfig> = {
     badgeClass:
       "border-[rgba(224,30,90,0.12)] bg-[rgba(224,30,90,0.06)] text-[#E01E5A]",
     label: "Slack",
-    openLabel: "Open in Slack",
+    openLabel: "channels.openInSlack",
   },
   discord: {
     badgeClass:
       "border-[rgba(88,101,242,0.14)] bg-[rgba(88,101,242,0.08)] text-[#5865F2]",
     label: "Discord",
-    openLabel: "Open in Discord",
+    openLabel: "channels.openInDiscord",
   },
   whatsapp: {
     badgeClass:
       "border-[rgba(37,211,102,0.14)] bg-[rgba(37,211,102,0.08)] text-[#25D366]",
     label: "WhatsApp",
-    openLabel: "Open in WhatsApp",
+    openLabel: "channels.openInWhatsApp",
   },
   telegram: {
     badgeClass:
       "border-[rgba(36,161,222,0.14)] bg-[rgba(36,161,222,0.08)] text-[#24A1DE]",
     label: "Telegram",
-    openLabel: "Open in Telegram",
+    openLabel: "channels.openInTelegram",
   },
   feishu: {
     badgeClass:
       "border-[rgba(51,112,255,0.14)] bg-[rgba(51,112,255,0.08)] text-[#3370FF]",
     label: "Feishu",
-    openLabel: "Open in Feishu",
+    openLabel: "channels.openInFeishu",
   },
   dingtalk: {
     badgeClass:
       "border-[rgba(44,44,44,0.14)] bg-[rgba(44,44,44,0.08)] text-[#2C2C2C]",
     label: "DingTalk",
-    openLabel: "Open in DingTalk",
+    openLabel: "channels.openInDingTalk",
   },
   wecom: {
     badgeClass:
       "border-[rgba(7,193,96,0.14)] bg-[rgba(7,193,96,0.08)] text-[#07C160]",
     label: "WeCom",
-    openLabel: "Open in WeCom",
+    openLabel: "channels.openInWeCom",
   },
   qqbot: {
     badgeClass:
       "border-[rgba(24,144,255,0.14)] bg-[rgba(24,144,255,0.08)] text-[#1890FF]",
     label: "QQ",
-    openLabel: "Open in QQ",
+    openLabel: "channels.openInQQ",
   },
   wechat: {
     badgeClass:
       "border-[rgba(141,200,27,0.14)] bg-[rgba(141,200,27,0.08)] text-[#8DC81B]",
     label: "WeChat",
-    openLabel: "Open in WeChat",
+    openLabel: "channels.openInWeChat",
   },
   web: DEFAULT_PLATFORM_CONFIG,
 };
@@ -751,7 +751,7 @@ export function SessionsPage() {
               )}
             >
               <FolderOpen className="size-[18px] text-text-secondary" />
-              <span>Open Folder</span>
+              <span>{t("sessions.openFolder")}</span>
             </button>
             {platform !== "web" &&
               platform !== "wechat" &&
@@ -773,7 +773,7 @@ export function SessionsPage() {
                   className={buttonClassName}
                 >
                   <PlatformIcon platform={platform} size={18} />
-                  <span>{platformCfg.openLabel}</span>
+                  <span>{t(platformCfg.openLabel)}</span>
                   <ArrowUpRight className="size-[16px] text-text-muted" />
                 </a>
               ) : (
@@ -783,7 +783,7 @@ export function SessionsPage() {
                   className={buttonClassName}
                 >
                   <PlatformIcon platform={platform} size={18} />
-                  <span>{platformCfg.openLabel}</span>
+                  <span>{t(platformCfg.openLabel)}</span>
                   <ArrowUpRight className="size-[16px] text-text-muted" />
                 </button>
               ))}


### PR DESCRIPTION
Replace hardcoded English strings with i18n keys:
- Home page "Chat" label
- Conversation page "Open Folder" button
- Conversation page platform open buttons (Open in Slack/Feishu/etc.)

Fixes #721

## What

<!-- One-liner: what does this PR do? -->

## Why

<!-- Motivation: what problem does it solve or what feature does it enable? Link related issues with "Closes #123". -->

## How

<!-- Implementation approach: key design decisions, trade-offs, or anything reviewers should know. -->

## Affected areas

<!-- Check all that apply -->

- [ ] Desktop app (Electron shell)
- [ ] Controller (backend / API)
- [ ] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [ ] Build / CI / Tooling

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

## Screenshots / recordings

<!-- If applicable, add screenshots or recordings to help explain the change. Delete this section if not needed. -->

## Notes for reviewers

<!-- Anything specific reviewers should focus on, test manually, or be aware of. Delete this section if not needed. -->
