### PR TITLE
chore: limit Feishu PR notifications to fork PRs

### DIFF
--- a/.github/workflows/feishu-pr-notify.yml
+++ b/.github/workflows/feishu-pr-notify.yml
@@ -1,7 +1,7 @@
 name: Feishu Pull Request Notification
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 permissions:
@@ -10,25 +10,12 @@ permissions:
 jobs:
   notify:
     name: Notify Feishu
+    if: ${{ github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
-      - name: Create GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.NEXU_PAL_APP_ID }}
-          private-key: ${{ secrets.NEXU_PAL_PRIVATE_KEY_PEM }}
-
-      - uses: actions/checkout@v4
-        with:
-          sparse-checkout: scripts
-
       - name: Send Feishu notification
         env:
           WEBHOOK_URL: ${{ secrets.NOTIFY_PR_FEISHU_WEBHOOK }}
-          EVENT_TYPE: pull_request
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
           TITLE: ${{ github.event.pull_request.title }}
           URL: ${{ github.event.pull_request.html_url }}
           NUMBER: ${{ github.event.pull_request.number }}
@@ -36,4 +23,74 @@ jobs:
           BODY: ${{ github.event.pull_request.body }}
           LABELS_OR_CATEGORY: ${{ join(github.event.pull_request.labels.*.name, ', ') }}
           REPO: ${{ github.repository }}
-        run: node scripts/notify/feishu-notify.mjs
+        run: |
+          node <<'EOF'
+          const webhookUrl = process.env.WEBHOOK_URL;
+          const title = process.env.TITLE ?? "";
+          const url = process.env.URL ?? "";
+          const number = process.env.NUMBER ?? "";
+          const author = process.env.AUTHOR ?? "";
+          const body = process.env.BODY ?? "";
+          const labelsOrCategory = process.env.LABELS_OR_CATEGORY || "none";
+          const repo = process.env.REPO ?? "";
+
+          if (!webhookUrl) {
+            console.error("WEBHOOK_URL is required");
+            process.exit(1);
+          }
+
+          if (!author) {
+            console.error("AUTHOR is required");
+            process.exit(1);
+          }
+
+          if (author === "sentry[bot]") {
+            console.log(
+              `Skipping Feishu notification for internal-equivalent author: ${author}`,
+            );
+            process.exit(0);
+          }
+
+          const bodySnippet =
+            body.length > 200 ? `${body.slice(0, 200)}...` : body || "(no description)";
+
+          const payload = {
+            msg_type: "interactive",
+            card: {
+              schema: "2.0",
+              header: {
+                title: {
+                  tag: "plain_text",
+                  content: `[${repo}] New Pull Request #${number}: ${title}`,
+                },
+                template: "purple",
+              },
+              body: {
+                direction: "vertical",
+                elements: [
+                  { tag: "markdown", content: `**Author:** ${author}` },
+                  { tag: "markdown", content: `**Labels:** ${labelsOrCategory}` },
+                  { tag: "markdown", content: bodySnippet },
+                  {
+                    tag: "button",
+                    text: { tag: "plain_text", content: "View Pull Request" },
+                    url,
+                    type: "primary",
+                  },
+                ],
+              },
+            },
+          };
+
+          const response = await fetch(webhookUrl, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(payload),
+          });
+
+          if (!response.ok) {
+            const text = await response.text();
+            console.error(`Webhook request failed (${response.status}): ${text}`);
+            process.exit(1);
+          }
+          EOF

--- a/specs/current/nexu-pal.md
+++ b/specs/current/nexu-pal.md
@@ -11,7 +11,7 @@ GitHub issue/discussion automation around **nexu-pal** issue processing and Feis
 | `Feishu Issue Notification` | `issues: [opened]` | `scripts/notify/feishu-notify.mjs` |
 | `nexu-pal: needs-triage notify` | `issues: [labeled]` (when label is `needs-triage`) | `scripts/notify/feishu-triage-notify.mjs` |
 | `Feishu Discussion Notification` | `discussion: [created]` | `scripts/notify/feishu-notify.mjs` |
-| `Feishu Pull Request Notification` | `pull_request: [opened]` | `scripts/notify/feishu-notify.mjs` |
+| `Feishu Pull Request Notification` | `pull_request_target: [opened]` | inline workflow script |
 
 ## On issue opened
 
