### PR TITLE
fix: route dingtalk through gateway and infer session metadata

### DIFF
--- a/apps/controller/src/lib/channel-binding-compiler.ts
+++ b/apps/controller/src/lib/channel-binding-compiler.ts
@@ -89,7 +89,8 @@ export function compileChannelBindings(
 export function compileChannelsConfig(params: {
   channels: ChannelResponse[];
   secrets: Record<string, string>;
-  controllerBaseUrl: string;
+  gatewayBaseUrl: string;
+  gatewayToken?: string;
 }): OpenClawConfig["channels"] {
   const slackAccounts: Record<string, SlackAccountConfig> = {};
   const discordAccounts: Record<string, DiscordAccountConfig> = {};
@@ -180,8 +181,8 @@ export function compileChannelsConfig(params: {
         enabled: true,
         clientId: secret("clientId") || channel.appId || "",
         clientSecret: secret("clientSecret"),
-        enableMediaUpload: false,
-        gatewayBaseUrl: params.controllerBaseUrl,
+        gatewayBaseUrl: params.gatewayBaseUrl,
+        ...(params.gatewayToken ? { gatewayToken: params.gatewayToken } : {}),
         dmPolicy: "open",
         allowFrom: ["*"],
         groupPolicy: "open",

--- a/apps/controller/src/lib/openclaw-config-compiler.ts
+++ b/apps/controller/src/lib/openclaw-config-compiler.ts
@@ -410,6 +410,13 @@ export function compileOpenClawConfig(
         allowedOrigins: [env.webUrl],
         dangerouslyAllowHostHeaderOriginFallback: true,
       },
+      http: {
+        endpoints: {
+          chatCompletions: {
+            enabled: true,
+          },
+        },
+      },
       tools: {
         allow: ["cron"],
       },
@@ -502,7 +509,8 @@ export function compileOpenClawConfig(
     channels: compileChannelsConfig({
       channels: config.channels,
       secrets: config.secrets,
-      controllerBaseUrl: `http://127.0.0.1:${env.port}`,
+      gatewayBaseUrl: `http://127.0.0.1:${env.openclawGatewayPort}`,
+      gatewayToken: env.openclawGatewayToken,
     }),
     bindings: compileChannelBindings(config.bots, config.channels),
     plugins: compilePlugins(config, env),

--- a/apps/controller/src/runtime/sessions-runtime.ts
+++ b/apps/controller/src/runtime/sessions-runtime.ts
@@ -70,6 +70,15 @@ type SessionsIndexEntry = {
     label?: string;
   };
 };
+type OpenAiUserSessionContext = {
+  channel?: string;
+  accountid?: string;
+  chattype?: string;
+  peerid?: string;
+  conversationid?: string;
+  sendername?: string;
+  groupsubject?: string;
+};
 type ControllerConfigRecord = {
   channels?: Array<{
     id?: string;
@@ -940,7 +949,7 @@ export class SessionsRuntime {
     filePath: string,
     sessionKey: string,
   ): SessionHints {
-    const entry = Object.values(index).find((item) => {
+    const matched = Object.entries(index).find(([, item]) => {
       if (item.sessionId === sessionKey) {
         return true;
       }
@@ -950,18 +959,53 @@ export class SessionsRuntime {
       return false;
     });
 
-    if (!entry) {
+    if (!matched) {
       return {};
     }
 
-    const rawChannel = entry.lastChannel ?? entry.origin?.provider ?? undefined;
-    const channelType = this.normalizeInferredChannelType(rawChannel);
-    const senderName = entry.origin?.label;
+    const [indexKey, entry] = matched;
+    const openAiUserContext = this.parseOpenAiUserSessionContext(indexKey);
+    const rawChannel =
+      openAiUserContext?.channel ??
+      entry.lastChannel ??
+      entry.origin?.provider ??
+      undefined;
+    const normalizedChannel = this.normalizeInferredChannelType(rawChannel);
+    const channelType =
+      normalizedChannel === "dingtalk-connector"
+        ? "dingtalk"
+        : normalizedChannel;
+    const senderName =
+      openAiUserContext?.sendername ?? entry.origin?.label ?? undefined;
+    const groupName = openAiUserContext?.groupsubject ?? undefined;
 
     return {
       senderName,
+      groupName,
       channelType,
     };
+  }
+
+  private parseOpenAiUserSessionContext(
+    indexKey: string,
+  ): OpenAiUserSessionContext | null {
+    const marker = ":openai-user:";
+    const markerIndex = indexKey.indexOf(marker);
+    if (markerIndex === -1) {
+      return null;
+    }
+
+    const rawContext = indexKey.slice(markerIndex + marker.length).trim();
+    if (!rawContext.startsWith("{")) {
+      return null;
+    }
+
+    try {
+      const parsed = JSON.parse(rawContext) as OpenAiUserSessionContext;
+      return typeof parsed === "object" && parsed !== null ? parsed : null;
+    } catch {
+      return null;
+    }
   }
 
   private async readSessionMetadata(
@@ -1193,6 +1237,9 @@ export class SessionsRuntime {
     const normalized = channelType.trim().toLowerCase();
     if (normalized === "wechat") {
       return "openclaw-weixin";
+    }
+    if (normalized === "dingtalk-connector") {
+      return "dingtalk";
     }
 
     return normalized || undefined;

--- a/apps/controller/tests/openclaw-config-compiler.test.ts
+++ b/apps/controller/tests/openclaw-config-compiler.test.ts
@@ -370,9 +370,18 @@ describe("compileOpenClawConfig", () => {
       enabled: true,
       clientId: "ding-client-id",
       clientSecret: "ding-client-secret",
+      gatewayBaseUrl: "http://127.0.0.1:18789",
+      gatewayToken: "token-123",
       dmPolicy: "open",
       groupPolicy: "open",
     });
+    expect(
+      (
+        result.gateway as {
+          http?: { endpoints?: { chatCompletions?: { enabled?: boolean } } };
+        }
+      ).http?.endpoints?.chatCompletions?.enabled,
+    ).toBe(true);
     expect(result.bindings).toContainEqual({
       agentId: "bot-1",
       match: {

--- a/apps/controller/tests/sessions-runtime.test.ts
+++ b/apps/controller/tests/sessions-runtime.test.ts
@@ -425,6 +425,67 @@ describe("SessionsRuntime", () => {
     expect(session?.title).toBe("WeChat ClawBot");
   });
 
+  it("infers dingtalk channel and sender name from the sessions index openai-user context", async () => {
+    rootDir = await mkdtemp(path.join(tmpdir(), "nexu-sessions-runtime-"));
+    const runtime = new SessionsRuntime(
+      createEnv({
+        openclawStateDir: rootDir,
+        openclawConfigPath: path.join(rootDir, "openclaw.json"),
+        openclawSkillsDir: path.join(rootDir, "skills"),
+        openclawWorkspaceTemplatesDir: path.join(
+          rootDir,
+          "workspace-templates",
+        ),
+      }),
+    );
+
+    const sessionsDir = path.join(rootDir, "agents", "main", "sessions");
+    await mkdir(sessionsDir, { recursive: true });
+    const sessionKey = "2c3d5c06-2b91-4dd1-a8d2-b4e707645ff8";
+    const sessionPath = path.join(sessionsDir, `${sessionKey}.jsonl`);
+
+    await writeFile(
+      sessionPath,
+      `${JSON.stringify({
+        type: "message",
+        id: "msg-dingtalk-1",
+        timestamp: "2026-04-14T10:00:10.543Z",
+        message: {
+          role: "user",
+          timestamp: 1776160810538,
+          content: [{ type: "text", text: "你好" }],
+        },
+      })}\n`,
+      "utf8",
+    );
+    await writeFile(
+      sessionPath.replace(/\.jsonl$/, ".meta.json"),
+      `${JSON.stringify({ title: sessionKey }, null, 2)}\n`,
+      "utf8",
+    );
+    await writeFile(
+      path.join(sessionsDir, "sessions.json"),
+      `${JSON.stringify(
+        {
+          'agent:main:openai-user:{"channel":"dingtalk-connector","accountid":"__default__","chattype":"direct","peerid":"dingtalk-user-123","sendername":"Test User"}':
+            {
+              sessionId: sessionKey,
+              updatedAt: 1776161129268,
+            },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    const sessions = await runtime.listSessions();
+    const session = sessions.find((item) => item.sessionKey === sessionKey);
+
+    expect(session?.channelType).toBe("dingtalk");
+    expect(session?.title).toBe("Test User · dingtalk");
+  });
+
   it("uses the WeChat ClawBot fallback even when an opaque @im.wechat sender id is present", async () => {
     // The iLink wechat protocol does not expose nicknames; inbound messages
     // only carry an opaque `<id>@im.wechat` sender id. Don't leak the raw


### PR DESCRIPTION
## What

Route DingTalk through the OpenClaw Gateway and restore DingTalk session metadata/title inference for native OpenClaw sessions.

## Why

After switching DingTalk to the official Gateway path, new DingTalk conversations were stored as native OpenClaw sessions. Nexu's session parser did not infer `dingtalk` from those session index entries, so the UI fell back to `Web`, showed no DingTalk icon, and displayed raw UUID titles.

## How

- point the compiled `dingtalk-connector` config at the OpenClaw Gateway instead of the controller compat endpoint
- enable the Gateway `chatCompletions` HTTP endpoint in the compiled OpenClaw config
- stop forcing `enableMediaUpload: false` so the connector can use its own defaults
- parse `openai-user` session index context in `SessionsRuntime` to infer `dingtalk`, sender name, and better titles for native DingTalk sessions
- add/update controller tests for the Gateway routing and DingTalk session inference path

## Affected areas

- [ ] Desktop app (Electron shell)
- [x] Controller (backend / API)
- [ ] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [ ] Build / CI / Tooling

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes
- [ ] `pnpm generate-types` run (if API routes/schemas changed)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced (use `unknown` with narrowing)

## Notes for reviewers

`pnpm test` is not green on the current branch baseline. I verified the touched session-runtime regression path locally, and `typecheck`/`lint` pass. This PR does not change API schemas or generated types.
