### PR TITLE
fix(skillhub): make Windows skill install work and surface failures (#920)

### DIFF
--- a/apps/controller/openapi.json
+++ b/apps/controller/openapi.json
@@ -10833,6 +10833,16 @@
                     },
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string",
+                      "enum": [
+                        "skill_not_found",
+                        "rate_limit",
+                        "npm_missing",
+                        "deps_install_failed",
+                        "unknown"
+                      ]
                     }
                   },
                   "required": [
@@ -10843,25 +10853,34 @@
             }
           },
           "400": {
-            "description": "Bad request",
+            "description": "Import rejected or failed",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "properties": {
                     "ok": {
-                      "type": "boolean",
-                      "enum": [
-                        false
-                      ]
+                      "type": "boolean"
+                    },
+                    "slug": {
+                      "type": "string"
                     },
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string",
+                      "enum": [
+                        "skill_not_found",
+                        "rate_limit",
+                        "npm_missing",
+                        "deps_install_failed",
+                        "unknown"
+                      ]
                     }
                   },
                   "required": [
-                    "ok",
-                    "error"
+                    "ok"
                   ]
                 }
               }

--- a/apps/controller/openapi.json
+++ b/apps/controller/openapi.json
@@ -10389,6 +10389,8 @@
                             "enum": [
                               "skill_not_found",
                               "rate_limit",
+                              "npm_missing",
+                              "deps_install_failed",
                               "unknown"
                             ]
                           },

--- a/apps/controller/scripts/generate-openapi.ts
+++ b/apps/controller/scripts/generate-openapi.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { fileURLToPath } from "node:url";
 import { createContainer } from "../src/app/container.js";
 import { createApp } from "../src/app/create-app.js";
 
@@ -9,6 +10,6 @@ const spec = app.getOpenAPIDocument({
   info: { title: "nexu Controller API", version: "1.0.0" },
 });
 
-const outputPath = new URL("../openapi.json", import.meta.url).pathname;
+const outputPath = fileURLToPath(new URL("../openapi.json", import.meta.url));
 fs.writeFileSync(outputPath, JSON.stringify(spec, null, 2));
 console.log(`OpenAPI spec written to ${outputPath}`);

--- a/apps/controller/src/routes/skillhub-routes.ts
+++ b/apps/controller/src/routes/skillhub-routes.ts
@@ -123,6 +123,15 @@ const skillhubImportResultSchema = z.object({
   ok: z.boolean(),
   slug: z.string().optional(),
   error: z.string().optional(),
+  errorCode: z
+    .enum([
+      "skill_not_found",
+      "rate_limit",
+      "npm_missing",
+      "deps_install_failed",
+      "unknown",
+    ])
+    .optional(),
 });
 
 export function registerSkillhubRoutes(
@@ -424,14 +433,9 @@ export function registerSkillhubRoutes(
         },
         400: {
           content: {
-            "application/json": {
-              schema: z.object({
-                ok: z.literal(false),
-                error: z.string(),
-              }),
-            },
+            "application/json": { schema: skillhubImportResultSchema },
           },
-          description: "Bad request",
+          description: "Import rejected or failed",
         },
       },
     }),
@@ -466,10 +470,14 @@ export function registerSkillhubRoutes(
       const result =
         await container.skillhubService.catalog.importSkillZip(buffer);
 
-      if (result.ok) {
-        await container.openclawSyncService.syncAll();
+      if (!result.ok) {
+        // Dependency-install failures, path-safety violations, etc.
+        // Structured payload (error + errorCode) lets the UI render
+        // retryable vs unrecoverable states without a generic 500.
+        return c.json(result, 400);
       }
 
+      await container.openclawSyncService.syncAll();
       return c.json(result, 200);
     },
   );

--- a/apps/controller/src/routes/skillhub-routes.ts
+++ b/apps/controller/src/routes/skillhub-routes.ts
@@ -43,7 +43,15 @@ const queueItemSchema = z.object({
   ]),
   position: z.number(),
   error: z.string().nullable(),
-  errorCode: z.enum(["skill_not_found", "rate_limit", "unknown"]).nullable(),
+  errorCode: z
+    .enum([
+      "skill_not_found",
+      "rate_limit",
+      "npm_missing",
+      "deps_install_failed",
+      "unknown",
+    ])
+    .nullable(),
   retries: z.number(),
   enqueuedAt: z.string(),
 });

--- a/apps/controller/src/services/skillhub/catalog-manager.ts
+++ b/apps/controller/src/services/skillhub/catalog-manager.ts
@@ -18,6 +18,7 @@ import {
   copyStaticSkills,
   resolveCuratedSkillsToInstall,
 } from "./curated-skills.js";
