### PR TITLE
fix(controller): isolate sessions across bots to stop cross-channel transcript leak

### DIFF
--- a/apps/controller/src/runtime/sessions-runtime.ts
+++ b/apps/controller/src/runtime/sessions-runtime.ts
@@ -110,6 +110,46 @@ function sessionMetadataPath(filePath: string): string {
   return filePath.replace(/\.jsonl$/, ".meta.json");
 }
 
+function encodeSessionId(botId: string, sessionKey: string): string {
+  return `session:${Buffer.from(
+    JSON.stringify({ botId, sessionKey }),
+    "utf8",
+  ).toString("base64url")}`;
+}
+
+function decodeSessionId(
+  id: string,
+): { botId: string; sessionKey: string } | null {
+  if (!id.startsWith("session:")) {
+    return null;
+  }
+
+  try {
+    const raw = Buffer.from(id.slice("session:".length), "base64url").toString(
+      "utf8",
+    );
+    const parsed = JSON.parse(raw) as {
+      botId?: unknown;
+      sessionKey?: unknown;
+    };
+    if (
+      typeof parsed.botId !== "string" ||
+      parsed.botId.length === 0 ||
+      typeof parsed.sessionKey !== "string" ||
+      parsed.sessionKey.length === 0
+    ) {
+      return null;
+    }
+
+    return {
+      botId: parsed.botId,
+      sessionKey: parsed.sessionKey,
+    };
+  } catch {
+    return null;
+  }
+}
+
 function abbreviateOpaqueId(value: string): string {
   return value.slice(0, 8).toUpperCase();
 }
