### PR TITLE
fix: avoid stale desktop auto-update checking state

### DIFF
--- a/apps/desktop/main/updater/update-manager.ts
+++ b/apps/desktop/main/updater/update-manager.ts
@@ -227,7 +227,9 @@ export class UpdateManager {
       onChecking: () => {
         const diagnostic = this.getDiagnostic();
         this.logCheck("update check event: checking for update", diagnostic);
-        this.send("update:checking", diagnostic);
+        if (this.userInitiatedCheck) {
+          this.send("update:checking", diagnostic);
+        }
       },
       onAvailable: (info) => {
         const diagnostic = this.getDiagnostic({
@@ -400,8 +402,9 @@ export class UpdateManager {
         "update check: background download already complete, surfacing",
         this.getDiagnostic(),
       );
-      // Brief "checking" flash so the settings button shows a transition
-      this.send("update:checking", this.getDiagnostic());
+      if (this.userInitiatedCheck) {
+        this.send("update:checking", this.getDiagnostic());
+      }
       this.send("update:downloaded", { version: this.pendingVersion });
       return { updateAvailable: true };
     }
@@ -416,8 +419,9 @@ export class UpdateManager {
         this.getDiagnostic(),
       );
 
-      // Brief "checking" flash so the settings button shows a transition
-      this.send("update:checking", this.getDiagnostic());
+      if (this.userInitiatedCheck) {
+        this.send("update:checking", this.getDiagnostic());
+      }
 
       const diagnostic = this.getDiagnostic({
         remoteVersion: this.pendingVersion,

--- a/apps/desktop/shared/host.ts
+++ b/apps/desktop/shared/host.ts
@@ -453,10 +453,7 @@ export type HostInvokeResultMap = {
   "update:download": { ok: boolean };
   "update:install": undefined;
   "update:get-current-version": { version: string };
-  "update:get-status": {
-    phase: "idle" | "downloading" | "ready";
-    version: string | null;
-  };
+  "update:get-status": DesktopUpdateStatus;
   "update:set-channel": { ok: boolean };
   "update:set-source": { ok: boolean };
   "component:check": {
@@ -746,6 +743,12 @@ export interface UpdateCheckDiagnostic {
   currentVersion: string;
   remoteVersion?: string;
   remoteReleaseDate?: string;
+}
+
+export interface DesktopUpdateStatus {
+  phase: "idle" | "downloading" | "ready";
+  version: string | null;
+  percent: number;
 }
 
 export type UpdaterEventMap = {

--- a/apps/desktop/src/hooks/use-auto-update.ts
+++ b/apps/desktop/src/hooks/use-auto-update.ts
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useState } from "react";
 import type { DesktopUpdateCapability } from "../../shared/host";
+import type { DesktopUpdateStatus } from "../../shared/host";
 import type { DesktopUpdateExperience } from "../../shared/update-policy";
 import {
   checkForUpdate,
   downloadUpdate,
   getUpdateCapability,
+  getUpdateStatus,
   installUpdate,
 } from "../lib/host-api";
 import { resolveLocale } from "../lib/i18n";
@@ -58,6 +60,30 @@ export function restorePhaseAfterInstall(
     : state;
 }
 
+export function applyUpdateStatus(
+  state: UpdateState,
+  status: DesktopUpdateStatus,
+): UpdateState {
+  if (state.phase === "installing") {
+    return state;
+  }
+
+  if (
+    (status.phase === "downloading" || status.phase === "ready") &&
+    status.version
+  ) {
+    return {
+      ...state,
+      phase: status.phase,
+      version: status.version,
+      percent: status.percent,
+      dismissed: false,
+    };
+  }
+
+  return state;
+}
+
 export function useAutoUpdate(options?: {
   experience?: DesktopUpdateExperience;
 }) {
@@ -94,6 +120,31 @@ export function useAutoUpdate(options?: {
 
     return () => {
       cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const pollStatus = () => {
+      void getUpdateStatus()
+        .then((status) => {
+          if (cancelled) {
+            return;
+          }
+          setState((prev) => applyUpdateStatus(prev, status));
+        })
+        .catch(() => {
+          // Ignore transient bridge errors and rely on event-driven updates.
+        });
+    };
+
+    pollStatus();
+    const pollTimer = window.setInterval(pollStatus, 1000);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(pollTimer);
     };
   }, []);
 

--- a/apps/desktop/src/lib/host-api.ts
+++ b/apps/desktop/src/lib/host-api.ts
@@ -2,6 +2,7 @@ import type {
   AppInfo,
   DesktopRuntimeConfig,
   DesktopUpdateCapability,
+  DesktopUpdateStatus,
   DiagnosticsExportResult,
   DiagnosticsInfo,
   HostDesktopCommand,
@@ -200,6 +201,10 @@ export async function checkForUpdate(): Promise<boolean> {
 
 export async function getUpdateCapability(): Promise<DesktopUpdateCapability> {
   return getHostBridge().invoke("update:get-capability", undefined);
+}
+
+export async function getUpdateStatus(): Promise<DesktopUpdateStatus> {
+  return getHostBridge().invoke("update:get-status", undefined);
 }
 
 export async function downloadUpdate(): Promise<boolean> {

--- a/tests/auto-update-install-phase.test.ts
+++ b/tests/auto-update-install-phase.test.ts
@@ -1,8 +1,67 @@
 import { describe, expect, it } from "vitest";
-import { restorePhaseAfterInstall as restoreDesktopPhase } from "../apps/desktop/src/hooks/use-auto-update";
+import type { DesktopUpdateStatus } from "../apps/desktop/shared/host";
+import {
+  applyUpdateStatus,
+  restorePhaseAfterInstall as restoreDesktopPhase,
+} from "../apps/desktop/src/hooks/use-auto-update";
 import { restorePhaseAfterInstall as restoreWebPhase } from "../apps/web/src/hooks/use-auto-update";
 
 describe("desktop useAutoUpdate", () => {
+  it("hydrates downloading state from polled main-process status", () => {
+    const status: DesktopUpdateStatus = {
+      phase: "downloading",
+      version: "1.2.3",
+      percent: 42,
+    };
+
+    expect(
+      applyUpdateStatus(
+        {
+          capability: null,
+          phase: "idle",
+          version: null,
+          releaseNotes: null,
+          actionUrl: null,
+          percent: 0,
+          errorMessage: null,
+          dismissed: true,
+          userInitiated: false,
+        },
+        status,
+      ),
+    ).toMatchObject({
+      phase: "downloading",
+      version: "1.2.3",
+      percent: 42,
+      dismissed: false,
+    });
+  });
+
+  it("does not override the installing phase with polled status", () => {
+    const status: DesktopUpdateStatus = {
+      phase: "ready",
+      version: "1.2.3",
+      percent: 100,
+    };
+
+    expect(
+      applyUpdateStatus(
+        {
+          capability: null,
+          phase: "installing",
+          version: "1.0.0",
+          releaseNotes: null,
+          actionUrl: null,
+          percent: 0,
+          errorMessage: null,
+          dismissed: false,
+          userInitiated: false,
+        },
+        status,
+      ).phase,
+    ).toBe("installing");
+  });
+
   it("restores the prior actionable phase after install returns without quitting", () => {
     expect(
       restoreDesktopPhase(

--- a/tests/desktop/update-manager-full.test.ts
+++ b/tests/desktop/update-manager-full.test.ts
@@ -237,8 +237,9 @@ describe("bindEvents", () => {
   // checking-for-update
   // -------------------------------------------------------------------------
 
-  it("checking-for-update: calls logCheck and sends update:checking", async () => {
-    const { win } = await createManager();
+  it("checking-for-update: user-initiated checks send update:checking", async () => {
+    const { mgr, win } = await createManager();
+    (mgr as { userInitiatedCheck: boolean }).userInitiatedCheck = true;
     const handlers = extractHandlers();
 
     handlers["checking-for-update"]();
@@ -260,6 +261,18 @@ describe("bindEvents", () => {
         source: "r2",
         currentVersion: "0.2.0",
       }),
+    );
+  });
+
+  it("checking-for-update: background checks do not send update:checking", async () => {
+    const { win } = await createManager();
+    const handlers = extractHandlers();
+
+    handlers["checking-for-update"]();
+
+    expect(win.webContents.send).not.toHaveBeenCalledWith(
+      "update:checking",
+      expect.anything(),
     );
   });
 


### PR DESCRIPTION
## What

Fix desktop auto-update startup state so packaged macOS builds do not get stuck showing a stale checking/loading banner during automatic background update checks.

## Why

On Apple Silicon packaged builds, the first visible update popup could remain in a checking/loading state for a long time before finally switching to downloading or ready. This made startup update UX feel broken and hid the real updater progress.

## How

- only emit `update:checking` for user-initiated update checks
- keep automatic background checks silent in the main updater flow
- expose typed `update:get-status` state through the desktop host bridge
- hydrate the desktop auto-update hook from main-process status so renderer state catches up to background downloads / ready state
- add regression tests for background checks staying silent and for hook status hydration

## Affected areas

- [x] Desktop app (Electron shell)
- [ ] Controller (backend / API)
- [ ] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [x] Shared schemas / packages
- [ ] Build / CI / Tooling

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

## Screenshots / recordings

- Packaged arm64 + local mock feed regression now shows `正在下载更新…` as the first visible update state instead of a stale checking/loading popup.

## Notes for reviewers

- Verified end-to-end with a packaged arm64 app against a local mock update feed.
- Full local validation passed: `pnpm typecheck`, `pnpm lint`, `pnpm test`.
