### PR TITLE
fix: improve desktop update failure recovery

### DIFF
--- a/apps/desktop/main/updater/update-manager.ts
+++ b/apps/desktop/main/updater/update-manager.ts
@@ -354,7 +354,11 @@ export class UpdateManager {
           this.downloadMode = "idle";
         }
 
-        this.send("update:error", { message: error.message, diagnostic });
+        this.send("update:error", {
+          message: error.message,
+          rawMessage: error.message,
+          diagnostic,
+        });
       },
     });
   }

--- a/apps/desktop/shared/host.ts
+++ b/apps/desktop/shared/host.ts
@@ -768,6 +768,7 @@ export type UpdaterEventMap = {
   "update:downloaded": { version: string };
   "update:error": {
     message: string;
+    rawMessage?: string;
     diagnostic?: UpdateCheckDiagnostic;
   };
 };

--- a/apps/desktop/src/components/update-banner.tsx
+++ b/apps/desktop/src/components/update-banner.tsx
@@ -49,6 +49,7 @@ const i18n = {
     localTestFeedDetail:
       "This local validation build has a test update feed configured. Before testing, adjust the environment variables according to the repository documentation.",
     checkNow: "Check for updates",
+    retry: "Retry",
   },
   zh: {
     badge: "更新",
@@ -78,6 +79,7 @@ const i18n = {
     localTestFeedDetail:
       "当前版本为本地验收构建，已配置测试更新源。请按照仓库内的文档说明调整环境变量后测试。",
     checkNow: "检查更新",
+    retry: "重试",
   },
 };
 
@@ -327,6 +329,15 @@ export function UpdateBanner({
             {errorMessage ?? t.unknownError}
           </div>
           <div className="update-card-actions">
+            {capability?.check && (
+              <button
+                className="update-card-btn update-card-btn--primary"
+                onClick={onCheck}
+                type="button"
+              >
+                {t.retry}
+              </button>
+            )}
             <button
               className="update-card-btn update-card-btn--ghost"
               onClick={onDismiss}

--- a/apps/desktop/src/hooks/use-auto-update.ts
+++ b/apps/desktop/src/hooks/use-auto-update.ts
@@ -35,18 +35,97 @@ function normalizeUpdateErrorMessage(
   message: string,
   experience: DesktopUpdateExperience,
 ): string {
-  if (experience !== "local-test-feed") {
-    return message;
-  }
-
-  if (/404\s+Not\s+Found/i.test(message)) {
-    return resolveLocale({
-      en: "The test update feed is unavailable. Check the guide and verify your NEXU_UPDATE_FEED_URL configuration.",
-      zh: "测试更新源不可用。请查看说明文档，并检查 NEXU_UPDATE_FEED_URL 配置是否正确。",
+  const trimmedMessage = message.trim();
+  const localized = (en: string, zh: string) =>
+    resolveLocale({
+      en,
+      zh,
     });
+
+  if (
+    /\b(ENOTFOUND|EAI_AGAIN|DNS|getaddrinfo)\b/i.test(trimmedMessage) ||
+    /Could not resolve host/i.test(trimmedMessage)
+  ) {
+    return localized(
+      "The update server address could not be resolved. Check your network or DNS settings and try again.",
+      "无法解析更新服务器地址。请检查网络或 DNS 设置后重试。",
+    );
   }
 
-  return message;
+  if (
+    /\b(ETIMEDOUT|ERR_CONNECTION_TIMED_OUT|timeout)\b/i.test(trimmedMessage)
+  ) {
+    return localized(
+      "The update request timed out. Check your network connection and try again.",
+      "更新请求超时。请检查网络连接后重试。",
+    );
+  }
+
+  if (
+    /\b(ECONNRESET|ECONNABORTED|socket hang up|network changed)\b/i.test(
+      trimmedMessage,
+    )
+  ) {
+    return localized(
+      "The network connection was interrupted while checking for updates. Try again after the connection stabilizes.",
+      "检查更新时网络连接中断。请等网络稳定后重试。",
+    );
+  }
+
+  if (
+    /\b(ENETUNREACH|EHOSTUNREACH|ENETDOWN|ERR_INTERNET_DISCONNECTED|offline)\b/i.test(
+      trimmedMessage,
+    )
+  ) {
+    return localized(
+      "No network connection is available right now. Reconnect and try the update again.",
+      "当前网络不可用。请恢复联网后再次尝试更新。",
+    );
+  }
+
+  if (/\b403\b/i.test(trimmedMessage)) {
+    return localized(
+      "The update server rejected the request. Check network restrictions or proxy settings and try again.",
+      "更新服务器拒绝了请求。请检查网络限制或代理设置后重试。",
+    );
+  }
+
+  if (experience !== "local-test-feed") {
+    if (/\b404\b/i.test(trimmedMessage)) {
+      return localized(
+        "The update feed could not be found. Check the update source configuration and try again.",
+        "未找到更新源。请检查更新源配置后重试。",
+      );
+    }
+
+    if (/\b(5\d\d|502|503|504)\b/i.test(trimmedMessage)) {
+      return localized(
+        "The update server is temporarily unavailable. Try again in a moment.",
+        "更新服务器暂时不可用。请稍后重试。",
+      );
+    }
+
+    return trimmedMessage;
+  }
+
+  if (
+    /404\s+Not\s+Found/i.test(trimmedMessage) ||
+    /\b404\b/i.test(trimmedMessage)
+  ) {
+    return localized(
+      "The test update feed is unavailable. Check the guide and verify your NEXU_UPDATE_FEED_URL configuration.",
+      "测试更新源不可用。请查看说明文档，并检查 NEXU_UPDATE_FEED_URL 配置是否正确。",
+    );
+  }
+
+  if (/\b(5\d\d|502|503|504)\b/i.test(trimmedMessage)) {
+    return localized(
+      "The test update server is temporarily unavailable. Try again later or verify your feed configuration.",
+      "测试更新服务器暂时不可用。请稍后重试，或检查更新源配置。",
+    );
+  }
+
+  return trimmedMessage;
 }
 
 export function restorePhaseAfterInstall(
@@ -171,10 +250,20 @@ export function useAutoUpdate(options?: {
 
     disposers.push(
       updater.onEvent("update:error", (data) => {
+        const rawMessage = data.rawMessage ?? data.message;
+        const friendlyMessage = normalizeUpdateErrorMessage(
+          data.message,
+          experience,
+        );
+        console.error("[desktop] update failed", {
+          rawMessage,
+          friendlyMessage,
+          diagnostic: data.diagnostic ?? null,
+        });
         setState((prev) => ({
           ...prev,
           phase: "error",
-          errorMessage: normalizeUpdateErrorMessage(data.message, experience),
+          errorMessage: friendlyMessage,
           userInitiated: false,
         }));
       }),


### PR DESCRIPTION
## What

Improve desktop update failure recovery by keeping update errors actionable for users instead of leaving the banner in a dead-end state.

## Why

Desktop update checks could fail with raw network/feed errors and no direct retry action from the banner, which made recovery slower and harder to understand.

## How

- include the raw updater error alongside the renderer payload so the UI can log diagnostics without losing a friendly message
- normalize common network/feed failures into localized user-facing guidance
- add a retry action to the error state in the update banner so users can retry immediately

## Affected areas

- [x] Desktop app (Electron shell)
- [ ] Controller (backend / API)
- [ ] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [ ] Build / CI / Tooling

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

## Notes for reviewers

I did not rerun repo checks in this PR flow; the unchecked items above are intentionally left for follow-up verification.