### PR TITLE
fix: constrain channel status error copy

### DIFF
--- a/apps/web/src/lib/channel-live-status.ts
+++ b/apps/web/src/lib/channel-live-status.ts
@@ -1,0 +1,30 @@
+export type ChannelLiveStatus =
+  | "connected"
+  | "connecting"
+  | "disconnected"
+  | "error"
+  | "restarting";
+
+export function getChannelStatusLabel(
+  status: ChannelLiveStatus | undefined,
+  labels: {
+    connected: string;
+    connecting: string;
+    disconnected: string;
+    error: string;
+    restarting: string;
+  },
+): string {
+  switch (status) {
+    case "connected":
+      return labels.connected;
+    case "connecting":
+      return labels.connecting;
+    case "restarting":
+      return labels.restarting;
+    case "error":
+      return labels.error;
+    default:
+      return labels.disconnected;
+  }
+}

--- a/apps/web/src/pages/channels.tsx
+++ b/apps/web/src/pages/channels.tsx
@@ -10,6 +10,10 @@ import { WhatsappSetupView } from "@/components/channel-setup/whatsapp-setup-vie
 import { useBotQuota } from "@/hooks/use-bot-quota";
 import { useCountdown } from "@/hooks/use-countdown";
 import { getChannelChatUrl } from "@/lib/channel-links";
+import {
+  type ChannelLiveStatus,
+  getChannelStatusLabel,
+} from "@/lib/channel-live-status";
 import { track } from "@/lib/tracking";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