@@ -309,7 +349,7 @@ export class SessionsRuntime {
           const lastMsg = messages.at(-1);
 
           sessions.push({
-            id: file.name,
+            id: encodeSessionId(agentEntry.name, sessionKey),
             botId: agentEntry.name,
             sessionKey,
             channelType: channelType ?? null,
@@ -904,7 +944,18 @@ export class SessionsRuntime {
   }
 
   async getSession(id: string): Promise<SessionResponse | null> {
+    const decoded = decodeSessionId(id);
+    if (decoded) {
+      return this.getSessionByKey(decoded.botId, decoded.sessionKey);
+    }
+
     const sessions = await this.listSessions();
+    const legacyMatches = sessions.filter(
+      (session) => `${session.sessionKey}.jsonl` === id,
+    );
+    if (legacyMatches.length === 1) {
+      return legacyMatches[0] ?? null;
+    }
     return sessions.find((session) => session.id === id) ?? null;
   }
 
@@ -912,11 +963,11 @@ export class SessionsRuntime {
     botId: string,
     sessionKey: string,
   ): Promise<SessionResponse | null> {
-    const id = `${sessionKey}.jsonl`;
     const sessions = await this.listSessions();
     return (
       sessions.find(
-        (session) => session.id === id && session.botId === botId,
+        (session) =>
+          session.botId === botId && session.sessionKey === sessionKey,
       ) ?? null
     );
   }

--- a/apps/controller/tests/sessions-runtime.test.ts
+++ b/apps/controller/tests/sessions-runtime.test.ts
@@ -51,6 +51,102 @@ describe("SessionsRuntime", () => {
     }
   });
 
+  it("returns unique ids and correct history for duplicate session filenames across bots", async () => {
+    rootDir = await mkdtemp(path.join(tmpdir(), "nexu-sessions-runtime-"));
+    const runtime = new SessionsRuntime(
+      createEnv({
+        openclawStateDir: rootDir,
+        openclawConfigPath: path.join(rootDir, "openclaw.json"),
+        openclawSkillsDir: path.join(rootDir, "skills"),
+        openclawWorkspaceTemplatesDir: path.join(
+          rootDir,
+          "workspace-templates",
+        ),
+      }),
+    );
+
+    const webSessionsDir = path.join(rootDir, "agents", "bot-web", "sessions");
+    const wechatSessionsDir = path.join(
+      rootDir,
+      "agents",
+      "bot-wechat",
+      "sessions",
+    );
+    await mkdir(webSessionsDir, { recursive: true });
+    await mkdir(wechatSessionsDir, { recursive: true });
+
+    await writeFile(
+      path.join(webSessionsDir, "shared.jsonl"),
+      `${JSON.stringify({
+        type: "message",
+        id: "web-msg-1",
+        timestamp: "2026-04-10T10:00:00.000Z",
+        message: {
+          role: "user",
+          timestamp: Date.parse("2026-04-10T10:00:00.000Z"),
+          content: "web only",
+        },
+      })}
+`,
+      "utf8",
+    );
+    await writeFile(
+      path.join(webSessionsDir, "shared.meta.json"),
+      JSON.stringify({
+        title: "Web thread",
+        channelType: "web",
+      }),
+      "utf8",
+    );
+
+    await writeFile(
+      path.join(wechatSessionsDir, "shared.jsonl"),
+      `${JSON.stringify({
+        type: "message",
+        id: "wechat-msg-1",
+        timestamp: "2026-04-10T10:01:00.000Z",
+        message: {
+          role: "user",
+          timestamp: Date.parse("2026-04-10T10:01:00.000Z"),
+          content: "wechat only",
+        },
+      })}
+`,
+      "utf8",
+    );
+    await writeFile(
+      path.join(wechatSessionsDir, "shared.meta.json"),
+      JSON.stringify({
+        title: "WeChat thread",
+        channelType: "openclaw-weixin",
+      }),
+      "utf8",
+    );
+
+    const sessions = await runtime.listSessions();
+    const webSession = sessions.find((session) => session.botId === "bot-web");
+    const wechatSession = sessions.find(
+      (session) => session.botId === "bot-wechat",
+    );
+
+    expect(webSession).toBeDefined();
+    expect(wechatSession).toBeDefined();
+
+    if (!webSession || !wechatSession) {
+      throw new Error("expected both repro sessions to exist");
+    }
+
+    expect(webSession.id).not.toBe(wechatSession.id);
+
+    const wechatHistory = await runtime.getChatHistory(wechatSession.id);
+    const webHistory = await runtime.getChatHistory(webSession.id);
+
+    expect(wechatHistory.messages).toHaveLength(1);
+    expect(wechatHistory.messages[0]?.content).toBe("wechat only");
+    expect(webHistory.messages).toHaveLength(1);
+    expect(webHistory.messages[0]?.content).toBe("web only");
+  });
+
   it("merges filesystem metadata into session responses", async () => {
     rootDir = await mkdtemp(path.join(tmpdir(), "nexu-sessions-runtime-"));
     const runtime = new SessionsRuntime(

--- a/scripts/repro/issue-980-verify.mjs
+++ b/scripts/repro/issue-980-verify.mjs
@@ -1,0 +1,225 @@
+import { execFile as execFileCb } from "node:child_process";
+import { mkdir, utimes, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCb);
+const repoRoot = process.cwd();
+const controllerBase = process.env.NEXU_CONTROLLER_BASE_URL ?? "http://127.0.0.1:50800";
+const stateAgentsDir = path.join(repoRoot, ".tmp/dev/openclaw/state/agents");
+
+const fixtures = [
+  {
+    botId: "repro-wechat-bot",
+    sessionKey: "shared-session",
+    title: "Repro WeChat Session",
+    channelType: "openclaw-weixin",
+    timestamp: "2026-04-15T06:41:00.000Z",
+    messageId: "wechat-msg-1",
+    content: "这是微信专属复现消息。",
+  },
+  {
+    botId: "repro-web-bot",
+    sessionKey: "shared-session",
+    title: "Repro Web Session",
+    channelType: "web",
+    timestamp: "2026-04-15T06:40:00.000Z",
+    messageId: "web-msg-1",
+    content: "This is the WEB-only repro message.",
+  },
+];
+
+async function run(cmd, args, options = {}) {
+  const { stdout, stderr } = await execFile(cmd, args, {
+    cwd: repoRoot,
+    env: process.env,
+    maxBuffer: 10 * 1024 * 1024,
+    ...options,
+  });
+  return { stdout: stdout.trim(), stderr: stderr.trim() };
+}
+
+async function seedFixtures() {
+  for (const fixture of fixtures) {
+    const sessionsDir = path.join(stateAgentsDir, fixture.botId, "sessions");
+    await mkdir(sessionsDir, { recursive: true });
+    const transcriptPath = path.join(sessionsDir, `${fixture.sessionKey}.jsonl`);
+    const metadataPath = transcriptPath.replace(/\.jsonl$/, ".meta.json");
+    const line = `${JSON.stringify({
+      type: "message",
+      id: fixture.messageId,
+      timestamp: fixture.timestamp,
+      message: {
+        role: "user",
+        timestamp: Date.parse(fixture.timestamp),
+        content: fixture.content,
+      },
+    })}\n`;
+    await writeFile(transcriptPath, line, "utf8");
+    await writeFile(
+      metadataPath,
+      JSON.stringify(
+        {
+          title: fixture.title,
+          channelType: fixture.channelType,
+          status: "active",
+          updatedAt: fixture.timestamp,
+          createdAt: fixture.timestamp,
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+    const ts = new Date(fixture.timestamp);
+    await utimes(transcriptPath, ts, ts);
+    await utimes(metadataPath, ts, ts);
+  }
+}
+
+async function fetchJson(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Request failed: ${response.status} ${response.statusText} for ${url}`);
+  }
+  return response.json();
+}
+
+async function waitForSessions() {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const payload = await fetchJson(`${controllerBase}/api/v1/sessions?limit=20`);
+    const found = fixtures.map((fixture) =>
+      payload.sessions.find(
+        (session) =>
+          session.botId === fixture.botId &&
+          session.sessionKey === fixture.sessionKey &&
+          session.title === fixture.title,
+      ),
+    );
+    if (found.every(Boolean)) {
+      return found;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error("Timed out waiting for repro sessions to appear in /api/v1/sessions");
+}
+
+async function activateDesktop() {
+  const script = `
+    tell application "System Events"
+      set appNames to name of every process whose background only is false
+      if appNames contains "Nexu" then
+        tell application "Nexu" to activate
+      else if appNames contains "Electron" then
+        tell application "Electron" to activate
+      end if
+    end tell
+  `;
+  await run("osascript", ["-e", script]);
+}
+
+async function inspectEval(expression) {
+  const { stdout } = await run("pnpm", ["dev", "inspect", "eval", expression]);
+  const valueMatch = stdout.match(/"value":\s*"((?:\\.|[^"\\])*)"/s);
+  if (valueMatch?.[1]) {
+    return JSON.parse(`"${valueMatch[1]}"`);
+  }
+  return stdout;
+}
+
+async function inspectScreenshot() {
+  const { stdout } = await run("pnpm", ["dev", "inspect", "screenshot"]);
+  const lines = stdout.split("\n").map((line) => line.trim()).filter(Boolean);
+  return lines.at(-1);
+}
+
+async function navigateAndCapture(session) {
+  const expression = `(() => {
+    const rows = Array.from(document.querySelectorAll('[data-sidebar-session-row]'));
+    const target = rows.find((row) => row.textContent?.includes(${JSON.stringify(session.title)}));
+    if (!(target instanceof HTMLElement)) {
+      return JSON.stringify({ found: false, title: ${JSON.stringify(session.title)} });
+    }
+    target.click();
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          const text = document.body.innerText;
+          resolve(JSON.stringify({
+            found: true,
+            pathname: location.pathname,
+            hasTitle: text.includes(${JSON.stringify(session.title)}),
+            hasMessage: text.includes(${JSON.stringify(session.expectedMessage)}),
+            hasWrongMessage: text.includes(${JSON.stringify(session.wrongMessage)}),
+          }));
+        });
+      });
+    });
+  })()`;
+  const raw = await inspectEval(expression);
+  const result = JSON.parse(raw);
+  const screenshotPath = await inspectScreenshot();
+  return { result, screenshotPath };
+}
+
+async function main() {
+  console.log("[issue-980] restarting desktop service...");
+  await run("pnpm", ["dev", "restart", "desktop"]);
+
+  console.log("[issue-980] seeding repro sessions...");
+  await seedFixtures();
+
+  console.log("[issue-980] waiting for sessions API...");
+  const sessions = await waitForSessions();
+
+  const [wechatSession, webSession] = sessions;
+  wechatSession.expectedMessage = fixtures[0].content;
+  wechatSession.wrongMessage = fixtures[1].content;
+  webSession.expectedMessage = fixtures[1].content;
+  webSession.wrongMessage = fixtures[0].content;
+
+  console.log("[issue-980] activating desktop app...");
+  await activateDesktop();
+
+  console.log("[issue-980] capturing WeChat repro view...");
+  const wechatCapture = await navigateAndCapture(wechatSession);
+
+  console.log("[issue-980] capturing Web repro view...");
+  const webCapture = await navigateAndCapture(webSession);
+
+  const pass =
+    wechatCapture.result.hasTitle &&
+    wechatCapture.result.hasMessage &&
+    !wechatCapture.result.hasWrongMessage &&
+    webCapture.result.hasTitle &&
+    webCapture.result.hasMessage &&
+    !webCapture.result.hasWrongMessage;
+
+  const output = {
+    pass,
+    controllerBase,
+    sessions: {
+      wechat: {
+        id: wechatSession.id,
+        title: wechatSession.title,
+        capture: wechatCapture,
+      },
+      web: {
+        id: webSession.id,
+        title: webSession.title,
+        capture: webCapture,
+      },
+    },
+  };
+
+  console.log(JSON.stringify(output, null, 2));
+
+  if (!pass) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error("[issue-980] verification failed", error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## What

Fix conversation record isolation so that two bots sharing a `sessionKey` never serve each other's transcripts or message counts.

## Why

Closes #980.

P0 user report (微信群): a WeChat session card showed 「3 条消息」 while the user only exchanged 2, and its history contained an English-language Web conversation that did not belong to them.

Root cause in `apps/controller/src/runtime/sessions-runtime.ts`: `listSessions` assigned `session.id = file.name` (the bare `<sessionKey>.jsonl`). When two bots happened to use the same `sessionKey`, both rows had the same id. `getSession(id)` ran `sessions.find(s => s.id === id)` and returned whichever bot's session had the most recent `updatedAt`. Opening the WeChat card therefore fetched the Web transcript, and the count came from the wrong file.

File layout (`agents/<botId>/sessions/<sessionKey>.jsonl`) is already bot-namespaced at the filesystem level, so nothing on the write side was wrong. The bug was purely read-side id resolution.

## How

- Encode `session.id` as `session:<base64url({botId, sessionKey})>` so every card carries an unambiguous identity. `base64url` keeps the value safe for React keys and URL paths (used directly in `/workspace/sessions/:id`).
- `getSession(id)` decodes the id and delegates to `getSessionByKey(botId, sessionKey)`, which now matches on both fields instead of the filename alone.
- Legacy `<sessionKey>.jsonl` ids are honored only when exactly one session matches. Ambiguous legacy ids (the exact condition that caused #980) return 404 rather than silently serving the wrong transcript.
- All mutating paths (`updateSession`, `resetSession`, `deleteSession`, `getChatHistory`) go through `getSession(id)`, so they inherit the fix.
- Added a regression test that seeds two bots with identical `shared.jsonl`, and asserts unique ids plus fully isolated transcript reads.
- Shipped a repro script at `scripts/repro/issue-980-verify.mjs` that seeds fixtures, drives the desktop renderer, and captures screenshots so reviewers can reproduce or regress-test the UX path locally.

## Affected areas

- [ ] Desktop app (Electron shell)
- [x] Controller (backend / API)
- [ ] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [ ] Shared schemas / packages
- [ ] Build / CI / Tooling

## Checklist

- [x] `pnpm --filter @nexu/controller typecheck` passes
- [x] Biome check on the changed files passes
- [x] `tests/sessions-runtime.test.ts` (new + existing isolation coverage) passes
- [ ] `pnpm generate-types` — no API route/schema changes, response shape is unchanged
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced

## Screenshots / recordings

Seeded two bots (`repro-web-bot`, `repro-wechat-bot`) with the same `shared-session` sessionKey. After the fix:

- Clicking **Repro WeChat Session** renders only 「这是微信专属复现消息。」 with `1 条消息`.
- Clicking **Repro Web Session** renders only `This is the WEB-only repro message.` with `1 条消息`.

On `main` the same fixture would serve the WeChat transcript to both cards (the newer `updatedAt` always wins), perfectly reproducing the #980 symptoms.

## Notes for reviewers

- The ambiguity-safe legacy fallback (`getSession` branch that only honors `<sessionKey>.jsonl` when there is a single match) is intentional — it avoids re-introducing the #980 silent mis-routing while still serving old bookmarks when they are unambiguous. If you prefer a hard cutover, happy to remove it.
- Out of scope for this PR, but surfaced during manual testing: the session detail header occasionally renders `Web` as the channel label for a WeChat session. That is a display-layer bug separate from the isolation fix and should be filed as a follow-up.