### PR TITLE
fix: add missing favicon references to login page

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -8,6 +8,11 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Caveat:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <link id="app-favicon" rel="icon" type="image/svg+xml" href="/favicon/favicon-light.svg" />
+    <link rel="icon" type="image/x-icon" href="/favicon/favicon.ico" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon/favicon-16x16.png" />
+    <link rel="apple-touch-icon" href="/favicon/apple-touch-icon.png" />
+    <link rel="manifest" href="/favicon/site.webmanifest" />
     <script>
       (() => {
         const media = window.matchMedia("(prefers-color-scheme: dark)");


### PR DESCRIPTION
## What
Added complete favicon configuration to the login page by adding missing favicon link references to `apps/web/index.html`.

## Why
The login page (nexu.powerformer.net/auth) was missing the official Nexu favicon, displaying a default browser icon instead. This affects user experience and brand perception at a critical entry point.

## How
Added favicon links for:
- `favicon.ico` (standard format for fallback)
- `favicon-16x16.png` and `favicon-32x32.png` (modern browser support)
- `apple-touch-icon.png` (iOS devices)
- `site.webmanifest` (PWA support)

These resources already exist in `/public/favicon/` but were not properly referenced in the HTML head.

## Affected areas
- Frontend: Web authentication page

## Verification
1. Open nexu login page in Chrome/Firefox/Safari
2. Check the browser tab - should now display the official Nexu logo favicon
3. Test on iOS/Android - should show Nexu icon when bookmarked

Closes #935