### PR TITLE
fix(controller): restart OpenClaw on every provider/cloud change

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,7 @@ The desktop test suite includes real launchd integration tests that run on macOS
 - Windows packaging split: use `pnpm dist:win` for the full installer/release path and keep it close to CI semantics. Use `pnpm dist:win:local` for local Windows validation when you need fast iteration; it is intentionally dir-only and reuse-first, so it is not a substitute for the full release build.
 - Controller sidecar packaging: every dependency in `apps/controller/package.json` is recursively deep-copied into the desktop distributable via `prepare-controller-sidecar` → `copyRuntimeDependencyClosure`. **Never add heavy transitive-dependency packages (e.g. `npm`, `yarn`) to the controller.** If the controller needs to shell out to a CLI tool, use PATH-based `execFile("npm", ...)` instead of bundling it as a dependency. Each MB added to controller deps adds ~1 MB to the final DMG/ZIP.
 - Native Node.js addons (e.g. `better-sqlite3`) must live in the controller, NOT in the desktop Electron main process. Electron's built-in Node.js has a different ABI version (NODE_MODULE_VERSION) from system Node.js, requiring `electron-rebuild` to recompile native modules. The controller runs as a regular Node.js process (`ELECTRON_RUN_AS_NODE=1`), so native addons work without recompilation.
+- **OpenClaw provider/model registry is not hot-reload-safe.** Any code path that mutates `models.providers` in `openclaw.json` (cloud login/logout, BYOK add/delete/bulk-update, OAuth connect/disconnect) MUST call `openclawProcess.restart(reason)` after `syncAll()`. OpenClaw builds its registry once at boot; writing the file is not enough. In packaged desktop OpenClaw is supervised by launchd, so `openclawProcess.stop()/start()` is a silent no-op — `restart()` routes through `launchctl kickstart -k` automatically. Always smoke-test provider-lifecycle changes in the packaged build, not just `pnpm dev`. See `specs/design-docs/2026-04-14-openclaw-registry-cache-invalidation.md`.
 
 ## Observability conventions
 
@@ -237,6 +238,7 @@ See `ARCHITECTURE.md` for the full bird's-eye view. Key points:
 | System design | `specs/designs/openclaw-multi-tenant.md` |
 | OpenClaw internals | `specs/designs/openclaw-architecture-internals.md` |
 | OpenClaw error handling & compaction | `specs/references/openclaw-error-handling-internals.md` |
+| OpenClaw registry cache invalidation (restart-on-provider-change) | `specs/design-docs/2026-04-14-openclaw-registry-cache-invalidation.md` |
 | Engineering principles | `specs/design-docs/core-beliefs.md` |
 | Config schema & pitfalls | `specs/references/openclaw-config-schema.md` |
 | API coding patterns | `specs/references/api-patterns.md` |

--- a/apps/controller/src/app/container.ts
+++ b/apps/controller/src/app/container.ts
@@ -152,15 +152,20 @@ export async function createContainer(): Promise<ControllerContainer> {
   );
   const githubStarVerificationService = new GithubStarVerificationService();
 