+import { ensureNpmAvailable, runNpmInstall } from "./npm-runner.js";
 import type { SkillDb, SkillRecord } from "./skill-db.js";
 import type {
   CatalogMeta,
@@ -678,14 +679,16 @@ export class CatalogManager {
   ): Promise<void> {
     if (!existsSync(resolve(skillDir, "package.json"))) return;
 
+    await ensureNpmAvailable();
+
     this.log("info", `installing npm deps: ${slug}`);
     try {
-      const npmArgs = ["install", "--production", "--no-audit", "--no-fund"];
-      await execFileAsync("npm", npmArgs, { cwd: skillDir });
+      await runNpmInstall(skillDir);
       this.log("info", `npm deps installed: ${slug}`);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      this.log("warn", `npm deps failed for ${slug}: ${message}`);
+      this.log("error", `npm deps failed for ${slug}: ${message}`);
+      throw new Error(`DEPS_INSTALL_FAILED: ${slug}: ${message}`);
     }
   }
 

--- a/apps/controller/src/services/skillhub/catalog-manager.ts
+++ b/apps/controller/src/services/skillhub/catalog-manager.ts
@@ -18,12 +18,14 @@ import {
   copyStaticSkills,
   resolveCuratedSkillsToInstall,
 } from "./curated-skills.js";
+import { classifyError } from "./install-queue.js";
 import { ensureNpmAvailable, runNpmInstall } from "./npm-runner.js";
 import type { SkillDb, SkillRecord } from "./skill-db.js";
 import type {
   CatalogMeta,
   InstalledSkill,
   MinimalSkill,
+  QueueErrorCode,
   SkillSource,
   SkillhubCatalogData,
 } from "./types.js";
@@ -562,22 +564,50 @@ export class CatalogManager {
     return { installed, skipped: toSkip, failed };
   }
 
-  async importSkillZip(
-    zipBuffer: Buffer,
-  ): Promise<{ ok: boolean; slug?: string; error?: string }> {
+  async importSkillZip(zipBuffer: Buffer): Promise<{
+    ok: boolean;
+    slug?: string;
+    error?: string;
+    errorCode?: QueueErrorCode;
+  }> {
     this.log("info", "importing custom skill from zip");
     const result = extractZip(zipBuffer, this.skillsDir);
-    if (result.ok && result.slug) {
-      this.db.recordInstall(result.slug, "custom");
-      this.log("info", `custom skill imported: ${result.slug}`);
-      await this.installSkillDeps(
-        resolve(this.skillsDir, result.slug),
-        result.slug,
-      );
-    } else {
+    if (!result.ok || !result.slug) {
       this.log("error", `custom skill import failed: ${result.error}`);
+      return result;
     }
-    return result;
+
+    // Install dependencies BEFORE recording in DB. If deps fail, roll back
+    // the extracted files and return a typed errorCode without writing a
+    // ledger entry — keeping disk, DB, and runtime consistently in the
+    // "not installed" state so a Retry starts from a clean slate.
+    const slug = result.slug;
+    const skillDir = resolve(this.skillsDir, slug);
+    try {
+      await this.installSkillDeps(skillDir, slug);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const errorCode = classifyError(message);
+      try {
+        rmSync(skillDir, { recursive: true, force: true });
+      } catch (cleanupErr) {
+        const cleanupMsg =
+          cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr);
+        this.log(
+          "warn",
+          `custom skill cleanup failed slug=${slug}: ${cleanupMsg}`,
+        );
+      }
+      this.log(
+        "error",
+        `custom skill deps failed slug=${slug} code=${errorCode}: ${message}`,
+      );
+      return { ok: false, error: message, errorCode };
+    }
+
+    this.db.recordInstall(slug, "custom");
+    this.log("info", `custom skill imported: ${slug}`);
+    return { ok: true, slug };
   }
 
   /**

--- a/apps/controller/src/services/skillhub/install-queue.ts
+++ b/apps/controller/src/services/skillhub/install-queue.ts
@@ -323,7 +323,10 @@ export class InstallQueue {
             item.errorCode = code;
             this.active.delete(item.slug);
             this.completed.push(item);
-            this.scheduleCleanup(item);
+            // Failed items are retained so the UI can render a failed card
+            // with a Retry affordance. Eviction happens only when the user
+            // explicitly retries (re-enqueue clears the prior failed entry)
+            // or cancels (cancel() evicts).
             this.drain();
             return;
           }
@@ -334,14 +337,15 @@ export class InstallQueue {
           this.pending.unshift(item);
           this.pauseQueue(pauseMs);
         } else {
-          // Non-rate-limit error: fail immediately
+          // Non-rate-limit error: fail immediately. Retain the item so the
+          // UI shows a failed card with Retry; eviction happens on user
+          // retry (re-enqueue) or explicit cancel.
           item.status = "failed";
           item.errorCode = code;
           item.error = message;
           this.active.delete(item.slug);
           this.completed.push(item);
           this.log("error", `Install failed for ${item.slug}: ${message}`);
-          this.scheduleCleanup(item);
           this.drain();
         }
       },

--- a/apps/controller/src/services/skillhub/install-queue.ts
+++ b/apps/controller/src/services/skillhub/install-queue.ts
@@ -27,7 +27,7 @@ const DEPS_INSTALL_FAILED_PREFIX = /^DEPS_INSTALL_FAILED:/;
 const RETRY_IN_PATTERN = /retry in (\d+)s/i;
 const RESET_IN_PATTERN = /reset in (\d+)s/i;
 
-function classifyError(message: string): QueueErrorCode {
+export function classifyError(message: string): QueueErrorCode {
   if (RATE_LIMIT_PREFIX.test(message)) return "rate_limit";
   if (SKILL_NOT_FOUND_PREFIX.test(message)) return "skill_not_found";
   if (NPM_MISSING_PREFIX.test(message)) return "npm_missing";

--- a/apps/controller/src/services/skillhub/install-queue.ts
+++ b/apps/controller/src/services/skillhub/install-queue.ts
@@ -22,12 +22,16 @@ const MAX_PAUSE_MS = 60000;
 
 const RATE_LIMIT_PREFIX = /Rate limit exceeded/i;
 const SKILL_NOT_FOUND_PREFIX = /Skill not found/i;
+const NPM_MISSING_PREFIX = /^NPM_MISSING:/;
+const DEPS_INSTALL_FAILED_PREFIX = /^DEPS_INSTALL_FAILED:/;
 const RETRY_IN_PATTERN = /retry in (\d+)s/i;
 const RESET_IN_PATTERN = /reset in (\d+)s/i;
 
 function classifyError(message: string): QueueErrorCode {
   if (RATE_LIMIT_PREFIX.test(message)) return "rate_limit";
   if (SKILL_NOT_FOUND_PREFIX.test(message)) return "skill_not_found";
+  if (NPM_MISSING_PREFIX.test(message)) return "npm_missing";
+  if (DEPS_INSTALL_FAILED_PREFIX.test(message)) return "deps_install_failed";
   return "unknown";
 }
 

--- a/apps/controller/src/services/skillhub/npm-runner.ts
+++ b/apps/controller/src/services/skillhub/npm-runner.ts
@@ -1,0 +1,56 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const isWindows = process.platform === "win32";
+
+/**
+ * On Windows `npm` is a `.cmd` shim that cannot be launched directly with
+ * `execFile` since Node 18.20.2 / 20.12.2 (CVE-2024-27980). Using `shell: true`
+ * lets the OS resolve and execute the shim. Arguments here are controller-owned
+ * (no user input), so shell quoting is safe.
+ */
+export function npmSpawnOptions(cwd: string): {
+  cwd: string;
+  shell?: boolean;
+  windowsHide: boolean;
+} {
+  return isWindows
+    ? { cwd, shell: true, windowsHide: true }
+    : { cwd, windowsHide: true };
+}
+
+let availabilityProbe: Promise<boolean> | null = null;
+
+export function resetNpmAvailabilityCache(): void {
+  availabilityProbe = null;
+}
+
+export async function ensureNpmAvailable(): Promise<void> {
+  if (!availabilityProbe) {
+    availabilityProbe = (async () => {
+      try {
+        await execFileAsync("npm", ["--version"], {
+          shell: isWindows,
+          windowsHide: true,
+        });
+        return true;
+      } catch {
+        return false;
+      }
+    })();
+  }
+  const ok = await availabilityProbe;
+  if (!ok) {
+    availabilityProbe = null;
+    throw new Error(
+      "NPM_MISSING: npm is not available on this system. Please install Node.js (which includes npm) from https://nodejs.org/ and restart Nexu.",
+    );
+  }
+}
+
+export async function runNpmInstall(skillDir: string): Promise<void> {
+  const args = ["install", "--production", "--no-audit", "--no-fund"];
+  await execFileAsync("npm", args, npmSpawnOptions(skillDir));
+}

--- a/apps/controller/src/services/skillhub/types.ts
+++ b/apps/controller/src/services/skillhub/types.ts
@@ -40,7 +40,12 @@ export type QueueItemStatus =
   | "done"
   | "failed";
 
-export type QueueErrorCode = "skill_not_found" | "rate_limit" | "unknown";
+export type QueueErrorCode =
+  | "skill_not_found"
+  | "rate_limit"
+  | "npm_missing"
+  | "deps_install_failed"
+  | "unknown";
 
 export type QueueItem = {
   readonly slug: string;

--- a/apps/controller/src/services/skillhub/zip-importer.ts
+++ b/apps/controller/src/services/skillhub/zip-importer.ts
@@ -7,7 +7,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { basename, posix, resolve } from "node:path";
+import { basename, posix, resolve, sep } from "node:path";
 
 const SLUG_REGEX = /^[a-z0-9][a-z0-9-]{0,127}$/;
 const MAX_ZIP_SIZE = 50 * 1024 * 1024; // 50 MB
@@ -147,10 +147,12 @@ export function importSkillZip(
     }
     extractZipArchive(zipPath, stagingDir);
 
-    // Validate no files escaped staging dir (zip-slip defense)
-    const normalizedStaging = stagingDir.endsWith("/")
+    // Validate no files escaped staging dir (zip-slip defense).
+    // Use the platform separator so the prefix check works on Windows
+    // (resolve() returns backslash-separated paths there).
+    const normalizedStaging = stagingDir.endsWith(sep)
       ? stagingDir
-      : `${stagingDir}/`;
+      : stagingDir + sep;
     for (const entry of readdirSync(stagingDir, {
       withFileTypes: true,
       recursive: true,

--- a/apps/controller/src/services/skillhub/zip-importer.ts
+++ b/apps/controller/src/services/skillhub/zip-importer.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process";
 import {
+  cpSync,
   existsSync,
   mkdirSync,
   readdirSync,
@@ -10,6 +11,7 @@ import { basename, posix, resolve } from "node:path";
 
 const SLUG_REGEX = /^[a-z0-9][a-z0-9-]{0,127}$/;
 const MAX_ZIP_SIZE = 50 * 1024 * 1024; // 50 MB
+const isWindows = process.platform === "win32";
 
 export type ZipImportResult = {
   readonly ok: boolean;
@@ -58,14 +60,63 @@ function isUnsafeZipEntryPath(entryPath: string): boolean {
   return normalizedPath.length === 0;
 }
 
-function readZipEntries(zipPath: string): string[] {
-  const output = execFileSync("unzip", ["-Z1", zipPath], {
-    encoding: "utf8",
-  });
+function powershellLiteral(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+function listZipEntriesWindows(zipPath: string): string[] {
+  // Use .NET ZipFile API via PowerShell — available on every Windows since
+  // PowerShell 5.0 (Win 10+), no external dependencies required.
+  const script = [
+    "Add-Type -AssemblyName System.IO.Compression.FileSystem",
+    `$zip = [System.IO.Compression.ZipFile]::OpenRead(${powershellLiteral(zipPath)})`,
+    "try { $zip.Entries | ForEach-Object { $_.FullName } } finally { $zip.Dispose() }",
+  ].join("; ");
+  const output = execFileSync(
+    "powershell.exe",
+    ["-NoProfile", "-NonInteractive", "-Command", script],
+    { encoding: "utf8", windowsHide: true },
+  );
   return output
     .split(/\r?\n/u)
     .map((entry) => entry.trim())
     .filter((entry) => entry.length > 0);
+}
+
+function listZipEntriesPosix(zipPath: string): string[] {
+  const output = execFileSync("unzip", ["-Z1", zipPath], { encoding: "utf8" });
+  return output
+    .split(/\r?\n/u)
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+function readZipEntries(zipPath: string): string[] {
+  return isWindows
+    ? listZipEntriesWindows(zipPath)
+    : listZipEntriesPosix(zipPath);
+}
+
+function extractZipWindows(zipPath: string, destDir: string): void {
+  // Expand-Archive ships with PowerShell 5.0+ on every supported Windows.
+  const script = `Expand-Archive -LiteralPath ${powershellLiteral(zipPath)} -DestinationPath ${powershellLiteral(destDir)} -Force`;
+  execFileSync(
+    "powershell.exe",
+    ["-NoProfile", "-NonInteractive", "-Command", script],
+    { windowsHide: true },
+  );
+}
+
+function extractZipPosix(zipPath: string, destDir: string): void {
+  execFileSync("unzip", ["-o", zipPath, "-d", destDir]);
+}
+
+function extractZipArchive(zipPath: string, destDir: string): void {
+  if (isWindows) {
+    extractZipWindows(zipPath, destDir);
+  } else {
+    extractZipPosix(zipPath, destDir);
+  }
 }
 
 export function importSkillZip(
@@ -94,7 +145,7 @@ export function importSkillZip(
         error: "Zip contains unsafe paths",
       };
     }
-    execFileSync("unzip", ["-o", zipPath, "-d", stagingDir]);
+    extractZipArchive(zipPath, stagingDir);
 
     // Validate no files escaped staging dir (zip-slip defense)
     const normalizedStaging = stagingDir.endsWith("/")
@@ -158,7 +209,8 @@ export function importSkillZip(
     }
     mkdirSync(destDir, { recursive: true });
 
-    execFileSync("cp", ["-R", `${skillRoot}/.`, destDir]);
+    // Cross-platform copy: Node's fs.cpSync handles Windows + POSIX uniformly.
+    cpSync(skillRoot, destDir, { recursive: true });
 
     return { ok: true, slug };
   } catch (error: unknown) {

--- a/apps/controller/tests/skillhub-custom-import.test.ts
+++ b/apps/controller/tests/skillhub-custom-import.test.ts
@@ -1,0 +1,133 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/services/skillhub/zip-importer.js", () => ({
+  importSkillZip: vi.fn(),
+  MAX_ZIP_SIZE: 50 * 1024 * 1024,
+}));
+
+vi.mock("../src/services/skillhub/npm-runner.js", () => ({
+  ensureNpmAvailable: vi.fn(),
+  runNpmInstall: vi.fn(),
+}));
+
+const { importSkillZip: extractZipMock } = await import(
+  "../src/services/skillhub/zip-importer.js"
+);
+const { ensureNpmAvailable, runNpmInstall } = await import(
+  "../src/services/skillhub/npm-runner.js"
+);
+const { CatalogManager } = await import(
+  "../src/services/skillhub/catalog-manager.js"
+);
+const { SkillDb } = await import("../src/services/skillhub/skill-db.js");
+
+function stubExtractTo(
+  slug: string,
+  skillsDir: string,
+  opts: { withPackageJson?: boolean } = {},
+) {
+  vi.mocked(extractZipMock).mockImplementationOnce(
+    (_buffer, target: string) => {
+      const skillDir = path.join(target, slug);
+      mkdirSync(skillDir, { recursive: true });
+      writeFileSync(
+        path.join(skillDir, "SKILL.md"),
+        `---\nname: ${slug}\ndescription: test\n---\n`,
+      );
+      if (opts.withPackageJson) {
+        writeFileSync(
+          path.join(skillDir, "package.json"),
+          JSON.stringify({ name: slug, version: "0.1.0" }),
+        );
+      }
+      return { ok: true, slug };
+    },
+  );
+}
+
+describe("CatalogManager.importSkillZip", () => {
+  let tmpDir: string;
+  let skillsDir: string;
+  let cacheDir: string;
+  let skillDb: InstanceType<typeof SkillDb>;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(tmpdir(), "nexu-custom-import-"));
+    skillsDir = path.join(tmpDir, "skills");
+    cacheDir = path.join(tmpDir, "cache");
+    mkdirSync(skillsDir, { recursive: true });
+    mkdirSync(cacheDir, { recursive: true });
+    skillDb = await SkillDb.create(path.join(tmpDir, "skill-ledger.json"));
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    skillDb.close();
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("records install when extraction succeeds and skill has no deps", async () => {
+    stubExtractTo("no-deps", skillsDir);
+    const catalog = new CatalogManager(cacheDir, { skillsDir, skillDb });
+
+    const result = await catalog.importSkillZip(Buffer.from("zip"));
+
+    expect(result).toEqual({ ok: true, slug: "no-deps" });
+    expect(existsSync(path.join(skillsDir, "no-deps", "SKILL.md"))).toBe(true);
+    expect(skillDb.getAllKnownSlugs().has("no-deps")).toBe(true);
+    expect(skillDb.getInstalledRecordsBySlug("no-deps")[0]?.status).toBe(
+      "installed",
+    );
+    expect(vi.mocked(ensureNpmAvailable)).not.toHaveBeenCalled();
+  });
+
+  it("rolls back extracted files and skips DB write when deps install fails with npm_missing", async () => {
+    stubExtractTo("needs-npm", skillsDir, { withPackageJson: true });
+    vi.mocked(ensureNpmAvailable).mockRejectedValueOnce(
+      new Error("NPM_MISSING: npm executable not found on PATH"),
+    );
+    const catalog = new CatalogManager(cacheDir, { skillsDir, skillDb });
+
+    const result = await catalog.importSkillZip(Buffer.from("zip"));
+
+    expect(result.ok).toBe(false);
+    expect(result.errorCode).toBe("npm_missing");
+    expect(result.error).toMatch(/NPM_MISSING/);
+    expect(existsSync(path.join(skillsDir, "needs-npm"))).toBe(false);
+    expect(skillDb.getAllKnownSlugs().has("needs-npm")).toBe(false);
+  });
+
+  it("rolls back and surfaces deps_install_failed when npm install throws", async () => {
+    stubExtractTo("broken-deps", skillsDir, { withPackageJson: true });
+    vi.mocked(ensureNpmAvailable).mockResolvedValueOnce(undefined);
+    vi.mocked(runNpmInstall).mockRejectedValueOnce(
+      new Error("npm ERR! ETIMEDOUT"),
+    );
+    const catalog = new CatalogManager(cacheDir, { skillsDir, skillDb });
+
+    const result = await catalog.importSkillZip(Buffer.from("zip"));
+
+    expect(result.ok).toBe(false);
+    expect(result.errorCode).toBe("deps_install_failed");
+    expect(existsSync(path.join(skillsDir, "broken-deps"))).toBe(false);
+    expect(skillDb.getAllKnownSlugs().has("broken-deps")).toBe(false);
+  });
+
+  it("propagates extraction failures without touching the DB", async () => {
+    vi.mocked(extractZipMock).mockReturnValueOnce({
+      ok: false,
+      error: "Zip contains unsafe paths",
+    });
+    const catalog = new CatalogManager(cacheDir, { skillsDir, skillDb });
+
+    const result = await catalog.importSkillZip(Buffer.from("zip"));
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("Zip contains unsafe paths");
+    expect(skillDb.getAllKnownSlugs().size).toBe(0);
+  });
+});

--- a/apps/web/lib/api/types.gen.ts
+++ b/apps/web/lib/api/types.gen.ts
@@ -3529,7 +3529,7 @@ export type GetApiV1SkillhubCatalogResponses = {
             status: 'queued' | 'downloading' | 'installing-deps' | 'done' | 'failed';
             position: number;
             error: string;
-            errorCode: 'skill_not_found' | 'rate_limit' | 'unknown';
+            errorCode: 'skill_not_found' | 'rate_limit' | 'npm_missing' | 'deps_install_failed' | 'unknown';
             retries: number;
             enqueuedAt: string;
         }>;

--- a/apps/web/lib/api/types.gen.ts
+++ b/apps/web/lib/api/types.gen.ts
@@ -3687,11 +3687,13 @@ export type PostApiV1SkillhubImportData = {
 
 export type PostApiV1SkillhubImportErrors = {
     /**
-     * Bad request
+     * Import rejected or failed
      */
     400: {
-        ok: false;
-        error: string;
+        ok: boolean;
+        slug?: string;
+        error?: string;
+        errorCode?: 'skill_not_found' | 'rate_limit' | 'npm_missing' | 'deps_install_failed' | 'unknown';
     };
 };
 
@@ -3705,6 +3707,7 @@ export type PostApiV1SkillhubImportResponses = {
         ok: boolean;
         slug?: string;
         error?: string;
+        errorCode?: 'skill_not_found' | 'rate_limit' | 'npm_missing' | 'deps_install_failed' | 'unknown';
     };
 };
 

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -771,6 +771,13 @@ const en = {
   "skills.cancelInstall": "Cancel",
   "skills.cancelling": "Cancelling…",
   "skills.cancelFailed": "Failed to cancel: {{error}}",
+  "skills.installNpmMissing":
+    "npm is required to install this skill. Please install Node.js from https://nodejs.org/ and restart Nexu.",
+  "skills.installDepsFailed":
+    'Failed to install dependencies for "{{slug}}". Check the controller logs for details.',
+  "skills.installFailed": 'Failed to install "{{slug}}": {{error}}',
+  "skills.installRequestFailed": "Could not start the install: {{error}}",
+  "skills.uninstallRequestFailed": "Could not uninstall the skill: {{error}}",
   "skills.import": "Import",
   "skills.importSkill": "Import Skill",
   "skills.importSkillDesc":

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -727,6 +727,13 @@ const zhCN = {
   "skills.cancelInstall": "取消",
   "skills.cancelling": "取消中…",
   "skills.cancelFailed": "取消失败：{{error}}",
+  "skills.installNpmMissing":
+    "安装该技能需要 npm。请先从 https://nodejs.org/ 安装 Node.js 并重启 Nexu。",
+  "skills.installDepsFailed":
+    '"{{slug}}" 的依赖安装失败，请查看控制器日志了解详情。',
+  "skills.installFailed": '"{{slug}}" 安装失败：{{error}}',
+  "skills.installRequestFailed": "无法启动安装：{{error}}",
+  "skills.uninstallRequestFailed": "无法卸载该技能：{{error}}",
   "skills.import": "导入",
   "skills.importSkill": "导入技能",
   "skills.importSkillDesc": "从 zip 文件或 GitHub 仓库添加自定义技能",

--- a/apps/web/src/pages/skills.tsx
+++ b/apps/web/src/pages/skills.tsx
@@ -115,13 +115,22 @@ function SkillCard({
     queueStatus === "downloading" ||
     queueStatus === "installing-deps";
   const isFailed = queueStatus === "failed";
-  const canRetry = isFailed && queueErrorCode !== "skill_not_found";
+  // Retry is suppressed for terminal errors that the user must resolve
+  // outside the app (skill removed, or npm not installed).
+  const canRetry =
+    isFailed &&
+    queueErrorCode !== "skill_not_found" &&
+    queueErrorCode !== "npm_missing";
   const failedMessage = isFailed
     ? queueErrorCode === "skill_not_found"
       ? t("skills.skillNotAvailable")
       : queueErrorCode === "rate_limit"
         ? t("skills.installRateLimited")
-        : t("skills.installFailedGeneric")
+        : queueErrorCode === "npm_missing"
+          ? t("skills.installNpmMissing")
+          : queueErrorCode === "deps_install_failed"
+            ? t("skills.installDepsFailed", { slug: skill.slug })
+            : t("skills.installFailedGeneric")
     : null;
   const isMutating = pendingAction !== null;
 
@@ -140,7 +149,9 @@ function SkillCard({
         name: skill.name,
         skill_source: skillSource,
       });
-    } catch {
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      toast.error(t("skills.installRequestFailed", { error: message }));
       track("workspace_skill_install", {
         skill_name: skill.name,
         skill_type: skillType,
@@ -186,7 +197,9 @@ function SkillCard({
         name: skill.name,
         skill_source: skillSource,
       });
-    } catch {
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      toast.error(t("skills.uninstallRequestFailed", { error: message }));
       track("workspace_skill_uninstall", {
         skill_name: skill.name,
         skill_source: skillSource,

--- a/apps/web/src/types/desktop.d.ts
+++ b/apps/web/src/types/desktop.d.ts
@@ -17,7 +17,12 @@ export type QueueItemStatus =
   | "done"
   | "failed";
 
-export type QueueErrorCode = "skill_not_found" | "rate_limit" | "unknown";
+export type QueueErrorCode =
+  | "skill_not_found"
+  | "rate_limit"
+  | "npm_missing"
+  | "deps_install_failed"
+  | "unknown";
 
 export type QueueItem = {
   readonly slug: string;

--- a/specs/design-docs/2026-04-14-windows-shellout-audit.md
+++ b/specs/design-docs/2026-04-14-windows-shellout-audit.md
@@ -1,44 +1,145 @@
-# Windows shell-out audit (controller)
+# Windows compatibility audit (whole repo)
 
-Tracking ticket: follow-up to issue #920. This branch (`fix/win-skill-install`)
-addresses the immediate skill-install failure path. The items below were
-discovered during that audit and need their own branch.
+Tracking ticket: follow-up to issue #920. The branch `fix/win-skill-install`
+addresses the immediate skill-install failure path. This document expands the
+original controller-only audit into a repo-wide map of remaining
+Windows-compatibility hazards so they can be triaged into follow-up branches.
 
-## Scope
+## Method
 
-Grep target: `apps/controller/src` for `execFile`, `execFileSync`, `spawn`,
-`execSync`, `spawnSync`.
+Grep targets across `apps/`, `packages/`, `scripts/`, `openclaw-runtime/`
+(skipped: `node_modules`, `.tmp`, `dist`, `.dist-runtime`, `.worktrees`):
+
+- `child_process` invocations: `execFile`, `execFileSync`, `exec`, `execSync`, `spawn`, `spawnSync`
+- POSIX-only binaries on PATH: `pgrep`, `pkill`, `lsof`, `osascript`, `launchctl`, `defaults`, `mdfind`, `pbcopy`, `cp -R`, `unzip`, `chmod`, etc.
+- Hard-coded POSIX paths: `/usr/`, `/tmp/`, `~/`, `$HOME` (in code)
+- Path-separator assumptions: `.startsWith("/")` used as "absolute" check, manual `"/"` joins
+- macOS-specific APIs: launchd, LSUIElement, `~/Library/...`
+- POSIX-only signals: `SIGUSR1`, `SIGUSR2`, `SIGHUP`
+- File-system specifics: `fs.symlinkSync`, `fs.chmod`, reserved Windows names
+- Build / dev scripts: `.sh`, `.zsh`, `.bash`, `package.json` shell syntax
 
 ## Status legend
 
-- ✅ already cross-platform safe (macOS + Windows)
-- ⚠️ Windows-only hazard, fix in a follow-up branch
-- 🟡 platform-gated (mac-only), no Windows impact
+- ✅ already cross-platform safe (this branch or earlier)
+- 🔴 critical: Windows users hit it in normal flow — fix soon
+- 🟡 medium: edge case or dev-only impact — fix when convenient
+- 🟢 low: gated, doc-only, or graceful fallback already present
 
 ## Findings
 
-| File:line | Command | Status | Notes |
+### Controller — `apps/controller/`
+
+| File:line | Operation | Status | Notes |
 |---|---|---|---|
-| `services/skillhub/catalog-manager.ts:206-211` | `tar` | ✅ | Has explicit Win32 branch with `--force-local` fallback for bsdtar. |
+| `services/skillhub/catalog-manager.ts:683` | `npm install` via spawn | ✅ | Routed through `npm-runner.ts` with `shell: true` on Win32 + npm preflight (this branch). |
+| `services/skillhub/catalog-manager.ts:206-211` | `tar` extract | ✅ | Has Win32 branch with `--force-local` fallback for bsdtar. |
 | `services/skillhub/catalog-manager.ts:290,333,507` | clawhub via `process.execPath` | ✅ | Invokes Node directly with JS entry — no PATH lookup, no `.cmd` shim. |
-| `services/skillhub/catalog-manager.ts:683` (post-fix) | `npm` | ✅ | Now goes through `npm-runner.ts` with `shell: true` on Win32. |
-| `services/skillhub/zip-importer.ts:75,87,101,109` (post-fix) | `unzip` / `cp` | ✅ | Replaced with PowerShell `Expand-Archive` on Win32 + `fs.cpSync` for copy. |
-| `services/skillhub/skill-db.ts:352` | `sqlite3` | ⚠️ | One-shot legacy DB migration. Will silently fail on Windows users who hit the migration path (no `sqlite3` CLI on default Win install). Low blast radius — only fires once per install when migrating from the pre-v0.1.x ledger. **Fix:** use `better-sqlite3` (already a controller dep) to read the legacy DB instead of shelling out. |
-| `services/channel-service.ts:1595` | `launchctl` | 🟡 | macOS-only; channel-service should gate or no-op on Win32. Verify call site is gated. |
-| `runtime/openclaw-process.ts:304` | `launchctl` | 🟡 | Same as above; verify the supervisor doesn't reach this branch on Win32. |
-| `runtime/openclaw-process.ts:694` | `/usr/bin/pgrep` | ⚠️ | Hard-coded Unix path; this code path needs to be gated by `process.platform !== "win32"` or replaced with a cross-platform process lookup (e.g. `tasklist` on Windows, or skip the orphan-sweep entirely on Win32 if launchd is the only consumer). |
-| `routes/desktop-routes.ts:138` | dynamic `cmd` open-folder | ⚠️ | Verify `cmd` here resolves to `explorer.exe` on Windows, `open` on macOS, `xdg-open` on Linux. Currently uses `execFile` without `shell: true`; if `cmd` is `cmd.exe` or any `.cmd` shim this will break the same way `npm` did. |
-| `services/model-provider-service.ts:1227` | `execFile` (unspecified) | ⚠️ | Audit the actual `cmd` value — same `.cmd` / `.exe` resolution caveat as desktop-routes. |
+| `services/skillhub/zip-importer.ts:75,87,101,109` | `unzip` / `cp` | ✅ | Replaced with PowerShell `Expand-Archive` + `fs.cpSync` (this branch). |
+| `services/skillhub/skill-db.ts:352` | `sqlite3` CLI | 🟡 | One-shot legacy DB migration. Silently fails on Windows users without `sqlite3`. **Fix:** use `better-sqlite3` (already a dep) to read the legacy DB. |
+| `runtime/openclaw-process.ts:694` | `/usr/bin/pgrep -f 'openclaw.*gateway'` | 🔴 | Hard-coded Unix path, no platform guard. Used to detect orphan OpenClaw processes; on Windows it silently no-ops, leaving stale processes after restarts and possibly causing port conflicts. **Fix:** gate by `process.platform !== "win32"` and add a `tasklist /FI` Windows branch (or no-op if Windows uses a different supervisor architecture). |
+| `runtime/openclaw-process.ts:304` | `launchctl kickstart` | 🟢 | Reachable only when supervised by launchd, which is macOS-only. Verify call-site context never invokes on Win32. |
+| `services/channel-service.ts:1595` | `launchctl kickstart` | 🟢 | Same as above. Verify gating at call site. |
+| `services/model-provider-service.ts:1227` | `execFile` (dynamic cmd) | 🟡 | Audit the actual `cmd` value at runtime — same `.cmd` / `.exe` shim caveat as `npm`. If it ever resolves to a `.cmd`, needs `shell: true`. |
+| `routes/desktop-routes.ts:138` | dynamic `cmd` open-folder | 🟡 | Resolves to `explorer.exe` on Win32, `open` on Mac, `xdg-open` on Linux per platform branch. Uses `execFile` without `shell: true` — direct `.exe` is fine, but if anyone routes a `.cmd` shim through here it will fail. Add `shell: true` defensively on Win32, or document the constraint. |
+| `runtime/openclaw-ws-client.ts:146`, `static/runtime-plugins/openclaw-weixin/src/auth/accounts.ts:218` | `fs.chmodSync(..., 0o600)` | ✅ | Wrapped in try-catch — chmod is a no-op on Windows but doesn't throw. |
+| `runtime/sessions-runtime.ts:1571` | `process.env.HOME` | ✅ | Falls back to `os.homedir()` — portable. |
 
-## Suggested follow-up branch plan
+### Desktop — `apps/desktop/`
 
-1. `fix/win-skillhub-sqlite-migration` — swap `execFileSync("sqlite3", …)` for `better-sqlite3` reads.
-2. `fix/win-process-supervisor` — gate `pgrep` / `launchctl` paths by platform; provide Win32 equivalents (`tasklist` / `taskkill`) or no-op + telemetry.
-3. `fix/win-open-folder` — verify the open-folder command resolution per platform; route `.cmd`/`.bat` shims through `shell: true` or use `process.execPath` for embedded entries.
+| File:line | Operation | Status | Notes |
+|---|---|---|---|
+| `main/services/launchd-bootstrap.ts` (entire) | launchd suite | ✅ | Macos-only by design. Win32 branch at line 535 no-ops the entire launchd stack; desktop on Windows uses the in-process orchestrator instead. |
+| `main/services/launchd-bootstrap.ts:1672` | `lsof +D` | ✅ | Gated by Win32-returns-false branch above. |
+| `main/services/launchd-bootstrap.ts:1474` | `pgrep -P` | ✅ | Same gating. |
+| `main/services/launchd-manager.ts` | `launchctl` operations | ✅ | macOS-only by design; not invoked on Win32. |
+| `main/bootstrap.ts:177` | `reg.exe query` | ✅ | Windows-only code path, correctly gated. |
+| `main/platforms/shared/runtime-roots.ts:5` | `process.env.HOME` for `~` expansion | 🟡 | Should use `os.homedir()` directly — `process.env.HOME` is undefined on Windows. Currently mostly OK because the affected code paths are dev-mode helpers, but it's a latent bug. |
+| `tests/desktop/create-symlink.ts:15-19` | `fs.symlinkSync` | 🟢 | Windows requires admin or Developer Mode. Test gracefully skips with `KnownSymlinkPlatformGapError`. Non-blocking but limits coverage. |
 
-## Test gap
+### Web — `apps/web/`
 
-Add a Vitest that asserts `process.platform === "win32"` paths in the controller
-do not invoke posix-only binaries (`unzip`, `cp`, `sqlite3`, `pgrep`,
-`launchctl`). A simple grep test or a runtime mock-based test would catch
-regressions.
+No Windows hazards identified. React/Vite/TypeScript only; no spawn or filesystem assumptions.
+
+### Shared / dev-utils — `packages/`
+
+| File:line | Operation | Status | Notes |
+|---|---|---|---|
+| `packages/dev-utils/src/process.ts:67-75` | `lsof` for port detection (Darwin path) | ✅ | Win32 branch routes through `tasklist` / `netstat` correctly; Linux uses `/proc`. |
+
+### openclaw-runtime — `openclaw-runtime/`
+
+| File:line | Operation | Status | Notes |
+|---|---|---|---|
+| `openclaw-runtime/install-runtime.mjs` | `npm ci` / `npm install` postinstall | 🟡 | Spawns `npm` to install runtime deps. Uses `shell: false` per Node defaults; same `.cmd` shim risk as the controller had. **Validate on Windows:** does `pnpm install` succeed at the runtime postinstall step? If not, add `shell: process.platform === "win32"`. |
+
+### Scripts — `scripts/`
+
+| File | Operation | Status | Notes |
+|---|---|---|---|
+| `scripts/launchd-lifecycle-e2e.sh` | shell script, `launchctl` | ✅ | Explicitly checks `uname = Darwin` at line 149 and skips otherwise. |
+| `scripts/dev-launchd.sh` | launchd dev wrapper | ✅ | macOS-only entry; Win32 dev flow goes through `scripts/dev/src/shared/platform/desktop-dev-platform.win32.*` instead. |
+| `scripts/desktop-stop-smoke.sh` | shell script | 🟡 | macOS-only smoke test. No Windows equivalent yet — Win32 stop semantics differ (no launchd) so a parallel `.ps1` or Node script should be added when Windows packaging stabilizes. |
+| `scripts/dev/` (TS sources) | platform-aware dev launcher | ✅ | Uses `scripts/dev/src/shared/platform/desktop-dev-platform.{darwin,win32,linux}.ts` for OS-specific handling. |
+| `apps/desktop/scripts/*.mjs` | Node-based packaging helpers | ✅ | All written in Node, no shell dependencies. |
+| `apps/desktop/package.json` scripts | electron-builder invocations | ✅ | No shell syntax (`cp`, `rm`, `chmod`, `find -exec`). Uses Node helpers. |
+
+### Process / signal usage
+
+| Pattern | Status | Notes |
+|---|---|---|
+| `process.kill(pid, "SIGKILL")` | ✅ | Translated to TerminateProcess on Windows by Node. |
+| `process.kill(pid, 0)` for existence | ✅ | Cross-platform with consistent error semantics. |
+| `SIGUSR1` / `SIGUSR2` / `SIGHUP` | ✅ | Only mentioned in comments; not delivered by code. |
+| `SIGINT` / `SIGTERM` handlers | ✅ | Both delivered on Windows (with caveats: `SIGTERM` from external `taskkill /T` works; from non-tree kill it doesn't). |
+
+## Critical findings (🔴)
+
+Only one truly critical item beyond what this branch already fixes:
+
+### `runtime/openclaw-process.ts:694` — hard-coded `/usr/bin/pgrep`
+
+```ts
+const output = execSync("/usr/bin/pgrep -f 'openclaw.*gateway'", { … });
+```
+
+On Windows, this path doesn't exist; `execSync` throws ENOENT. The catch (if any) silences the orphan sweep, so OpenClaw gateway processes from a previous session can survive across restarts → port conflicts, stale state, mysterious "address in use" errors.
+
+**Fix:** branch by platform:
+
+```ts
+if (process.platform === "win32") {
+  // tasklist /FI "IMAGENAME eq openclaw*.exe" /FO CSV
+} else {
+  execSync("/usr/bin/pgrep -f 'openclaw.*gateway'", …);
+}
+```
+
+Or, if Windows uses a different supervisor architecture entirely, no-op on Win32 with a telemetry log.
+
+## Suggested follow-up branches (priority order)
+
+1. **`fix/win-openclaw-orphan-sweep`** (🔴) — Gate `runtime/openclaw-process.ts:694`. Add Win32 `tasklist`/`taskkill` equivalent or platform no-op. Single-file change. **Ship before any Windows packaged release.**
+2. **`fix/win-skillhub-sqlite-migration`** (🟡) — Swap `execFileSync("sqlite3", …)` for `better-sqlite3` reads in `skill-db.ts:352`. Removes the only remaining external-binary dependency in the skill DB layer. Migration only fires on legacy installs; impact is bounded.
+3. **`fix/win-runtime-env-portability`** (🟡) — Replace `process.env.HOME` with `os.homedir()` everywhere it's used as a tilde-expansion fallback (`runtime-roots.ts:5` is the main offender). Tiny diff, prevents future Windows dev-mode regressions.
+4. **`fix/win-defensive-shell`** (🟡) — Audit `model-provider-service.ts:1227` and `desktop-routes.ts:138` — both use `execFile` with a dynamic `cmd`. Add `shell: process.platform === "win32"` defensively so future `.cmd`/`.bat` resolution doesn't regress like `npm` did.
+5. **`fix/win-runtime-postinstall-spawn`** (🟡) — Verify `openclaw-runtime/install-runtime.mjs` npm spawn works on Windows. If not, apply the same `shell: true` fix as `npm-runner.ts`.
+6. **`chore/win-platform-coverage`** (🟢) — Add a Vitest that statically asserts the controller does not invoke POSIX-only binaries on the Win32 path. Lightweight regression guard.
+7. **`docs/win-stop-smoke-script`** (🟢) — Port `desktop-stop-smoke.sh` to a Node script (or PowerShell) so Windows packaging gets the same post-stop verification.
+
+## Summary
+
+The codebase is largely well-gated for Windows. The two highest-impact fixes
+(npm with `shell: true` and the PowerShell-based zip importer) ship in the
+current `fix/win-skill-install` branch and unblock the most common user flow.
+
+Beyond that, **one critical hazard remains** (`pgrep` orphan sweep), and a
+handful of medium-priority items concentrate around legacy assumptions
+(`sqlite3` shellout, `process.env.HOME`, defensive `shell: true` on dynamic
+spawns). The shell scripts and launchd suite are intentionally macOS-only and
+correctly guarded — the desktop on Windows uses a different process model
+entirely (in-process orchestrator instead of launchd), so launchd code paths
+are unreachable.
+
+A focused 2–3 PR sequence (#1, then #2/#3 in parallel, then #4–#7 in a small
+batch) brings the controller and packaged desktop to full Windows parity.

--- a/specs/design-docs/2026-04-14-windows-shellout-audit.md
+++ b/specs/design-docs/2026-04-14-windows-shellout-audit.md
@@ -1,0 +1,44 @@
+# Windows shell-out audit (controller)
+
+Tracking ticket: follow-up to issue #920. This branch (`fix/win-skill-install`)
+addresses the immediate skill-install failure path. The items below were
+discovered during that audit and need their own branch.
+
+## Scope
+
+Grep target: `apps/controller/src` for `execFile`, `execFileSync`, `spawn`,
+`execSync`, `spawnSync`.
+
+## Status legend
+
+- ✅ already cross-platform safe (macOS + Windows)
+- ⚠️ Windows-only hazard, fix in a follow-up branch
+- 🟡 platform-gated (mac-only), no Windows impact
+
+## Findings
+
+| File:line | Command | Status | Notes |
+|---|---|---|---|
+| `services/skillhub/catalog-manager.ts:206-211` | `tar` | ✅ | Has explicit Win32 branch with `--force-local` fallback for bsdtar. |
+| `services/skillhub/catalog-manager.ts:290,333,507` | clawhub via `process.execPath` | ✅ | Invokes Node directly with JS entry — no PATH lookup, no `.cmd` shim. |
+| `services/skillhub/catalog-manager.ts:683` (post-fix) | `npm` | ✅ | Now goes through `npm-runner.ts` with `shell: true` on Win32. |
+| `services/skillhub/zip-importer.ts:75,87,101,109` (post-fix) | `unzip` / `cp` | ✅ | Replaced with PowerShell `Expand-Archive` on Win32 + `fs.cpSync` for copy. |
+| `services/skillhub/skill-db.ts:352` | `sqlite3` | ⚠️ | One-shot legacy DB migration. Will silently fail on Windows users who hit the migration path (no `sqlite3` CLI on default Win install). Low blast radius — only fires once per install when migrating from the pre-v0.1.x ledger. **Fix:** use `better-sqlite3` (already a controller dep) to read the legacy DB instead of shelling out. |
+| `services/channel-service.ts:1595` | `launchctl` | 🟡 | macOS-only; channel-service should gate or no-op on Win32. Verify call site is gated. |
+| `runtime/openclaw-process.ts:304` | `launchctl` | 🟡 | Same as above; verify the supervisor doesn't reach this branch on Win32. |
+| `runtime/openclaw-process.ts:694` | `/usr/bin/pgrep` | ⚠️ | Hard-coded Unix path; this code path needs to be gated by `process.platform !== "win32"` or replaced with a cross-platform process lookup (e.g. `tasklist` on Windows, or skip the orphan-sweep entirely on Win32 if launchd is the only consumer). |
+| `routes/desktop-routes.ts:138` | dynamic `cmd` open-folder | ⚠️ | Verify `cmd` here resolves to `explorer.exe` on Windows, `open` on macOS, `xdg-open` on Linux. Currently uses `execFile` without `shell: true`; if `cmd` is `cmd.exe` or any `.cmd` shim this will break the same way `npm` did. |
+| `services/model-provider-service.ts:1227` | `execFile` (unspecified) | ⚠️ | Audit the actual `cmd` value — same `.cmd` / `.exe` resolution caveat as desktop-routes. |
+
+## Suggested follow-up branch plan
+
+1. `fix/win-skillhub-sqlite-migration` — swap `execFileSync("sqlite3", …)` for `better-sqlite3` reads.
+2. `fix/win-process-supervisor` — gate `pgrep` / `launchctl` paths by platform; provide Win32 equivalents (`tasklist` / `taskkill`) or no-op + telemetry.
+3. `fix/win-open-folder` — verify the open-folder command resolution per platform; route `.cmd`/`.bat` shims through `shell: true` or use `process.execPath` for embedded entries.
+
+## Test gap
+
+Add a Vitest that asserts `process.platform === "win32"` paths in the controller
+do not invoke posix-only binaries (`unzip`, `cp`, `sqlite3`, `pgrep`,
+`launchctl`). A simple grep test or a runtime mock-based test would catch
+regressions.


### PR DESCRIPTION
## What

Fix the silent stuck UI when installing a skill on Windows (issue #920). After this PR, Windows skill installs actually succeed when the user has Node.js, and fail with a clear actionable message otherwise. Cross-platform support for the zip-import path comes along for the ride.

## Why

Closes #920.

On Windows, clicking install for any skill with npm dependencies showed a brief spinner then nothing — no toast, no error, skill not installed. Three layers combined:

1. `installSkillDeps` ran `execFile("npm", …)` without `shell: true`. On Windows `npm` is `npm.cmd`; Node ≥18.20.2/20.12.2 refuses to spawn `.cmd` shims directly (CVE-2024-27980), so install threw ENOENT/EINVAL on every Windows install.
2. The catch downgraded the error to a `warn` log and returned normally, so the InstallQueue marked the failed install as `done`.
3. The frontend `handleInstall` catch was empty, and the inline failed-card UI introduced in #1096 never triggered because the queue said done.

## How

- **`services/skillhub/npm-runner.ts` (new)** centralizes npm spawning. Uses `shell: true` on win32 (args are controller-owned, no user input). Exposes `ensureNpmAvailable()` which probes `npm --version` once per process and throws `NPM_MISSING:` if Node.js is not installed.
- **`catalog-manager.installSkillDeps`** calls `ensureNpmAvailable()` first and now **rethrows** on failure as `DEPS_INSTALL_FAILED:` instead of swallowing.
- **`install-queue.classifyError`** recognizes the two new error prefixes; `types.ts` and `skillhub-routes.ts` schemas extended with `npm_missing` and `deps_install_failed` codes (SDK regenerated via `pnpm generate-types`).
- **`skills.tsx`** `failedMessage` and `canRetry` extended for the new codes. `npm_missing` directs the user to install Node.js and **hides Retry** (terminal — retry won't help). `deps_install_failed` allows Retry (often transient network). The synchronous `handleInstall` / `handleUninstall` catches now `toast.error` so request-time failures are not silent either.
- **`zip-importer.ts`** replaces POSIX-only `unzip` and `cp` shellouts with PowerShell `Expand-Archive` + .NET `ZipFile` API on Windows, and `fs.cpSync` for the final copy. Both POSIX and Windows paths preserved.
- **i18n** (`en.ts` / `zh-CN.ts`): five new strings for the user-facing messages.

Follow-up audit recorded at `specs/design-docs/2026-04-14-windows-shellout-audit.md` covering remaining controller shell-outs (`sqlite3`, `pgrep`, `launchctl`, open-folder helper) that also need Windows-safe handling but are not on the skill-install hot path. These will be separate branches.

## Affected areas

- [x] Controller (backend / API)
- [x] Web dashboard (React UI)
- [x] Shared schemas / packages

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` — skillhub-relevant suites pass (25/25); 29 pre-existing failures elsewhere on `main` are unrelated to this PR
- [x] `pnpm generate-types` run (errorCode enum extended)
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced

## Notes for reviewers

**Real Windows reproduction is pending.** Verified statically (typecheck, lint, unit tests). Smoke-test plan to run on a Windows box:

| Scenario | Setup | Expected |
|---|---|---|
| A. Happy path | Fresh Win, npm installed | Skill installs, green card, `node_modules/` populated |
| B. npm absent | Rename `npm.cmd`, restart controller | Red card, "install Node.js" copy, **no Retry button** |
| C. npm install fails | Disable network or set bogus registry | Red card, generic deps-failed copy, **Retry available** |
| D. Packaged build | `pnpm dist:win:local` then run `.exe` | Same as A; this is the original #920 reproducer |
| E. Zip import | Drag a valid skill zip | Imports via PowerShell `Expand-Archive` |
| F. Controller down | Kill controller, click Install | Toast "Could not start the install: …" |

Recommend testing on a Windows host that builds via `pnpm dist:win:local` rather than cross-compiling from macOS — the bug is a runtime spawn behavior tied to the actual Node binary in the package.

**Why `shell: true` is safe here:** the only call sites in `npm-runner.ts` pass controller-generated paths (`skillDir` from the catalog) and a fixed argument list — no user-supplied strings concatenated into the command. PowerShell args in `zip-importer.ts` are quoted via `powershellLiteral()` (single-quote with `''` doubling) to defend against pathnames containing apostrophes.