@@ -63,9 +63,9 @@ Four GitHub Actions send Feishu webhook notifications for GitHub content:
 1. **Issue notification** — On `issues: [opened]`, sends the existing issue card to the issue notification webhook (`NOTIFY_ISSUE_FEISHU_WEBHOOK`), but skips notifications when the author is a repository-owner organization member or `sentry[bot]`.
 2. **Needs-triage issue notification** — On `issues: [labeled]`, when the added label is `needs-triage`, sends a triage card to either the bug or non-bug webhook based on the issue's current labels. The workflow maps GitHub secrets to internal env vars `BUG_WEBHOOK` and `REQ_WEBHOOK`.
 3. **Discussion notification** — On `discussion: [created]`, sends the existing discussion card format using the discussion category in place of labels to the discussion notification webhook (`NOTIFY_DISCUSSION_ISSUE_FEISHU_WEBHOOK`), but skips notifications when the author is a repository-owner organization member or `sentry[bot]`.
-4. **Pull request notification** — On `pull_request: [opened]`, sends the existing card format using pull request labels to the pull-request notification webhook (`NOTIFY_PR_FEISHU_WEBHOOK`), but skips notifications when the author is a repository-owner organization member or `sentry[bot]`.
+4. **Pull request notification** — On `pull_request_target: [opened]`, sends the existing card format using pull request labels to the pull-request notification webhook (`NOTIFY_PR_FEISHU_WEBHOOK`) for fork PRs only. The workflow is metadata-only (no checkout / no PR code execution), and internal same-repo PRs are skipped at the job level.
 
-The issue/discussion/pull-request workflows run `node scripts/notify/feishu-notify.mjs`. The triage workflow runs `node scripts/notify/feishu-triage-notify.mjs`.
+The issue/discussion workflows run `node scripts/notify/feishu-notify.mjs`. The pull-request workflow uses an inline metadata-only script. The triage workflow runs `node scripts/notify/feishu-triage-notify.mjs`.
 
 ## Labels managed
 
@@ -83,7 +83,7 @@ The issue/discussion/pull-request workflows run `node scripts/notify/feishu-noti
 
 The three **nexu-pal** workflows create a short-lived token via `actions/create-github-app-token@v1` using secrets `NEXU_PAL_APP_ID` and `NEXU_PAL_PRIVATE_KEY_PEM`. All GitHub API calls and the first-interaction action use this App token.
 
-The issue / discussion / pull-request Feishu notification workflows also create a short-lived GitHub App token so they can reuse the org-membership check and suppress notifications for organization-member internal authors; they also suppress `sentry[bot]` as internal-equivalent automation. The `needs-triage` Feishu workflow continues to use GitHub Actions event data plus Feishu incoming-webhook secrets.
+The issue / discussion Feishu notification workflows create a short-lived GitHub App token so they can reuse the org-membership check and suppress notifications for organization-member internal authors; they also suppress `sentry[bot]` as internal-equivalent automation. The pull-request Feishu workflow instead runs on `pull_request_target` with a metadata-only inline script, avoids checkout, and is gated to fork PRs only so external contributions notify safely without notifying same-repo PRs. The `needs-triage` Feishu workflow continues to use GitHub Actions event data plus Feishu incoming-webhook secrets.
 
 ## Secrets
 
@@ -120,5 +120,5 @@ scripts/nexu-pal/
   lib/signals/duplicate-detector.mjs  # duplicate detector stub
 scripts/notify/
   feishu-triage-notify.mjs # route needs-triage issue notifications via BUG_WEBHOOK / REQ_WEBHOOK
-  feishu-notify.mjs        # issue / discussion / pull-request Feishu webhook card notification with org-member suppression
+  feishu-notify.mjs        # issue / discussion Feishu webhook card notification with org-member suppression
 ```


### PR DESCRIPTION
## What

Limit the Feishu pull request notification workflow to fork PRs only and update the nexu-pal spec to match the new behavior.

## Why

The previous `pull_request` workflow could not access secrets for fork PRs, so external contributor PR notifications failed. Same-repo PRs do not need this notification path.

## How

- switch the PR notification workflow to `pull_request_target`
- gate the job to `github.event.pull_request.head.repo.fork`
- remove the GitHub App token and checkout dependency from the PR notification path
- inline the metadata-only Feishu payload sender and document the workflow change

## Affected areas

- [ ] Desktop app (Electron shell)
- [ ] Controller (backend / API)
- [ ] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [x] Build / CI / Tooling

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

## Notes for reviewers

This keeps the workflow metadata-only so fork PR notifications can use secrets safely without checking out or executing PR code.