### PR TITLE
fix: restore welcome locale switching and add channel setup diagnostics

### DIFF
--- a/apps/controller/src/app/bootstrap.ts
+++ b/apps/controller/src/app/bootstrap.ts
@@ -6,11 +6,16 @@ export async function bootstrapController(
 ): Promise<() => void> {
   logger.info(
     {
+      nexuHomeDir: container.env.nexuHomeDir,
       openclawOwnershipMode: container.env.openclawOwnershipMode,
       openclawBaseUrl: container.env.openclawBaseUrl,
       openclawConfigPath: container.env.openclawConfigPath,
       openclawStateDir: container.env.openclawStateDir,
+      openclawSkillsDir: container.env.openclawSkillsDir,
+      openclawWorkspaceTemplatesDir:
+        container.env.openclawWorkspaceTemplatesDir,
       openclawLogDir: container.env.openclawLogDir,
+      platformTemplatesDir: container.env.platformTemplatesDir ?? null,
     },
     "controller_bootstrap_runtime_contract",
   );

--- a/apps/controller/src/runtime/workspace-template-writer.ts
+++ b/apps/controller/src/runtime/workspace-template-writer.ts
@@ -67,6 +67,16 @@ export class WorkspaceTemplateWriter {
         // silently destroy self-evolution state.
         if (await this.pathExists(targetPath)) {
           preservedCount += 1;
+          logger.debug(
+            {
+              botId,
+              workspaceDir,
+              sourcePath,
+              targetPath,
+              decision: "preserved",
+            },
+            "platform_template_file_decision",
+          );
           continue;
         }
 
@@ -76,6 +86,16 @@ export class WorkspaceTemplateWriter {
           errorOnExist: false,
         });
         seededCount += 1;
+        logger.debug(
+          {
+            botId,
+            workspaceDir,
+            sourcePath,
+            targetPath,
+            decision: "seeded",
+          },
+          "platform_template_file_decision",
+        );
       }
 
       logger.debug(

--- a/apps/controller/src/services/channel-service.ts
+++ b/apps/controller/src/services/channel-service.ts
@@ -728,6 +728,23 @@ export class ChannelService {
     return this.configStore.getChannel(channelId);
   }
 
+  private getWorkspacePath(botId: string): string {
+    return path.join(this.env.openclawStateDir, "agents", botId);
+  }
+
+  private logChannelConnectSuccess(channel: ChannelResponse): void {
+    logger.info(
+      {
+        channelType: channel.channelType,
+        channelId: channel.id,
+        accountId: channel.accountId,
+        botId: channel.botId,
+        workspacePath: this.getWorkspacePath(channel.botId),
+      },
+      "channel_connect_workspace_binding",
+    );
+  }
+
   async getBotQuota(): Promise<BotQuotaResponse> {
     const base: BotQuotaResponse = {
       available: true,
@@ -805,6 +822,7 @@ export class ChannelService {
       botUserId: authData.user_id ?? null,
     });
     await this.syncService.syncAll();
+    this.logChannelConnectSuccess(channel);
     logger.info(
       { channelId: channel.id, teamName: authData.team },
       "slack_connect_success",
@@ -922,6 +940,7 @@ export class ChannelService {
     } catch (error) {
       throw this.toSyncConnectError(error, "discord");
     }
+    this.logChannelConnectSuccess(channel);
     logger.info(
       { channelId: channel.id, botUserId: userData.id },
       "discord_connect_success",
@@ -940,6 +959,7 @@ export class ChannelService {
       "wechat_connect_sync_all",
     );
     await this.syncService.syncAll();
+    this.logChannelConnectSuccess(channel);
     logger.info(
       {
         accountId,
@@ -1135,6 +1155,7 @@ export class ChannelService {
     } catch (error) {
       throw this.toSyncConnectError(error, "telegram");
     }
+    this.logChannelConnectSuccess(channel);
     logger.info(
       { channelId: channel.id, botUsername: payload.result.username },
       "telegram_connect_success",
@@ -1152,6 +1173,7 @@ export class ChannelService {
       appSecret,
     });
     await this.syncService.syncAll();
+    this.logChannelConnectSuccess(channel);
     logger.info({ channelId: channel.id, appId }, "qqbot_connect_success");
     return channel;
   }
@@ -1167,6 +1189,7 @@ export class ChannelService {
       clientSecret,
     });
     await this.syncService.syncAll();
+    this.logChannelConnectSuccess(channel);
     logger.info(
       { channelId: channel.id, clientId },
       "dingtalk_connect_success",
@@ -1202,6 +1225,7 @@ export class ChannelService {
       secret,
     });
     await this.syncService.syncAll();
+    this.logChannelConnectSuccess(channel);
     logger.info({ channelId: channel.id, botId }, "wecom_connect_success");
     return channel;
   }
@@ -1433,6 +1457,7 @@ export class ChannelService {
           "WhatsApp linked, but the runtime failed to start the listener.",
       );
     }
+    this.logChannelConnectSuccess(channel);
     await resetActiveWhatsappLogin(accountId);
     return channel;
   }
@@ -1469,6 +1494,7 @@ export class ChannelService {
 
     const channel = await this.configStore.connectFeishu(input);
     await this.syncService.syncAll();
+    this.logChannelConnectSuccess(channel);
     logger.info(
       { channelId: channel.id, appId: input.appId },
       "feishu_connect_success",

--- a/apps/controller/src/store/nexu-config-store.ts
+++ b/apps/controller/src/store/nexu-config-store.ts
@@ -612,7 +612,7 @@ export class NexuConfigStore {
   /** Callback fired when cloud state changes (connect/disconnect). */
   onCloudStateChanged?: (change: DesktopCloudStateChange) => Promise<void>;
 
-  constructor(env: ControllerEnv) {
+  constructor(private readonly env: ControllerEnv) {
     this.store = new LowDbStore<NexuConfig>(
       env.nexuConfigPath,
       nexuConfigSchema,
@@ -929,16 +929,41 @@ export class NexuConfigStore {
     if (existing.length > 0) {
       const firstBot = existing[0];
       if (firstBot) {
+        logger.info(
+          {
+            botId: firstBot.id,
+            slug: firstBot.slug,
+            workspacePath: path.join(
+              this.env.openclawStateDir,
+              "agents",
+              firstBot.id,
+            ),
+            existingBotCount: existing.length,
+            resolution: "reused_existing",
+          },
+          "default_bot_resolution",
+        );
         return firstBot;
       }
     }
 
     const config = await this.getConfig();
-    return this.createBot({
+    const bot = await this.createBot({
       name: "nexu Assistant",
       slug: "nexu-assistant",
       modelId: config.runtime.defaultModelId,
     });
+    logger.info(
+      {
+        botId: bot.id,
+        slug: bot.slug,
+        workspacePath: path.join(this.env.openclawStateDir, "agents", bot.id),
+        existingBotCount: existing.length,
+        resolution: "created_implicit_default",
+      },
+      "default_bot_resolution",
+    );
+    return bot;
   }
 
   async createBot(input: {
@@ -965,6 +990,16 @@ export class NexuConfigStore {
       ...config,
       bots: [...config.bots, bot],
     }));
+
+    logger.info(
+      {
+        botId: bot.id,
+        slug: bot.slug,
+        workspacePath: path.join(this.env.openclawStateDir, "agents", bot.id),
+        createdVia: "nexu_config_store.createBot",
+      },
+      "bot_created",
+    );
 
     return bot;
   }

--- a/apps/web/src/components/brand-rail.tsx
+++ b/apps/web/src/components/brand-rail.tsx
@@ -124,7 +124,10 @@ export function BrandRail({
       </div>
 
       <div className="relative z-10 flex w-full flex-col justify-between px-10 pb-12 pt-8 xl:px-12 xl:py-12">
-        <FadeIn delay={80} className="flex items-center justify-between">
+        <FadeIn
+          delay={80}
+          className="relative z-30 flex items-center justify-between"
+        >
           <button
             type="button"
             onClick={onLogoClick}
@@ -135,7 +138,7 @@ export function BrandRail({
           {topRight ?? <div />}
         </FadeIn>
 
-        <div>
+        <div className="relative z-10">
           <FadeIn delay={220}>
             <h1
               className="max-w-[560px] text-[40px] leading-[0.96] tracking-tight text-white sm:text-[52px] lg:text-[64px]"

--- a/apps/web/src/components/language-switcher.tsx
+++ b/apps/web/src/components/language-switcher.tsx
@@ -73,7 +73,10 @@ export function LanguageSwitcher({ variant = "light", size = "sm" }: Props) {
   }[variant];
 
   return (
-    <div ref={rootRef} className="relative inline-flex">
+    <div
+      ref={rootRef}
+      className="relative z-50 inline-flex pointer-events-auto"
+    >
       <button
         type="button"
         aria-haspopup="menu"
@@ -97,7 +100,7 @@ export function LanguageSwitcher({ variant = "light", size = "sm" }: Props) {
       {open && (
         <div
           role="menu"
-          className={`absolute right-0 top-[calc(100%+12px)] min-w-full overflow-hidden rounded-[24px] p-2 ${colors.menu}`}
+          className={`absolute right-0 top-[calc(100%+12px)] z-50 min-w-full overflow-hidden rounded-[24px] p-2 pointer-events-auto ${colors.menu}`}
         >
           {options.map((option) => (
             <button

--- a/apps/web/src/hooks/use-locale.tsx
+++ b/apps/web/src/hooks/use-locale.tsx
@@ -49,7 +49,7 @@ export function LocaleProvider({ children }: { children: ReactNode }) {
   const userInteractedRef = useRef(false);
 
   useEffect(() => {
-    i18n.changeLanguage(locale);
+    document.documentElement.lang = locale === "zh" ? "zh-CN" : "en";
   }, [locale]);
 
   useEffect(() => {
@@ -62,6 +62,7 @@ export function LocaleProvider({ children }: { children: ReactNode }) {
 
   const setLocale = useCallback((l: Locale) => {
     userInteractedRef.current = true;
+    void i18n.changeLanguage(l);
     setLocaleState(l);
     try {
       localStorage.setItem(STORAGE_KEY, l);
@@ -119,6 +120,7 @@ async function bootstrapLocale(
 
   if (storedLocale === "en" || storedLocale === "zh-CN") {
     const nextLocale = storedLocale === "zh-CN" ? "zh" : "en";
+    await i18n.changeLanguage(nextLocale);
     setLocaleState(nextLocale);
     try {
       localStorage.setItem(STORAGE_KEY, nextLocale);

--- a/tests/desktop/libtv-video-skill.test.ts
+++ b/tests/desktop/libtv-video-skill.test.ts
@@ -189,7 +189,7 @@ describe("libtv bundled skill", () => {
     } finally {
       await gateway.close();
     }
-  });
+  }, 15000);
 
   it("records an empty delivery block when no channel context is present", async () => {
     const nexuHome = makeTempDir();


### PR DESCRIPTION
## What

Fix the welcome-page language switcher so its selected locale and dropdown interactions work correctly again, and add controller diagnostics to trace implicit bot selection and workspace binding during channel setup.

## Why

The welcome flow could show stale localized copy after a language change, and the language dropdown options could appear unclickable because the menu rendered beneath animated hero content. In parallel, the channel-setup investigation needed better evidence about whether connects were creating or reusing bots and which workspace paths were actually involved.

## How

- update `use-locale` so `i18n.changeLanguage(...)` is synchronized when locale state is applied, while still keeping `document.documentElement.lang` in sync
- raise the welcome-page language switcher stack order above the animated brand content and keep the dropdown interactive
- add controller logging for bootstrap runtime roots, default-bot resolution, channel-to-workspace binding, and per-file platform template seed/preserve decisions

## Affected areas

- [ ] Desktop app (Electron shell)
- [x] Controller (backend / API)
- [x] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [ ] Build / CI / Tooling

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

## Notes for reviewers

- The web fix addresses two separate causes discovered during debugging: locale changes not re-rendering welcome copy reliably, and the dropdown menu being visually present but hit-tested underneath animated hero content due to stacking contexts.
- The controller logging is intentionally diagnostic-only and should help validate whether channel connect flows are binding to the expected bot workspace during teammate repros.