@@ -341,7 +345,18 @@ function ConfiguredView({
   const liveStatus = liveStatusData
     ? (liveEntry?.status ?? "connecting")
     : "connecting";
-  const liveError = liveEntry?.lastError ?? null;
+  const liveStatusLabel = getChannelStatusLabel(
+    liveStatus as ChannelLiveStatus,
+    {
+      connected: t("channels.statusConnected", {
+        platform: PLATFORM_LABELS[platform],
+      }),
+      connecting: `${PLATFORM_LABELS[platform]} ${t("channels.statusConnecting")}`,
+      disconnected: `${PLATFORM_LABELS[platform]} ${t("channels.statusError")}`,
+      error: `${PLATFORM_LABELS[platform]} ${t("channels.statusError")}`,
+      restarting: `${PLATFORM_LABELS[platform]} ${t("channels.statusConnecting")}`,
+    },
+  );
 
   const disconnectMutation = useMutation({
     mutationFn: async () => {
@@ -455,30 +470,20 @@ function ConfiguredView({
           </div>
           <div className="flex-1">
             <div className="text-[13px] font-semibold text-text-primary">
-              {liveStatus === "error" || liveStatus === "disconnected"
-                ? `${PLATFORM_LABELS[platform]} ${t("channels.statusError")}`
-                : liveStatus === "connecting" || liveStatus === "restarting"
-                  ? `${PLATFORM_LABELS[platform]} ${t("channels.statusConnecting")}`
-                  : t("channels.statusConnected", {
-                      platform: PLATFORM_LABELS[platform],
-                    })}
+              {liveStatusLabel}
             </div>
             <div className="text-[11px] text-text-muted mt-0.5">
-              {liveError ? (
-                <span className="text-red-400">{liveError}</span>
-              ) : (
-                <>
-                  {channel.teamName ?? channel.accountId}
-                  {channel.createdAt &&
-                    ` \u00B7 ${t("channels.configuredDate", { date: new Date(channel.createdAt).toLocaleDateString() })}`}
-                  {liveStatus === "connected" && (
-                    <>
-                      {" \u00B7 "}
-                      {t("channels.connectionActive")}
-                    </>
-                  )}
-                </>
-              )}
+              <>
+                {channel.teamName ?? channel.accountId}
+                {channel.createdAt &&
+                  ` \u00B7 ${t("channels.configuredDate", { date: new Date(channel.createdAt).toLocaleDateString() })}`}
+                {liveStatus === "connected" && (
+                  <>
+                    {" \u00B7 "}
+                    {t("channels.connectionActive")}
+                  </>
+                )}
+              </>
             </div>
           </div>
           <button

--- a/apps/web/src/pages/home.tsx
+++ b/apps/web/src/pages/home.tsx
@@ -29,6 +29,10 @@ import {
 import { useDesktopRewardsStatus } from "@/hooks/use-desktop-rewards";
 import { useGitHubStars } from "@/hooks/use-github-stars";
 import { getChannelChatUrl } from "@/lib/channel-links";
+import {
+  type ChannelLiveStatus,
+  getChannelStatusLabel,
+} from "@/lib/channel-live-status";
 import { normalizeChannel, track } from "@/lib/tracking";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowUpRight, Cable, X } from "lucide-react";
@@ -51,13 +55,6 @@ import {
   getApiV1ChannelsLiveStatus,
   getApiV1Sessions,
 } from "../../lib/api/sdk.gen";
-
-type ChannelLiveStatus =
-  | "connected"
-  | "connecting"
-  | "disconnected"
-  | "error"
-  | "restarting";
 
 type ChannelLiveStatusEntry = {
   channelType: string;
@@ -276,7 +273,6 @@ function getChannelOptions(t: (key: string) => string) {
 function getChannelStatusMeta(
   status: ChannelLiveStatus | undefined,
   t: (key: string) => string,
-  lastError?: string | null,
 ): { colorClass: string; pulse: boolean; label: string } {
   switch (status) {
     case "connected":
@@ -295,24 +291,37 @@ function getChannelStatusMeta(
       return {
         colorClass: "bg-[var(--color-warning)]",
         pulse: true,
-        label: t("home.channel.restarting"),
+        label: getChannelStatusLabel(status, {
+          connected: t("home.connected"),
+          connecting: t("home.channelConnecting"),
+          disconnected: t("home.channel.disconnected"),
+          error: t("home.channel.error"),
+          restarting: t("home.channel.restarting"),
+        }),
       };
-    case "error": {
-      const errorKey = lastError ? `home.channel.errorDetail.${lastError}` : "";
-      const hasDetail = lastError && t(errorKey) !== errorKey;
+    case "error":
       return {
-        colorClass: hasDetail
-          ? "bg-[var(--color-warning)]"
-          : "bg-[var(--color-danger)]",
+        colorClass: "bg-[var(--color-danger)]",
         pulse: false,
-        label: hasDetail ? t(errorKey) : t("home.channel.error"),
+        label: getChannelStatusLabel(status, {
+          connected: t("home.connected"),
+          connecting: t("home.channelConnecting"),
+          disconnected: t("home.channel.disconnected"),
+          error: t("home.channel.error"),
+          restarting: t("home.channel.restarting"),
+        }),
       };
-    }
     default:
       return {
         colorClass: "bg-text-muted/40",
         pulse: false,
-        label: t("home.channel.disconnected"),
+        label: getChannelStatusLabel(status, {
+          connected: t("home.connected"),
+          connecting: t("home.channelConnecting"),
+          disconnected: t("home.channel.disconnected"),
+          error: t("home.channel.error"),
+          restarting: t("home.channel.restarting"),
+        }),
       };
   }
 }
@@ -668,7 +677,7 @@ export function HomePage() {
       return;
     }
     if (pending.status === "error") {
-      toast.error(pending.lastError ?? t("home.channel.error"), {
+      toast.error(t("home.channel.error"), {
         id: toastId,
       });
       connectingToastIdRef.current = null;
@@ -1076,11 +1085,7 @@ export function HomePage() {
                     (!statusEntry || statusEntry.status === "disconnected")
                       ? "connecting"
                       : statusEntry?.status;
-                  const statusMeta = getChannelStatusMeta(
-                    effectiveStatus,
-                    t,
-                    statusEntry?.lastError,
-                  );
+                  const statusMeta = getChannelStatusMeta(effectiveStatus, t);
                   const isConnectedLive = effectiveStatus === "connected";
                   const channelChatUrl = connectedChannel
                     ? getChannelChatUrl(
@@ -1131,7 +1136,7 @@ export function HomePage() {
                           {ch.name}
                         </span>
                         <span
-                          title={statusEntry?.lastError ?? statusMeta.label}
+                          title={statusMeta.label}
                           className={`w-1.5 h-1.5 rounded-full shrink-0 ${statusMeta.colorClass} ${statusMeta.pulse ? "animate-pulse" : ""}`}
                         />
                       </div>

--- a/apps/web/tests/channel-live-status.test.ts
+++ b/apps/web/tests/channel-live-status.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { getChannelStatusLabel } from "../src/lib/channel-live-status";
+
+describe("getChannelStatusLabel", () => {
+  const labels = {
+    connected: "Connected",
+    connecting: "Connecting...",
+    disconnected: "Disconnected",
+    error: "Connection error",
+    restarting: "Restarting...",
+  };
+
+  it("returns the predefined error label instead of any raw backend payload", () => {
+    expect(getChannelStatusLabel("error", labels)).toBe("Connection error");
+  });
+
+  it("returns the disconnected label for undefined status", () => {
+    expect(getChannelStatusLabel(undefined, labels)).toBe("Disconnected");
+  });
+});


### PR DESCRIPTION
## What

Stop rendering raw backend channel status errors in the home Channels list and channel configuration status card. The UI now only shows predefined status copy.

## Why

Some disconnect and live-status failures were surfacing full backend payloads in the web UI, including large JSON error blobs. That makes the homepage noisy and exposes transport-level details instead of the intended product states.

## How

Added a small web-side channel status label helper and updated both the home page and channels page to use fixed labels for connected, connecting, restarting, disconnected, and error states. Removed direct rendering of backend error payloads from those surfaces and added a regression test for the fixed mapping.

## Affected areas

- [ ] Desktop app (Electron shell)
- [ ] Controller (backend / API)
- [x] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [ ] Build / CI / Tooling

## Checklist

- [x] pnpm typecheck passes
- [x] pnpm lint passes
- [ ] pnpm test passes
- [ ] pnpm generate-types run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No any types introduced (use unknown with narrowing)

## Notes for reviewers

I ran targeted web tests for the touched surfaces: tests/channel-live-status.test.ts and tests/home.test.tsx. I did not mark the full pnpm test checkbox because the web test suite currently has pre-existing sessions expectation failures unrelated to this change.