### PR TITLE
fix: clear stale cloud model on disconnect and hide plan credits row

### DIFF
--- a/apps/controller/src/app/container.ts
+++ b/apps/controller/src/app/container.ts
@@ -152,9 +152,10 @@ export async function createContainer(): Promise<ControllerContainer> {
   );
   const githubStarVerificationService = new GithubStarVerificationService();
 
-  // Wire cloud state change callback to sync refreshed cloud inventory without
-  // auto-switching the default model during startup or first-channel connect.
+  // Wire cloud state change callback to sync refreshed cloud inventory and
+  // auto-select a default model when inventory changes.
   configStore.onCloudStateChanged = async (change) => {
+    await modelProviderService.ensureValidDefaultModel();
     await openclawSyncService.syncAll();
     if (change.hadCloudInventory !== change.hasCloudInventory) {
       await openclawProcess.stop();

--- a/apps/controller/src/app/container.ts
+++ b/apps/controller/src/app/container.ts
@@ -156,7 +156,7 @@ export async function createContainer(): Promise<ControllerContainer> {
   // auto-switching the default model during startup or first-channel connect.
   configStore.onCloudStateChanged = async (change) => {
     await openclawSyncService.syncAll();
-    if (!change.hadCloudInventory && change.hasCloudInventory) {
+    if (change.hadCloudInventory !== change.hasCloudInventory) {
       await openclawProcess.stop();
       openclawProcess.enableAutoRestart();
       openclawProcess.start();

--- a/apps/controller/src/routes/desktop-compat-routes.ts
+++ b/apps/controller/src/routes/desktop-compat-routes.ts
@@ -301,8 +301,12 @@ export function registerDesktopCompatRoutes(
         },
       },
     }),
-    async (c) =>
-      c.json(await container.desktopLocalService.disconnectCloud(), 200),
+    async (c) => {
+      const result = await container.desktopLocalService.disconnectCloud();
+      await container.modelProviderService.ensureValidDefaultModel();
+      const { configPushed } = await container.openclawSyncService.syncAll();
+      return c.json({ ...result, configPushed }, 200);
+    },
   );
 
   app.openapi(

--- a/apps/controller/src/store/nexu-config-store.ts
+++ b/apps/controller/src/store/nexu-config-store.ts
@@ -2688,6 +2688,12 @@ export class NexuConfigStore {
     const previousCloud = readDesktopCloud(await this.getConfig());
     this.abortDesktopCloudPolling();
 
+    const config = await this.getConfig();
+    const currentModelId = config.runtime.defaultModelId;
+    const wasCloudModel =
+      resolveManagedCloudModel(currentModelId, previousCloud.models ?? []) !==
+      null;
+
     await this.setDesktopCloudState({
       connected: false,
       polling: false,
@@ -2699,6 +2705,11 @@ export class NexuConfigStore {
       apiKey: null,
       models: [],
     });
+
+    if (wasCloudModel) {
+      await this.setDefaultModel("");
+    }
+
     await this.onCloudStateChanged?.({
       hadCloudInventory: (previousCloud.models?.length ?? 0) > 0,
       hasCloudInventory: false,

--- a/apps/controller/static/runtime-plugins/nexu-runtime-model/index.js
+++ b/apps/controller/static/runtime-plugins/nexu-runtime-model/index.js
@@ -44,7 +44,7 @@ const plugin = {
   register(api) {
     api.on("before_model_resolve", async () => {
       const state = loadState();
-      if (!state) {
+      if (!state || !state.selectedModelRef) {
         return;
       }
       const slashIndex = state.selectedModelRef.indexOf("/");
@@ -63,7 +63,7 @@ const plugin = {
 
     api.on("before_prompt_build", async () => {
       const state = loadState();
-      if (!state?.promptNotice) {
+      if (!state?.selectedModelRef || !state?.promptNotice) {
         return;
       }
       return {

--- a/apps/web/src/layouts/workspace-layout.tsx
+++ b/apps/web/src/layouts/workspace-layout.tsx
@@ -1085,28 +1085,6 @@ function WorkspaceLayoutInner() {
                                 {sidebarCreditBreakdown.giftedBalance}
                               </span>
                             </div>
-                            <div className="flex items-center justify-between">
-                              <span className="flex items-center gap-1 text-[11px] text-text-muted">
-                                {t("layout.sidebar.balancePopup.recharged")}
-                                <span className="group relative inline-flex cursor-default items-center">
-                                  <Info
-                                    size={10}
-                                    className="text-text-muted/60"
-                                  />
-                                  <span
-                                    role="tooltip"
-                                    className="pointer-events-none absolute bottom-full left-0 z-[10000] mb-1.5 w-52 rounded-md bg-neutral-800 px-2.5 py-1.5 text-left text-[11px] font-normal leading-snug text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100"
-                                  >
-                                    {t(
-                                      "layout.sidebar.balancePopup.rechargedTooltip",
-                                    )}
-                                  </span>
-                                </span>
-                              </span>
-                              <span className="tabular-nums text-[11px] font-medium text-text-secondary">
-                                {sidebarCreditBreakdown.planBalance}
-                              </span>
-                            </div>
                           </div>
                           <button
                             type="button"


### PR DESCRIPTION
## What

Clear stale cloud model reference after cloud disconnect and remove the plan credits row from the sidebar balance popup.

## Why

After logging out of a Nexu cloud account, the bot could still use cloud/Link models because:
1. `defaultModelId` was never reset — it kept pointing to the old cloud model
2. `ensureValidDefaultModel()` was not called in the disconnect route (unlike all other cloud mutation routes)
3. OpenClaw was not restarted on disconnect, so cached link provider credentials persisted in memory

The plan credits (套餐积分) row in the sidebar balance popup is no longer needed.

## How

**Cloud disconnect fix (3 changes):**
- `desktop-compat-routes.ts`: Add `ensureValidDefaultModel()` + `syncAll()` to `cloud-disconnect` handler, matching the `cloud-profile/disconnect` pattern. Handles BYOK fallback.
- `nexu-config-store.ts`: In `disconnectDesktopCloud()`, check if `defaultModelId` was a cloud model using `resolveManagedCloudModel()` (already imported). If so, clear it to `""`. Handles the no-BYOK case.
- `container.ts`: Change `onCloudStateChanged` condition from `!hadCloud && hasCloud` to `hadCloud !== hasCloud` so OpenClaw restarts on both connect and disconnect.

**UI fix:**
- `workspace-layout.tsx`: Remove the recharged/plan credits row from the sidebar balance popup.

## Affected areas

- [x] Controller (backend / API)
- [x] Web dashboard (React UI)

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

## Notes for reviewers

The OpenClaw restart via `openclawProcess.stop()/.start()` is a no-op in launchd mode (controller doesn't own the process). Existing sessions may still use cached link provider until they expire or OpenClaw is fully restarted by the desktop process. A follow-up may be needed to have `syncAll()` trigger session invalidation when model providers are removed (similar to the existing `touchAnySkillMarker()` approach for skills).