-  // Wire cloud state change callback to sync refreshed cloud inventory without
-  // auto-switching the default model during startup or first-channel connect.
-  configStore.onCloudStateChanged = async (change) => {
+  configStore.onCloudStateChanged = async (_change) => {
+    // Auto-select a valid default model: on login, pick a managed model;
+    // on logout, fall back to any remaining BYOK/OAuth model (or leave
+    // cleared, which surfaces the explicit no-model guidance).
+    await modelProviderService.ensureValidDefaultModel();
     await openclawSyncService.syncAll();
-    if (!change.hadCloudInventory && change.hasCloudInventory) {
-      await openclawProcess.stop();
-      openclawProcess.enableAutoRestart();
-      openclawProcess.start();
-    }
+    // Restart the gateway on every login/logout.  Provider-level changes
+    // are not hot-reload-safe: OpenClaw builds its provider/model registry
+    // once at boot, so without a restart the old providers map stays
+    // resident in memory and the runtime keeps resolving to stale entries
+    // (e.g. link/*) after disconnect, or reports "Unknown model" after a
+    // fresh login because the registry never saw the new providers map.
+    // `restart()` handles both dev-managed and launchd-managed modes.
+    await openclawProcess.restart("cloud_state_changed");
   };
 
   return {

--- a/apps/controller/src/lib/openclaw-config-compiler.ts
+++ b/apps/controller/src/lib/openclaw-config-compiler.ts
@@ -120,9 +120,15 @@ function compileModelsConfig(
       continue;
     }
 
+    // Keep apiKey when it's a non-empty string or a secret-ref object; only
+    // drop it when null/undefined or an empty string. Emitting apiKey:""
+    // caused OpenClaw to reject the provider (and caused relogin to fail
+    // with "Unknown model: link/...").
+    const hasUsableApiKey =
+      apiKey !== null && !(typeof apiKey === "string" && apiKey.length === 0);
     providers[descriptor.runtimeKey] = {
       baseUrl: descriptor.provider.baseUrl,
-      apiKey: apiKey ?? "",
+      ...(hasUsableApiKey ? { apiKey } : {}),
       api: descriptor.apiKind,
       ...(descriptor.authHeader ? { authHeader: true } : {}),
       ...(descriptor.defaultHeaders

--- a/apps/controller/src/runtime/openclaw-auth-profiles-writer.ts
+++ b/apps/controller/src/runtime/openclaw-auth-profiles-writer.ts
@@ -24,6 +24,23 @@ type AuthProfileRecord =
 
 type AuthProfileEntry = [string, AuthProfileRecord];
 
+function mergeAuthProfileEntries(
+  primaryEntries: AuthProfileEntry[],
+  fallbackEntries: AuthProfileEntry[],
+): AuthProfileEntry[] {
+  const merged = new Map<string, AuthProfileRecord>();
+
+  for (const [key, profile] of fallbackEntries) {
+    merged.set(key, profile);
+  }
+
+  for (const [key, profile] of primaryEntries) {
+    merged.set(key, profile);
+  }
+
+  return [...merged.entries()];
+}
+
 function isApiKeyProfile(profile: unknown): profile is { type: "api_key" } {
   return (
     typeof profile === "object" &&
@@ -65,28 +82,29 @@ export class OpenClawAuthProfilesWriter {
       providerSource,
     );
 
-    const effectiveEntries =
-      profileEntries.length > 0
-        ? profileEntries
-        : fallbackProviders.flatMap((provider): AuthProfileEntry[] => {
-            if (
-              typeof provider.apiKey === "string" &&
-              provider.apiKey.length > 0
-            ) {
-              return [
-                [
-                  `${provider.providerId}:default`,
-                  {
-                    type: "api_key",
-                    provider: provider.providerId,
-                    key: provider.apiKey,
-                  },
-                ],
-              ];
-            }
+    const fallbackEntries = fallbackProviders.flatMap(
+      (provider): AuthProfileEntry[] => {
+        if (typeof provider.apiKey === "string" && provider.apiKey.length > 0) {
+          return [
+            [
+              `${provider.providerId}:default`,
+              {
+                type: "api_key",
+                provider: provider.providerId,
+                key: provider.apiKey,
+              },
+            ],
+          ];
+        }
 
-            return [];
-          });
+        return [];
+      },
+    );
+
+    const effectiveEntries = mergeAuthProfileEntries(
+      profileEntries,
+      fallbackEntries,
+    );
 
     const profiles = Object.fromEntries(effectiveEntries) as Record<
       string,

--- a/apps/controller/src/runtime/openclaw-process.ts
+++ b/apps/controller/src/runtime/openclaw-process.ts
@@ -1,8 +1,16 @@
-import { type ChildProcess, execSync, spawn } from "node:child_process";
+import {
+  type ChildProcess,
+  execFile,
+  execSync,
+  spawn,
+} from "node:child_process";
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { readdir, rm } from "node:fs/promises";
 import net from "node:net";
-import { tmpdir } from "node:os";
+import os, { tmpdir } from "node:os";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
 import path from "node:path";
 import { createInterface } from "node:readline";
 import type { ControllerEnv } from "../app/env.js";
@@ -272,6 +280,47 @@ export class OpenClawProcessManager {
       "restarting unhealthy openclaw process",
     );
     this.child.kill("SIGKILL");
+  }
+
+  /**
+   * Restart the gateway regardless of whether the controller manages the
+   * process directly (dev / local-dev) or an external supervisor owns it
+   * (packaged desktop via launchd). Returns once the restart has been
+   * initiated — callers that need readiness should probe separately.
+   */
+  async restart(reason: string): Promise<void> {
+    logger.info({ reason }, "openclaw_restart_requested");
+
+    if (this.env.manageOpenclawProcess) {
+      await this.stop();
+      this.enableAutoRestart();
+      this.start();
+      return;
+    }
+
+    if (this.env.openclawLaunchdLabel) {
+      const domain = `gui/${os.userInfo().uid}/${this.env.openclawLaunchdLabel}`;
+      try {
+        await execFileAsync("launchctl", ["kickstart", "-k", domain]);
+        logger.info({ reason, domain }, "openclaw_restart_launchd_kickstarted");
+      } catch (err) {
+        logger.error(
+          { reason, domain, err },
+          "openclaw_restart_launchd_failed",
+        );
+        throw err;
+      }
+      return;
+    }
+
+    logger.warn(
+      {
+        reason,
+        manageOpenclawProcess: this.env.manageOpenclawProcess,
+        hasLaunchdLabel: false,
+      },
+      "openclaw_restart_skipped_no_supervisor",
+    );
   }
 
   async stop(): Promise<void> {

--- a/apps/controller/src/runtime/openclaw-runtime-model-writer.ts
+++ b/apps/controller/src/runtime/openclaw-runtime-model-writer.ts
@@ -6,10 +6,28 @@ import { logger } from "../lib/logger.js";
 export interface OpenClawRuntimeModelState {
   selectedModelRef: string;
   promptNotice: string;
+  noModelMessage: string | null;
   updatedAt: string;
 }
 
 const RUNTIME_MODEL_FALLBACK = "anthropic/claude-opus-4-6";
+export type NoModelMessageLocale = "en" | "zh-CN";
+
+const NO_MODEL_CONFIGURED_MESSAGES: Record<NoModelMessageLocale, string> = {
+  en: "No model is available right now. Please sign in to your Nexu Official account, or add your own API key or OAuth provider under Settings → Models to enable a model.",
+  "zh-CN":
+    "当前没有可用的模型。请登录 Nexu 官方账号，或在 设置 → 模型 中配置您自己的 API Key 或 OAuth 服务商以启用模型。",
+};
+
+export const NO_MODEL_CONFIGURED_MESSAGE = NO_MODEL_CONFIGURED_MESSAGES.en;
+
+export function resolveNoModelConfiguredMessage(
+  locale: NoModelMessageLocale,
+): string {
+  return (
+    NO_MODEL_CONFIGURED_MESSAGES[locale] ?? NO_MODEL_CONFIGURED_MESSAGES.en
+  );
+}
 
 function buildPromptNotice(selectedModelRef: string): string {
   return [
@@ -25,19 +43,15 @@ function buildPromptNotice(selectedModelRef: string): string {
 export class OpenClawRuntimeModelWriter {
   constructor(private readonly env: ControllerEnv) {}
 
-  async write(selectedModelRef: string): Promise<void> {
+  private async writeState(payload: OpenClawRuntimeModelState): Promise<void> {
     await mkdir(path.dirname(this.env.openclawRuntimeModelStatePath), {
       recursive: true,
     });
-    const payload: OpenClawRuntimeModelState = {
-      selectedModelRef,
-      promptNotice: buildPromptNotice(selectedModelRef),
-      updatedAt: new Date().toISOString(),
-    };
     logger.info(
       {
         path: this.env.openclawRuntimeModelStatePath,
-        selectedModelRef,
+        selectedModelRef: payload.selectedModelRef,
+        hasNoModelMessage: payload.noModelMessage !== null,
       },
       "runtime_model_write_begin",
     );
@@ -49,13 +63,51 @@ export class OpenClawRuntimeModelWriter {
     logger.info(
       {
         path: this.env.openclawRuntimeModelStatePath,
-        selectedModelRef,
+        selectedModelRef: payload.selectedModelRef,
+        hasNoModelMessage: payload.noModelMessage !== null,
       },
       "runtime_model_write_complete",
     );
   }
 
+  async write(selectedModelRef: string): Promise<void> {
+    await this.writeState({
+      selectedModelRef,
+      promptNotice: buildPromptNotice(selectedModelRef),
+      noModelMessage: null,
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  async writeNoModelState(
+    noModelMessage = NO_MODEL_CONFIGURED_MESSAGE,
+  ): Promise<void> {
+    await this.writeState({
+      selectedModelRef: "",
+      promptNotice: "",
+      noModelMessage,
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
   async writeFallback(): Promise<void> {
     await this.write(RUNTIME_MODEL_FALLBACK);
+  }
+
+  /**
+   * Remove the runtime-model state file so OpenClaw has no model override.
+   * Called when all model providers are removed (e.g. link account logout).
+   */
+  async clear(): Promise<void> {
+    const { unlink } = await import("node:fs/promises");
+    try {
+      await unlink(this.env.openclawRuntimeModelStatePath);
+      logger.info(
+        { path: this.env.openclawRuntimeModelStatePath },
+        "runtime_model_cleared",
+      );
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+    }
   }
 }

--- a/apps/controller/src/services/model-provider-service.ts
+++ b/apps/controller/src/services/model-provider-service.ts
@@ -539,6 +539,7 @@ export class ModelProviderService {
     const next = await this.configStore.setModelProviderConfigDocument(config);
     await this.ensureValidDefaultModel();
     await this.openclawSyncService.syncAll();
+    await this.restartRuntime("model_provider_config_changed");
     return next;
   }
 
@@ -564,6 +565,7 @@ export class ModelProviderService {
     if (changed) {
       await this.ensureValidDefaultModel();
       await this.openclawSyncService.syncAll();
+      await this.restartRuntime("nexu_official_models_refreshed");
       logger.info(
         {
           provider: NEXU_OFFICIAL_PROVIDER_ID,
@@ -602,7 +604,11 @@ export class ModelProviderService {
   }
 
   async deleteProvider(providerId: string) {
-    return this.configStore.deleteProvider(providerId);
+    const result = await this.configStore.deleteProvider(providerId);
+    await this.ensureValidDefaultModel();
+    await this.openclawSyncService.syncAll();
+    await this.restartRuntime("provider_deleted");
+    return result;
   }
 
   async getInventoryStatus(): Promise<ModelInventoryStatus> {
@@ -1242,17 +1248,13 @@ export class ModelProviderService {
     });
   }
 
-  private async restartRuntime(): Promise<void> {
-    if (!this.openclawProcess.managesProcess()) {
-      logger.info(
-        {},
-        "model_provider_runtime_restart_skipped_external_openclaw",
-      );
-      return;
-    }
-
-    await this.openclawProcess.stop();
-    this.openclawProcess.enableAutoRestart();
-    this.openclawProcess.start();
+  private async restartRuntime(reason = "provider_changed"): Promise<void> {
+    // Provider-level changes are not hot-reload-safe: OpenClaw caches its
+    // provider/model registry once at boot. Without a restart, deleting or
+    // disabling a provider leaves stale entries resident and the runtime
+    // keeps trying to resolve against removed providers (e.g. "No API key
+    // for openai-codex" after the user disabled all BYOK providers).
+    // `restart()` handles both dev-managed and launchd-managed modes.
+    await this.openclawProcess.restart(reason);
   }
 }

--- a/apps/controller/src/services/openclaw-sync-service.ts
+++ b/apps/controller/src/services/openclaw-sync-service.ts
@@ -13,6 +13,7 @@ import type { OpenClawAuthProfilesStore } from "../runtime/openclaw-auth-profile
 import type { OpenClawAuthProfilesWriter } from "../runtime/openclaw-auth-profiles-writer.js";
 import type { OpenClawConfigWriter } from "../runtime/openclaw-config-writer.js";
 import type { OpenClawRuntimeModelWriter } from "../runtime/openclaw-runtime-model-writer.js";
+import { resolveNoModelConfiguredMessage } from "../runtime/openclaw-runtime-model-writer.js";
 import type { OpenClawRuntimePluginWriter } from "../runtime/openclaw-runtime-plugin-writer.js";
 import type { OpenClawWatchTrigger } from "../runtime/openclaw-watch-trigger.js";
 import type { WorkspaceTemplateWriter } from "../runtime/workspace-template-writer.js";
@@ -312,27 +313,56 @@ export class OpenClawSyncService {
     }
 
     // 2. Always write files once (persistence + watcher hot-reload path).
+    const hasAnyProvider =
+      Object.keys(compiled.models?.providers ?? {}).length > 0;
+
+    // When no model provider is configured (e.g. after link logout with no
+    // BYOK keys), strip the model from agents so OpenClaw cannot fall back
+    // to its built-in registry with the bare model name.  This is a
+    // hot-reload-safe change (agents.list → dynamic reads, no gateway restart).
+    if (!hasAnyProvider) {
+      if (compiled.agents.defaults?.model) {
+        compiled.agents.defaults = {
+          ...compiled.agents.defaults,
+          model: undefined,
+        };
+      }
+      for (const agent of compiled.agents.list ?? []) {
+        if (agent.model) {
+          agent.model = undefined;
+        }
+      }
+    }
+
     await this.configWriter.write(compiled);
     await this.authProfilesWriter.writeForAgents(
       compiled,
       config.models.providers,
     );
     this.gatewayService.noteConfigWritten(compiled);
-    const runtimeModelRef = resolvePrimaryModelRef(
-      compiled.agents.defaults?.model,
-      config,
-      compiled,
-      this.env,
-      oauthState,
-    );
+    const runtimeModelRef = hasAnyProvider
+      ? resolvePrimaryModelRef(
+          compiled.agents.defaults?.model,
+          config,
+          compiled,
+          this.env,
+          oauthState,
+        )
+      : null;
     logger.info({ seq, runtimeModelRef }, "doSync: resolved runtime model");
-    await this.runtimeModelWriter.write(runtimeModelRef);
     // Write locale state for the credit-guard patch in OpenClaw runtime.
     // Match the controller's own locale default: unset → "en" (not "zh-CN").
     const locale =
       (config.desktop as Record<string, unknown>).locale === "zh-CN"
         ? "zh-CN"
         : "en";
+    if (runtimeModelRef) {
+      await this.runtimeModelWriter.write(runtimeModelRef);
+    } else {
+      await this.runtimeModelWriter.writeNoModelState(
+        resolveNoModelConfiguredMessage(locale),
+      );
+    }
     await this.creditGuardStateWriter.write(locale);
     await this.compiledStore.saveConfig(compiled);
 

--- a/apps/controller/src/services/openclaw-sync-service.ts
+++ b/apps/controller/src/services/openclaw-sync-service.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { selectPreferredModel } from "@nexu/shared";
+import type { OpenClawConfig } from "@nexu/shared";
 import type { ControllerEnv } from "../app/env.js";
 import { logger } from "../lib/logger.js";
 import {
@@ -281,13 +282,39 @@ export class OpenClawSyncService {
         )
       : undefined;
 
-    const compiled = compileOpenClawConfig(
+    const rawCompiled = compileOpenClawConfig(
       config,
       this.env,
       oauthState,
       installedSlugs,
       workspaceMap,
     );
+
+    const hasAnyProvider =
+      Object.keys(rawCompiled.models?.providers ?? {}).length > 0;
+
+    // When no model provider is configured (e.g. after link logout with no
+    // BYOK keys), strip the model from agents so OpenClaw cannot fall back
+    // to its built-in registry with the bare model name. This normalization
+    // must happen BEFORE shouldPushConfig() — otherwise the pre-normalized
+    // hash we diff against diverges from the post-normalized hash we store
+    // via noteConfigWritten(), which would mark every subsequent no-provider
+    // sync as changed and trigger spurious touchAnySkillMarker() runs.
+    // Rebuild immutably (no in-place mutation of the compiled object).
+    const compiled: OpenClawConfig = hasAnyProvider
+      ? rawCompiled
+      : {
+          ...rawCompiled,
+          agents: {
+            ...rawCompiled.agents,
+            defaults: rawCompiled.agents.defaults
+              ? { ...rawCompiled.agents.defaults, model: undefined }
+              : rawCompiled.agents.defaults,
+            list: (rawCompiled.agents.list ?? []).map((agent) =>
+              agent.model ? { ...agent, model: undefined } : agent,
+            ),
+          },
+        };
 
     logger.info(
       {
@@ -313,26 +340,6 @@ export class OpenClawSyncService {
     }
 
     // 2. Always write files once (persistence + watcher hot-reload path).
-    const hasAnyProvider =
-      Object.keys(compiled.models?.providers ?? {}).length > 0;
-
-    // When no model provider is configured (e.g. after link logout with no
-    // BYOK keys), strip the model from agents so OpenClaw cannot fall back
-    // to its built-in registry with the bare model name.  This is a
-    // hot-reload-safe change (agents.list → dynamic reads, no gateway restart).
-    if (!hasAnyProvider) {
-      if (compiled.agents.defaults?.model) {
-        compiled.agents.defaults = {
-          ...compiled.agents.defaults,
-          model: undefined,
-        };
-      }
-      for (const agent of compiled.agents.list ?? []) {
-        if (agent.model) {
-          agent.model = undefined;
-        }
-      }
-    }
 
     await this.configWriter.write(compiled);
     await this.authProfilesWriter.writeForAgents(
@@ -359,6 +366,11 @@ export class OpenClawSyncService {
     if (runtimeModelRef) {
       await this.runtimeModelWriter.write(runtimeModelRef);
     } else {
+      // TODO(alche): This writes `noModelMessage` into the runtime-model state
+      // file, but the downstream OpenClaw/runtime consumer still primarily acts
+      // on non-empty `selectedModelRef` / `promptNotice`. Wire that reader path
+      // to surface `noModelMessage` explicitly so users see this guidance
+      // instead of falling through to a generic runtime/provider error.
       await this.runtimeModelWriter.writeNoModelState(
         resolveNoModelConfiguredMessage(locale),
       );

--- a/apps/controller/src/store/nexu-config-store.ts
+++ b/apps/controller/src/store/nexu-config-store.ts
@@ -38,7 +38,10 @@ import {
 import type { z } from "zod";
 import type { ControllerEnv } from "../app/env.js";
 import { logger } from "../lib/logger.js";
-import { resolveManagedCloudModel } from "../lib/managed-models.js";
+import {
+  isManagedCloudModelId,
+  resolveManagedCloudModel,
+} from "../lib/managed-models.js";
 import { proxyFetch } from "../lib/proxy-fetch.js";
 import {
   type CloudRewardService,
@@ -2685,7 +2688,8 @@ export class NexuConfigStore {
   }
 
   async disconnectDesktopCloud() {
-    const previousCloud = readDesktopCloud(await this.getConfig());
+    const previousConfig = await this.getConfig();
+    const previousCloud = readDesktopCloud(previousConfig);
     this.abortDesktopCloudPolling();
 
     await this.setDesktopCloudState({
@@ -2699,6 +2703,14 @@ export class NexuConfigStore {
       apiKey: null,
       models: [],
     });
+    if (
+      isManagedCloudModelId(
+        previousConfig.runtime.defaultModelId,
+        previousCloud.models,
+      )
+    ) {
+      await this.setDefaultModel("");
+    }
     await this.onCloudStateChanged?.({
       hadCloudInventory: (previousCloud.models?.length ?? 0) > 0,
       hasCloudInventory: false,

--- a/apps/controller/src/store/nexu-config-store.ts
+++ b/apps/controller/src/store/nexu-config-store.ts
@@ -2703,13 +2703,40 @@ export class NexuConfigStore {
       apiKey: null,
       models: [],
     });
-    if (
-      isManagedCloudModelId(
-        previousConfig.runtime.defaultModelId,
-        previousCloud.models,
-      )
-    ) {
-      await this.setDefaultModel("");
+    // Strip every managed-cloud (link/*) reference from the persisted config:
+    // the runtime default AND per-bot overrides. Only clearing the global
+    // default leaves bots that were explicitly set to a Link model still
+    // pointing at an unavailable link/* id, which later compiles into the
+    // agent runtime and surfaces as "Unknown model"/"no provider" errors.
+    // BYOK/OAuth selections are untouched so user-configured non-Link bots
+    // keep working.
+    const previousCloudModels = previousCloud.models;
+    const defaultWasManaged = isManagedCloudModelId(
+      previousConfig.runtime.defaultModelId,
+      previousCloudModels,
+    );
+    const botsHaveManaged = previousConfig.bots.some((bot) =>
+      isManagedCloudModelId(bot.modelId, previousCloudModels),
+    );
+    if (defaultWasManaged || botsHaveManaged) {
+      const updatedAt = now();
+      await this.store.update((config) => ({
+        ...config,
+        runtime: {
+          ...config.runtime,
+          defaultModelId: isManagedCloudModelId(
+            config.runtime.defaultModelId,
+            previousCloudModels,
+          )
+            ? ""
+            : config.runtime.defaultModelId,
+        },
+        bots: config.bots.map((bot) =>
+          isManagedCloudModelId(bot.modelId, previousCloudModels)
+            ? { ...bot, modelId: "", updatedAt }
+            : bot,
+        ),
+      }));
     }
     await this.onCloudStateChanged?.({
       hadCloudInventory: (previousCloud.models?.length ?? 0) > 0,

--- a/apps/controller/static/runtime-plugins/nexu-runtime-model/index.js
+++ b/apps/controller/static/runtime-plugins/nexu-runtime-model/index.js
@@ -47,23 +47,28 @@ const plugin = {
       if (!state) {
         return;
       }
-      const slashIndex = state.selectedModelRef.indexOf("/");
-      if (slashIndex <= 0) {
-        return {
-          modelOverride: state.selectedModelRef,
-        };
+      if (state.selectedModelRef.trim().length === 0) {
+        return;
       }
+      const slashIndex = state.selectedModelRef.indexOf("/");
       const providerOverride = state.selectedModelRef.slice(0, slashIndex);
-      const modelOverride = state.selectedModelRef.slice(slashIndex + 1);
+      const modelOverride =
+        slashIndex > 0
+          ? state.selectedModelRef.slice(slashIndex + 1)
+          : state.selectedModelRef;
       return {
-        providerOverride,
+        ...(slashIndex > 0 ? { providerOverride } : {}),
         modelOverride,
       };
     });
 
     api.on("before_prompt_build", async () => {
       const state = loadState();
-      if (!state?.promptNotice) {
+      if (
+        !state ||
+        state.selectedModelRef.trim().length === 0 ||
+        state.promptNotice.trim().length === 0
+      ) {
         return;
       }
       return {

--- a/apps/controller/tests/nexu-config-store.test.ts
+++ b/apps/controller/tests/nexu-config-store.test.ts
@@ -1157,6 +1157,74 @@ describe("NexuConfigStore", () => {
     expect(status.viewer.usingManagedModel).toBe(true);
   });
 
+  it("clears a link-selected default model when desktop cloud disconnects", async () => {
+    await mkdir(path.dirname(env.nexuConfigPath), { recursive: true });
+    await writeFile(
+      env.nexuConfigPath,
+      JSON.stringify(
+        {
+          $schema: "https://nexu.io/config.json",
+          schemaVersion: 2,
+          app: {},
+          bots: [
+            {
+              id: "bot-1",
+              name: "Assistant",
+              slug: "assistant",
+              poolId: null,
+              modelId: "link/gemini-3-flash-preview",
+              status: "active",
+              systemPrompt: null,
+              createdAt: "2026-04-01T00:00:00.000Z",
+              updatedAt: "2026-04-01T00:00:00.000Z",
+            },
+          ],
+          runtime: {
+            gateway: {
+              port: env.openclawGatewayPort,
+              bind: "loopback",
+              authMode: "none",
+            },
+            defaultModelId: "link/gemini-3-flash-preview",
+          },
+          models: {
+            mode: "merge",
+            providers: {},
+          },
+          integrations: [],
+          channels: [],
+          templates: {},
+          desktop: {
+            cloud: {
+              connected: true,
+              polling: false,
+              userName: "Cloud User",
+              userEmail: "user@nexu.io",
+              connectedAt: "2026-04-01T00:00:00.000Z",
+              linkUrl: "https://link.nexu.io",
+              apiKey: "valid-key",
+              models: [
+                { id: "gemini-3-flash-preview", name: "Gemini 3 Flash" },
+              ],
+            },
+          },
+          secrets: {},
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const store = new NexuConfigStore(env);
+
+    await store.disconnectDesktopCloud();
+
+    const config = await store.getConfig();
+    expect(config.runtime.defaultModelId).toBe("");
+    expect(config.bots[0]?.modelId).toBe("");
+  });
+
   it("backfills missing desktop cloud userId from /api/v1/me during bootstrap", async () => {
     const store = new NexuConfigStore(env);
 

--- a/apps/controller/tests/openclaw-config-compiler.test.ts
+++ b/apps/controller/tests/openclaw-config-compiler.test.ts
@@ -1122,4 +1122,49 @@ describe("compileOpenClawConfig", () => {
       primary: "openai-codex/gpt-5.4",
     });
   });
+
+  it("omits empty apiKey fields for oauth-backed providers in compiled models config", () => {
+    const result = compileOpenClawConfig(
+      createConfig({
+        providers: [],
+        models: {
+          mode: "merge",
+          providers: {
+            openai: {
+              enabled: true,
+              auth: "oauth",
+              api: "openai-completions",
+              apiKey: null,
+              oauthProfileRef: "openai-codex",
+              baseUrl: "https://api.openai.com/v1",
+              models: [
+                {
+                  id: "gpt-5.4",
+                  name: "GPT-5.4",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: {
+                    input: 0,
+                    output: 0,
+                    cacheRead: 0,
+                    cacheWrite: 0,
+                  },
+                  contextWindow: 0,
+                  maxTokens: 0,
+                },
+              ],
+            },
+          },
+        },
+        desktop: {
+          selectedModelId: null,
+        },
+      }),
+      createEnv(),
+    );
+
+    expect(result.models?.providers.openai).toBeDefined();
+    expect(result.models?.providers.openai).not.toHaveProperty("apiKey");
+    expect(result.models?.providers.openai?.models[0]?.id).toBe("gpt-5.4");
+  });
 });

--- a/packages/shared/src/schemas/openclaw-config.ts
+++ b/packages/shared/src/schemas/openclaw-config.ts
@@ -439,7 +439,7 @@ const modelEntrySchema = z.object({
 const modelProviderSchema = z
   .object({
     baseUrl: z.string(),
-    apiKey: z.union([z.string(), providerSecretRefSchema]),
+    apiKey: z.union([z.string(), providerSecretRefSchema]).optional(),
     api: z.string(),
     models: z.array(modelEntrySchema),
   })

--- a/specs/design-docs/2026-04-14-model-id-field-usage.md
+++ b/specs/design-docs/2026-04-14-model-id-field-usage.md
@@ -1,0 +1,145 @@
+# Model-Level ID Field Usage in Nexu
+
+Date: 2026-04-14
+Scope: single model record `id` field (e.g. `"gpt-5.4"`, `"gemini-3-flash-preview"`) — **not** provider id, runtime ref, bot id, or session id.
+
+## TL;DR
+
+The raw model `id` flows: external provider API → cloud inventory / BYOK config → persisted bot/runtime config → compiled `openclaw.json`, passing through multiple transformation layers (prefix stripping, namespace addition, OAuth remapping, alias resolution). Validation is minimal at ingestion points. Same raw id can exist under multiple providers — uniqueness is provider-scoped, made globally unique only by adding the runtime prefix.
+
+## 1. Schema & type definitions
+
+### Primary schemas
+
+`packages/shared/src/schemas/model-provider-config.ts:44`
+```ts
+modelProviderModelEntrySchema = z.object({
+  id: z.string().min(1),  // raw provider-native id, no namespace
+  name: z.string().min(1),
+  ...
+})
+```
+- Constraint: `.min(1)` only — no format / uniqueness / collision checks
+
+`packages/shared/src/schemas/bot.ts:29`
+```ts
+botResponseSchema = z.object({
+  modelId: z.string(),  // may contain provider prefix
+  ...
+})
+```
+
+`apps/controller/src/store/schemas.ts:466`
+```ts
+controllerRuntimeConfigSchema = z.object({
+  defaultModelId: z.string().default("link/gemini-3-flash-preview"),
+  ...
+})
+```
+Default is a cloud runtime ref; accepts `link/`, `litellm/`, `debug/`-prefixed refs.
+
+## 2. Compilation into `openclaw.json`
+
+`apps/controller/src/lib/openclaw-config-compiler.ts:58-76` — `buildModelEntry(id, name?)` wraps the raw id with OpenClaw metadata. Three callers:
+
+1. Line 108 — LiteLLM: `buildModelEntry(modelId)` (after stripping `litellm/` prefix)
+2. Line 139 — bundled providers: `buildModelEntry(buildProviderRuntimeModelId(descriptor, model.id), model.name)`
+3. Line 156 — cloud (Link): `buildModelEntry(model.id, model.name)` (passed through as-is)
+
+Bot runtime ref resolution at `openclaw-config-compiler.ts:256-258`:
+```ts
+model: bot.modelId
+  ? { primary: resolveModelId(config, env, bot.modelId, oauthState) }
+  : undefined,
+```
+
+## 3. OAuth remapping
+
+`apps/controller/src/lib/openclaw-config-compiler.ts:30-32, 188-196`
+```ts
+const OAUTH_PROVIDER_MAP: Record<string, string> = {
+  openai: "openai-codex",
+};
+```
+
+In `resolveModelId()`, when OAuth is connected for OpenAI, the runtime prefix is remapped `openai/<id>` → `openai-codex/<id>`. The raw id itself does not change.
+
+## 4. Prefix / namespace normalization
+
+`apps/controller/src/lib/model-provider-runtime.ts:275-282` — `stripCanonicalModelPrefix(namespace, modelId)`:
+- Input `"openai/gpt-4o"` → output `"gpt-4o"`
+- Input already bare → returned unchanged
+
+`model-provider-runtime.ts:284-306` — `buildProviderRuntimeModelId(descriptor, modelId)`:
+- Custom provider → returns raw id unchanged
+- Canonical provider (runtime key == canonical OpenClaw id) → returns raw id
+- Proxied / BYOK → returns `${namespace}/${id}`
+
+`model-provider-runtime.ts:308-313` — `buildProviderRuntimeModelRef(descriptor, modelId)` assembles `${runtimeKey}/${runtimeModelId}`.
+
+`apps/controller/src/store/schemas.ts:141-145` — special prefixes (`link/`, `litellm/`, `debug/`) skip normalization entirely.
+
+## 5. Bot / agent defaults
+
+`packages/shared/src/schemas/bot.ts:13` — createBotSchema default is `"gpt-4o"` (bare).
+
+`apps/controller/src/store/schemas.ts:131-176` — `normalizePersistedModelRef(rawModelId, modelsConfig)`:
+- Pass-through for `link/`, `litellm/`, `debug/`
+- Otherwise match against persisted providers, strip legacy `byok_` prefix, or normalize existing `provider/id` shape
+- Last resort: return as-is
+
+Applied on config load at `schemas.ts:600-606` to every `bot.modelId`.
+
+## 6. Cloud (Link) inventory ingestion
+
+`apps/controller/src/lib/openclaw-config-compiler.ts:34-49` — `isDesktopCloudConfig` type-guard expects `models: Array<{ id: string; name: string; provider?: string }>`. Only type checks, no format validation.
+
+Line 149-159: cloud models compiled straight into `providers.link.models` via `buildModelEntry(model.id, model.name)` — raw id preserved, no remapping.
+
+Config-store side: `apps/controller/src/store/nexu-config-store.ts:211, 2093`.
+
+## 7. Web UI consumption
+
+`apps/web/src/pages/models.tsx:312-316` — `getModelDisplayLabel(modelId)` strips the provider prefix for display only.
+
+`models.tsx:318-331` — `isModelSelected(a, b)` matches by display label + namespace-presence parity, so `"gpt-4o"` and `"openai/gpt-4o"` treated as the same selection.
+
+`models.tsx:333-346` — `normalizeByokModelSelectionKey(providerKey, modelId)` lowercases + prefixes for BYOK matching.
+
+`models.tsx:359-372` — `getProviderIdFromModelId(models, modelId)` looks up provider by id or parses from `provider/id` syntax; returns null for bare ids with no match.
+
+Drop-down at line 2424: `isSelected = isModelSelected(model.id, currentModelId)`.
+
+## 8. Tests
+
+`apps/controller/tests/model-provider-registry.test.ts:100-112` — composite custom-provider keys. Format `template/instance`; bundled provider ids rejected as custom.
+
+## Collisions & ambiguities
+
+1. **Provider-scoped uniqueness.** `"gpt-4o"` can exist under OpenAI and under a custom OpenAI-compat BYOK simultaneously. Uniqueness is achieved only by the runtime prefix — nothing prevents an ingestion path from claiming an id owned by another provider.
+2. **Same id with / without namespace.** Users can store `"gpt-4o"` or `"openai/gpt-4o"`; `isModelSelected` treats them as equivalent at UI level.
+3. **Provider alias fuzziness.** `"gemini"`, `"Gemini"`, `"google"` all route to Google via alias resolution. Stored form is `"google/gemini-3-flash-preview"` after normalization.
+
+## Sanitization gaps
+
+1. **Cloud inventory:** no format validation on `id` — any string passes. No duplicate detection across entries. No collision check against bundled providers.
+2. **Bot / runtime assignment:** `botResponseSchema.modelId: z.string()` has no constraints. Normalized at load-time, but invalid ids (e.g. referencing a deleted provider) may persist.
+3. **Case handling:** provider keys are case-insensitive; model ids are case-sensitive inside a provider. UI lowercases for BYOK matching but stored ids retain original case — potential ingestion mismatch.
+
+## Open design questions
+
+1. **Should model id be globally unique or provider-scoped?** Currently provider-scoped; every consumer needs the provider context. Risk: silent collisions between custom and bundled providers resolved by precedence order.
+2. **Source of truth for id strings.** No canonical store — each layer copies from the one above (external API → cloud → config → compiled). If cloud API renames a model, persisted bot configs don't auto-update.
+3. **Should the id format be validated?** Current constraint is `.min(1)` only. A regex like `/^[a-zA-Z0-9._-]+$/` would reject whitespace and special characters at ingestion; worth considering for BYOK user-submitted ids especially.
+
+## Key file map
+
+| File | Role |
+|---|---|
+| `packages/shared/src/schemas/model-provider-config.ts` | Raw entry shape + `.min(1)` constraint |
+| `packages/shared/src/schemas/bot.ts` | Bot `modelId` field (no constraint) |
+| `apps/controller/src/store/schemas.ts` | Persisted-config normalization + defaultModelId |
+| `apps/controller/src/lib/openclaw-config-compiler.ts` | `buildModelEntry`, `resolveModelId`, OAuth remap, cloud ingestion |
+| `apps/controller/src/lib/model-provider-runtime.ts` | Prefix strip + runtime id/ref construction |
+| `apps/controller/src/store/nexu-config-store.ts` | Cloud inventory storage shape |
+| `apps/web/src/pages/models.tsx` | Display / selection / BYOK normalization |

--- a/specs/design-docs/2026-04-14-openclaw-registry-cache-invalidation.md
+++ b/specs/design-docs/2026-04-14-openclaw-registry-cache-invalidation.md
@@ -1,0 +1,83 @@
+# OpenClaw Provider Registry Cache Invalidation
+
+Date: 2026-04-14
+Status: Shipped — PR #1094 (`fix(controller): restart OpenClaw on every provider/cloud change`)
+
+## TL;DR
+
+OpenClaw builds its provider/model registry **once at process boot** and does not re-read it when `openclaw.json` changes on disk. Every code path that mutates `models.providers` — cloud login/logout, BYOK add/delete/bulk-update, OAuth connect — must explicitly restart OpenClaw. In packaged desktop mode (where OpenClaw is supervised by launchd) the controller restart must go through `launchctl kickstart -k gui/<uid>/<label>`; `openclawProcess.stop()/start()` is a no-op because `env.manageOpenclawProcess === false`.
+
+## Reported symptoms
+
+1. **After Nexu cloud logout:** bot kept replying with `link/gemini-3.1-flash-lite-preview` even though `openclaw.json` on disk had `providers: []`.
+2. **After Nexu cloud re-login:** bot errored with `FailoverError: Unknown model: link/gemini-3-flash-preview` despite `providers.link.models` clearly containing that id.
+3. **After deleting BYOK providers:** bot errored with `No API key found for provider "openai-codex"` — the deleted provider's name — because OpenClaw's in-memory auth lookup still referenced it.
+
+All three are the same class of bug: OpenClaw's registry and the on-disk config diverged.
+
+## Root cause
+
+Provider-level changes are not hot-reload-safe inside OpenClaw:
+
+- `openclaw.json` is watched for skills, prompts, and some runtime state — but the `models.providers` block is consumed into an internal model registry at boot time only.
+- Nexu compiles a fresh `openclaw.json` on every `syncAll()`, so disk state is always current.
+- But absent a gateway restart, OpenClaw keeps whatever registry it built at boot.
+- In packaged desktop the controller does not own the OpenClaw child process — launchd does. `openclawProcess.stop()/start()` early-returns when `env.manageOpenclawProcess === false` (`apps/controller/src/runtime/openclaw-process.ts:76-78, 117`). So the existing `container.ts` restart code was silently a no-op in packaged mode.
+- Only the WhatsApp lifecycle path (`channel-service.ts:1586`) had already worked out the correct launchd pattern (`launchctl kickstart -k`). Nothing else used it.
+
+## Fix
+
+Three load-bearing changes:
+
+| File | Change |
+|---|---|
+| `apps/controller/src/runtime/openclaw-process.ts` | New `restart(reason)` method handling both dev (`stop` + `start`) and launchd (`launchctl kickstart -k gui/<uid>/<label>`) modes |
+| `apps/controller/src/app/container.ts` | `onCloudStateChanged` now always runs `ensureValidDefaultModel()` + `syncAll()` + `openclawProcess.restart("cloud_state_changed")` on every login/logout |
+| `apps/controller/src/services/model-provider-service.ts` | `restartRuntime()` uses the new `restart()`; called from `setModelProviderConfigDocument`, `refreshNexuOfficialModels`, `deleteProvider`, MiniMax OAuth completion |
+
+Supporting fixes surfaced during the investigation (independently real bugs):
+
+- **`openclaw-config-compiler.ts` + `packages/shared/src/schemas/openclaw-config.ts`** — stop emitting `apiKey: ""` for OAuth providers (schema `apiKey` now `.optional()`). OpenClaw's normalizer rejected the entire `models.providers` block on `""`, which took `link` down with any OAuth entry.
+- **`openclaw-auth-profiles-writer.ts`** — merge primary + fallback credentials (primary wins) instead of either-or, so Link auth survives when other providers coexist.
+- **`nexu-config-store.ts`** — `disconnectDesktopCloud` clears managed default only if it was cloud-backed, preserving BYOK defaults.
+- **`openclaw-sync-service.ts`** — strip `agents.defaults.model` + per-agent `model` when no providers exist; write locale-aware no-model guidance via `resolveNoModelConfiguredMessage(locale)`.
+- **`openclaw-runtime-model-writer.ts`** — adds `writeNoModelState()`, `clear()`, bilingual (EN / zh-CN) no-model message helper.
+- **`nexu-runtime-model/index.js`** — plugin no-ops cleanly when `selectedModelRef` is empty.
+
+## Validated end-to-end (packaged desktop)
+
+Observed `openclaw_restart_launchd_kickstarted domain=gui/501/io.nexu.openclaw` for each of:
+
+| Transition | Restart reason |
+|---|---|
+| Cloud login | `cloud_state_changed` |
+| Cloud logout | `cloud_state_changed` |
+| BYOK add | `model_provider_config_changed` |
+| BYOK delete | `model_provider_config_changed` |
+
+Zero `Unknown model: link/*` errors across the full cycle. `openclaw.json` providers always matched the UI state post-transition.
+
+## Known remaining gap (out of scope)
+
+When **no** provider is configured, OpenClaw's hardcoded alias fallback (`anthropic/claude-opus-4-6`, defined in `openclaw/src/config/defaults.ts:21-34`) wins, so the user sees `No API key found for provider "anthropic"` instead of Nexu's bilingual `noModelMessage`. The message is written to `nexu-runtime-model.json` but no consumer on the Slack path reads it today. This is Layer 3 work: either a new OpenClaw plugin hook upstream, or a Nexu-side sentinel-override + channel-service rewrite. Does **not** modify OpenClaw source (hard rule).
+
+## Retrospective: debugging bottleneck
+
+Two traps consumed the most time:
+
+1. **Treating the bug as a data-flow problem instead of a control-plane problem.** Early work focused on making `openclaw.json` correct on disk — which produced several real adjacent bugfixes (apiKey, auth-profiles merge, managed-default clearing) but never addressed the actual cause. OpenClaw's memory was ignored. Until the gateway is bounced, disk correctness is cosmetic.
+
+2. **Dev-mode success masked the packaged-mode failure.** The existing `container.ts:stop() + start()` worked in `pnpm dev` and read as if the restart path was handled. In packaged desktop those calls are no-ops because OpenClaw runs under launchd, not as a controller child. The bug only reproduces in packaged mode, so every dev-mode smoke test gave false confidence.
+
+**What would have short-circuited this:**
+
+- **Compare memory vs. disk, not just disk.** The decisive evidence was `cat openclaw.json | grep link` (present ✅) + `openclaw.error.log` saying `Unknown model: link/...` simultaneously. Once we had that, the only viable hypothesis was "registry is stale."
+- **Always smoke-test in packaged mode for anything touching `openclawProcess`.** Dev-mode tests won't catch the launchd-vs-child divergence.
+- **Ratio of load-bearing to adjacent work on branch 1 was roughly 3:5:5** (fix : real-but-adjacent : cleanup). The carved-out branch 2 (#1094) shipped the combination that coherently explains itself.
+
+## Related
+
+- Branch (shipped): `fix/openclaw-restart-on-cloud-state-change`
+- Parent branch (multi-commit accumulation): `fix/clear-model-on-provider-logout`
+- OAuth-apiKey-empty root-cause detail: `/Users/alche/.claude/projects/-Users-alche-Documents-digit-sutando-nexu/memory/2026-04-14-oauth-apikey-empty-link-rejection.md`
+- Pre-existing WhatsApp launchd pattern: `apps/controller/src/services/channel-service.ts:1586`

--- a/tests/desktop/nexu-runtime-model-plugin.test.ts
+++ b/tests/desktop/nexu-runtime-model-plugin.test.ts
@@ -13,13 +13,15 @@ const stateModulePath = path.resolve(
   "../../apps/controller/static/nexu-runtime-model.json",
 );
 
-async function writeState(selectedModelRef: string) {
+async function writeState(selectedModelRef: string, promptNotice?: string) {
   await writeFile(
     stateModulePath,
     `${JSON.stringify(
       {
         selectedModelRef,
-        promptNotice: `Authoritative runtime model for this turn: ${selectedModelRef}.`,
+        promptNotice:
+          promptNotice ??
+          `Authoritative runtime model for this turn: ${selectedModelRef}.`,
       },
       null,
       2,
@@ -83,5 +85,32 @@ describe("nexu-runtime-model plugin", () => {
       providerOverride: "byok_openai",
       modelOverride: "openai/gpt-4.1",
     });
+  });
+
+  it("ignores empty runtime-model state", async () => {
+    const { default: plugin } = await import(
+      `${pluginModulePath}?t=${Date.now()}`
+    );
+
+    await writeState("", "");
+    let beforeModelResolveHandler:
+      | (() => Promise<Record<string, string> | undefined>)
+      | undefined;
+    let beforePromptBuildHandler:
+      | (() => Promise<Record<string, string> | undefined>)
+      | undefined;
+    plugin.register({
+      on(event, handler) {
+        if (event === "before_model_resolve") {
+          beforeModelResolveHandler = handler;
+        }
+        if (event === "before_prompt_build") {
+          beforePromptBuildHandler = handler;
+        }
+      },
+    });
+
+    await expect(beforeModelResolveHandler?.()).resolves.toBeUndefined();
+    await expect(beforePromptBuildHandler?.()).resolves.toBeUndefined();
   });
 });

--- a/tests/desktop/openclaw-auth-profiles-writer.test.ts
+++ b/tests/desktop/openclaw-auth-profiles-writer.test.ts
@@ -291,4 +291,90 @@ describe("OpenClawAuthProfilesWriter", () => {
       expires: 1_900_000_000_000,
     });
   });
+
+  it("merges compiled link credentials even when provider-source entries already exist", async () => {
+    const env = createEnv(tempDir);
+    const writer = new OpenClawAuthProfilesWriter(
+      new OpenClawAuthProfilesStore(env),
+    );
+
+    await writer.writeForAgents(
+      {
+        agents: {
+          list: [
+            {
+              id: "bot_1",
+              name: "Bot One",
+              workspace: resolve(env.openclawStateDir, "agents", "bot_1"),
+            },
+          ],
+        },
+        models: {
+          mode: "merge",
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              apiKey: "openai-key",
+              api: "openai-responses",
+              models: [{ id: "gpt-5.4", name: "gpt-5.4" }],
+            },
+            link: {
+              baseUrl: "https://link.nexu.io/v1",
+              apiKey: "link-key",
+              api: "openai-completions",
+              models: [{ id: "gemini-2.5-flash", name: "gemini-2.5-flash" }],
+            },
+          },
+        },
+      } as never,
+      {
+        openai: {
+          enabled: true,
+          auth: "api-key",
+          api: "openai-responses",
+          apiKey: "openai-key",
+          baseUrl: "https://api.openai.com/v1",
+          models: [
+            {
+              id: "gpt-5.4",
+              name: "gpt-5.4",
+              reasoning: false,
+              input: ["text"],
+              cost: {
+                input: 0,
+                output: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+              },
+              contextWindow: 0,
+              maxTokens: 0,
+            },
+          ],
+        },
+      },
+    );
+
+    const authProfilesPath = resolve(
+      env.openclawStateDir,
+      "agents",
+      "bot_1",
+      "agent",
+      "auth-profiles.json",
+    );
+    const parsed = JSON.parse(readFileSync(authProfilesPath, "utf8")) as {
+      version: number;
+      profiles: Record<string, { type: string; provider: string; key: string }>;
+    };
+
+    expect(parsed.profiles["openai:default"]).toEqual({
+      type: "api_key",
+      provider: "openai",
+      key: "openai-key",
+    });
+    expect(parsed.profiles["link:default"]).toEqual({
+      type: "api_key",
+      provider: "link",
+      key: "link-key",
+    });
+  });
 });


### PR DESCRIPTION
## What

Restart the OpenClaw gateway whenever the user logs into / out of Nexu cloud, or mutates BYOK / OAuth providers — so OpenClaw's in-memory provider registry no longer goes stale.

## Why

OpenClaw builds its provider/model registry **once at process boot** — provider-level changes to `openclaw.json` are not hot-reload-safe. The existing code only restarted OpenClaw on first cloud-login, and even that path was a no-op in packaged desktop (where OpenClaw runs under launchd) because `openclawProcess.stop()/start()` early-returns when `env.manageOpenclawProcess === false`.

Visible symptoms before the fix:

- **After Link logout:** bot kept replying using the cached Link provider (`link/gemini-3.1-flash-lite-preview`) even though `openclaw.json` on disk had `providers: []`.
- **After Link re-login:** bot errored with `FailoverError: Unknown model: link/gemini-3-flash-preview` despite the model clearly being present in the freshly-written `providers.link.models`.
- **After deleting BYOK providers:** bot errored with stale `No API key found for provider "openai-codex"` because the deleted provider was still in OpenClaw's memory.

All three are the same class of bug — OpenClaw's registry and `openclaw.json` on disk diverging whenever providers change.

## How

1. **New `OpenClawProcessManager.restart(reason)`** (`apps/controller/src/runtime/openclaw-process.ts`) that handles both supervision modes:
   - Dev-managed: the existing `stop()` + `enableAutoRestart()` + `start()` path
   - Packaged / launchd-managed: `launchctl kickstart -k gui/<uid>/<label>` — same pattern already used by `channel-service.ts` for the WhatsApp lifecycle
2. **`container.ts`** — `onCloudStateChanged` now always runs `ensureValidDefaultModel()` + `syncAll()` + `openclawProcess.restart(\"cloud_state_changed\")` on every transition (login **and** logout), so BYOK auto-fallback kicks in on logout and Link is truly evicted.
3. **`model-provider-service.ts`** — `restartRuntime()` switched to the new `restart()` so it works in packaged mode; called from `setModelProviderConfigDocument`, `refreshNexuOfficialModels`, `deleteProvider`, and the existing MiniMax OAuth completion path. Every BYOK/OAuth mutation now bounces the gateway.

### Supporting fixes the investigation surfaced

- **`openclaw-config-compiler.ts` + `packages/shared/src/schemas/openclaw-config.ts`** — stop emitting `apiKey: \"\"` for OAuth providers (kept secret-ref objects intact); provider `apiKey` is now optional at the shared schema level. Prevents OpenClaw's normalizer from rejecting the entire `models.providers` block and taking `link` down with it.
- **`openclaw-auth-profiles-writer.ts`** — merge primary + fallback credential entries (primary wins on collision) instead of either-or. Ensures Link auth stays written when other providers coexist.
- **`nexu-config-store.ts`** — `disconnectDesktopCloud` now clears the default model only when it was actually cloud-backed, preserving user-selected BYOK defaults.
- **`openclaw-sync-service.ts`** — when no providers exist, strip `agents.defaults.model` and per-agent `model`; write locale-aware no-model state via new helper.
- **`openclaw-runtime-model-writer.ts`** — adds `writeNoModelState()`, `clear()`, and `resolveNoModelConfiguredMessage(locale)` returning EN / zh-CN guidance text. (Delivery to Slack is still Layer 3; the text is on-disk for the compat path and for the future plugin hook.)
- **`nexu-runtime-model/index.js`** — plugin no-ops cleanly when `selectedModelRef` is empty instead of trying to parse it.

### Smoke-tested end-to-end in packaged desktop

Observed `openclaw_restart_launchd_kickstarted domain=gui/501/io.nexu.openclaw` for each of:

| Transition | Restart reason |
|---|---|
| Cloud login | \`cloud_state_changed\` |
| Cloud logout | \`cloud_state_changed\` |
| BYOK add | \`model_provider_config_changed\` |
| BYOK delete | \`model_provider_config_changed\` |

No \`Unknown model: link/*\` errors in \`openclaw.error.log\` across the full cycle. \`openclaw.json\` providers always matched the UI state post-transition.

## Affected areas

- [ ] Desktop app (Electron shell)
- [x] Controller (backend / API)
- [ ] Web dashboard (React UI)
- [x] OpenClaw runtime
- [ ] Skills
- [x] Shared schemas / packages
- [ ] Build / CI / Tooling

## Checklist

- [x] \`pnpm typecheck\` passes
- [x] \`pnpm lint\` passes (Biome ran as pre-commit hook)
- [x] \`pnpm test\` passes (failing tests match main baseline — pre-existing, unrelated)
- [ ] \`pnpm generate-types\` run (if API routes/schemas changed) — N/A, no API route changes
- [x] No credentials or tokens in code or logs
- [x] No \`any\` types introduced

## Notes for reviewers

- The launchd kickstart path mirrors the existing \`channel-service.ts:1586\` WhatsApp lifecycle pattern — worth reviewing that the \`env.openclawLaunchdLabel\` fallback to \`openclaw_restart_skipped_no_supervisor\` is acceptable for local-dev-without-launchd edge cases.
- \`noModelMessage\` (EN + zh-CN) is written to \`nexu-runtime-model.json\` but not yet delivered as an agent reply for Slack — OpenClaw's hardcoded alias fallback (\`anthropic/claude-opus-4-6\`) still wins on the zero-provider path, surfacing as \`No API key found for provider \"anthropic\"\`. Making OpenClaw defer to our message is a separate follow-up (either a new OpenClaw plugin hook upstream, or a Nexu-side sentinel-override + channel-service rewrite).
- Cross-provider session history bug (\`Invalid 'input[N].call_id': string too long\`) is independent and out of scope — it's OpenClaw-side.