### PR TITLE
fix: add logout confirmation dialogs in settings

### DIFF
--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -448,6 +448,9 @@ const en = {
   "settings.general.loggedOutHint":
     "Sign in to sync settings and use premium models.",
   "settings.general.goLogin": "Go to sign in",
+  "settings.general.logoutConfirmTitle": "Log out of your nexu account?",
+  "settings.general.logoutConfirmDescription":
+    "This will disconnect your current nexu account from this desktop workspace.",
   "settings.general.preferences": "Preferences",
   "settings.general.language": "Language",
   "settings.general.languageHint": "Choose your interface language",
@@ -582,6 +585,9 @@ const en = {
     "Sign in with your nexu account to access unlimited premium models like Claude Opus 4.6, GPT-5.4, and more — no API key needed.",
   "models.managed.waitingLogin": "Waiting for browser login...",
   "models.managed.loginButton": "Sign in to nexu",
+  "models.managed.logoutConfirmTitle": "Log out of nexu Official?",
+  "models.managed.logoutConfirmDescription":
+    "This will disconnect nexu Official from your current nexu account on this device.",
   "models.managed.availableModels": "Available models",
   "models.managed.refreshSucceeded": "Models refreshed",
   "models.managed.refreshFailed": "Could not refresh models",

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -424,6 +424,9 @@ const zhCN = {
   "settings.general.loggedOut": "未登录",
   "settings.general.loggedOutHint": "登录后可同步设置并使用高级模型",
   "settings.general.goLogin": "去登录",
+  "settings.general.logoutConfirmTitle": "确认退出当前 nexu 账号？",
+  "settings.general.logoutConfirmDescription":
+    "退出后，当前桌面工作区将断开与你的 nexu 账号连接。",
   "settings.general.preferences": "偏好",
   "settings.general.language": "语言",
   "settings.general.languageHint": "选择界面显示语言",
@@ -549,6 +552,9 @@ const zhCN = {
     "登录 nexu 账号后，即可无限使用 Claude Opus 4.6、GPT-5.4 等高级模型，无需 API Key。",
   "models.managed.waitingLogin": "等待浏览器登录...",
   "models.managed.loginButton": "登录 nexu 账号",
+  "models.managed.logoutConfirmTitle": "确认退出 nexu Official？",
+  "models.managed.logoutConfirmDescription":
+    "退出后，此设备上的 nexu Official 将断开当前 nexu 账号连接。",
   "models.managed.availableModels": "可用模型",
   "models.managed.refreshSucceeded": "模型已刷新",
   "models.managed.refreshFailed": "刷新模型失败",

--- a/apps/web/src/pages/models.tsx
+++ b/apps/web/src/pages/models.tsx
@@ -79,6 +79,14 @@ import type {
   PutApiV1ModelProvidersConfigData,
 } from "../../lib/api/types.gen";
 import { Button } from "../components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../components/ui/dialog";
 import { PageHeader } from "../components/ui/page-header";
 import {
   Select,
@@ -138,6 +146,53 @@ type MiniMaxDesktopOauthStatus = {
   region?: "global" | "cn" | null;
   error?: string | null;
 };
+
+type LogoutConfirmDialogProps = {
+  open: boolean;
+  title: string;
+  description: string;
+  confirmLabel: string;
+  cancelLabel: string;
+  pending: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+};
+
+function LogoutConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel,
+  cancelLabel,
+  pending,
+  onOpenChange,
+  onConfirm,
+}: LogoutConfirmDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader className="border-b-0 pb-2">
+          <DialogTitle className="text-[16px]">{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="border-t-0 pt-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={pending}
+          >
+            {cancelLabel}
+          </Button>
+          <Button type="button" variant="destructive" onClick={onConfirm}>
+            {pending && <Loader2 className="animate-spin" />}
+            {confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
 
 type MiniMaxDesktopOauthStartResult = MiniMaxDesktopOauthStatus & {
   started: boolean;
@@ -572,6 +627,8 @@ function _GeneralSettings() {
   const [appVersion, setAppVersion] = useState<string | null>(null);
   const [accountConnecting, setAccountConnecting] = useState(false);
   const [accountDisconnecting, setAccountDisconnecting] = useState(false);
+  const [showAccountLogoutConfirm, setShowAccountLogoutConfirm] =
+    useState(false);
   const [crashReportsEnabled, setCrashReportsEnabled] = useState(true);
   const hostBridge = getModelsHostInvokeBridge();
   const { data: desktopCloudStatus, refetch: refetchDesktopCloudStatus } =
@@ -847,6 +904,7 @@ function _GeneralSettings() {
     try {
       await postApiInternalDesktopCloudDisconnect().catch(() => {});
       await syncDesktopCloudQueries(queryClient);
+      setShowAccountLogoutConfirm(false);
     } finally {
       setAccountDisconnecting(false);
     }
@@ -881,7 +939,7 @@ function _GeneralSettings() {
             disabled={accountActionBusy}
             onClick={() =>
               void (cloudConnected
-                ? handleAccountLogout()
+                ? setShowAccountLogoutConfirm(true)
                 : handleAccountLogin())
             }
           >
@@ -893,6 +951,17 @@ function _GeneralSettings() {
           </Button>
         </div>
       </div>
+
+      <LogoutConfirmDialog
+        open={showAccountLogoutConfirm}
+        onOpenChange={setShowAccountLogoutConfirm}
+        pending={accountDisconnecting}
+        title={t("settings.general.logoutConfirmTitle")}
+        description={t("settings.general.logoutConfirmDescription")}
+        confirmLabel={t("layout.signOut")}
+        cancelLabel={t("common.cancel")}
+        onConfirm={() => void handleAccountLogout()}
+      />
 
       <div className="overflow-hidden rounded-xl border border-border bg-surface-1">
         <div className="border-b border-border px-5 py-4">
@@ -2123,6 +2192,7 @@ function ManagedProviderDetail({
   const [loginError, setLoginError] = useState<string | null>(null);
   const [loginBusy, setLoginBusy] = useState(false);
   const [cloudDisconnecting, setCloudDisconnecting] = useState(false);
+  const [showCloudLogoutConfirm, setShowCloudLogoutConfirm] = useState(false);
   const queryClient = useQueryClient();
   const { data: desktopCloudStatus, refetch: refetchDesktopCloudStatus } =
     useDesktopCloudStatus();
@@ -2210,6 +2280,20 @@ function ManagedProviderDetail({
     setLoginError(null);
   };
 
+  const handleCloudLogout = async () => {
+    if (cloudDisconnecting) {
+      return;
+    }
+    setCloudDisconnecting(true);
+    try {
+      await postApiInternalDesktopCloudDisconnect().catch(() => {});
+      await syncDesktopCloudQueries(queryClient);
+      setShowCloudLogoutConfirm(false);
+    } finally {
+      setCloudDisconnecting(false);
+    }
+  };
+
   const cloudToggleBusy = loginBusy || cloudDisconnecting;
 
   return (
@@ -2241,14 +2325,7 @@ function ManagedProviderDetail({
             }
             onClick={async () => {
               if (cloudConnected) {
-                if (cloudDisconnecting) return;
-                setCloudDisconnecting(true);
-                try {
-                  await postApiInternalDesktopCloudDisconnect().catch(() => {});
-                  await syncDesktopCloudQueries(queryClient);
-                } finally {
-                  setCloudDisconnecting(false);
-                }
+                setShowCloudLogoutConfirm(true);
               }
             }}
             className="inline-flex items-center gap-1.5 text-[11px] font-medium shrink-0 rounded-lg border border-border px-2.5 py-1 transition-colors cursor-pointer text-text-secondary hover:text-text-primary hover:bg-surface-2 disabled:cursor-not-allowed disabled:opacity-60"
@@ -2264,6 +2341,17 @@ function ManagedProviderDetail({
           </button>
         )}
       </div>
+
+      <LogoutConfirmDialog
+        open={showCloudLogoutConfirm}
+        onOpenChange={setShowCloudLogoutConfirm}
+        pending={cloudDisconnecting}
+        title={t("models.managed.logoutConfirmTitle")}
+        description={t("models.managed.logoutConfirmDescription")}
+        confirmLabel={t("models.managed.connected")}
+        cancelLabel={t("common.cancel")}
+        onConfirm={() => void handleCloudLogout()}
+      />
 
       {/* Login prompt */}
       {!cloudConnected && (


### PR DESCRIPTION
## What

Add logout confirmation dialogs for the settings account action and the nexu Official provider action.

## Why

Both logout entry points were disconnecting the current nexu account immediately. Adding a confirmation step reduces accidental logout/disconnects.

## How

- add a reusable logout confirmation dialog in apps/web/src/pages/models.tsx
- show the dialog before disconnecting from General > Account
- show the dialog before disconnecting from AI Model Providers > nexu Official
- add matching English and Chinese copy
- remove the dialog divider for this confirmation modal only

## Affected areas

- [ ] Desktop app (Electron shell)
- [ ] Controller (backend / API)
- [x] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [ ] Build / CI / Tooling

## Checklist

- [x] pnpm typecheck passes
- [x] pnpm lint passes
- [ ] pnpm test passes
- [ ] pnpm generate-types run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No any types introduced (use unknown with narrowing)

## Notes for reviewers

pnpm test was not run because this is a small UI-only change with no logic or API contract changes beyond the existing logout flow.
