### PR TITLE
fix(notify): optimize developer notification card copy and button layout

### DIFF
--- a/scripts/notify/developer-notify.mjs
+++ b/scripts/notify/developer-notify.mjs
@@ -3,6 +3,7 @@
 const CONTRIBUTOR_GUIDE_URL = "https://docs.nexu.io/zh/guide/first-pr";
 const GOOD_FIRST_ISSUE_URL =
   "https://github.com/nexu-io/nexu/labels/good-first-issue";
+const ALL_ISSUES_URL = "https://github.com/nexu-io/nexu/issues";
 const WEBHOOK_TIMEOUT_MS = 30_000;
 
 function createTimeoutSignal(timeoutMs) {
@@ -126,11 +127,12 @@ function createButtonColumns(actions) {
 
 function createRewardCopy() {
   return [
-    "只需 3 步💥，1️⃣选任务 2️⃣ 认领 3️⃣ 提交",
-    "🎁 即可同时获得以下奖励🎉 （详情请看群公告）",
-    "1️⃣ 最高价值 20 美金的 nexu 使用额度积分奖励",
-    "2️⃣ GitHub README 公开致谢",
-    "3️⃣ Github 社区徽章。",
+    "只需 3 步💥：❶ 选任务 ❷ 认领 ❸ 提交 PR",
+    "",
+    "🎁 合并后即可获得以下奖励：",
+    "✅ 最高 2000 积分，可兑换价值 $20 的 nexu 使用额度",
+    "✅ GitHub README 贡献者公开致谢",
+    "✅ GitHub 社区徽章",
   ].join("\n");
 }
 
@@ -145,7 +147,7 @@ export function buildDeveloperPrPayload({ author, labels, prUrl }) {
       header: {
         title: {
           tag: "plain_text",
-          content: "🎉 又新增 1 位贡献者给 Nexu 提 PR 啦～ 立即派出奖励💰！",
+          content: "🎉 又有新贡献者给 Nexu 提 PR 啦！你也来试试？",
         },
         template: "purple",
       },
@@ -160,13 +162,14 @@ export function buildDeveloperPrPayload({ author, labels, prUrl }) {
           {
             tag: "markdown",
             content: [
-              "Nexu 准备好一批对新手友好任务的 Good First Issue 👇",
+              "Nexu 还准备了一批新手友好的 Good First Issue 等你来领 👇 提交后 24 小时内审核回复",
               createRewardCopy(),
             ].join("\n"),
           },
           createButtonColumns([
+            createButton("Good First Issue", GOOD_FIRST_ISSUE_URL),
             createButton("贡献者指南", CONTRIBUTOR_GUIDE_URL),
-            createButton("立即贡献", GOOD_FIRST_ISSUE_URL),
+            createButton("查看全部 Issue", ALL_ISSUES_URL),
           ]),
         ],
       },
@@ -202,7 +205,7 @@ export function buildDeveloperIssuePayload({
         elements: [
           {
             tag: "markdown",
-            content: `**标题：** ${safeTitle}\n**Author:** ${safeAuthor}\n**Labels:** ${safeLabels}\n**Bug description:** ${safeBody}`,
+            content: `**标题：** ${safeTitle}\n**提交者：** ${safeAuthor}\n**标签：** ${safeLabels}\n**描述：** ${safeBody}`,
           },
           createButtonColumns([
             createButton("查看 issue", issueUrl, "primary"),
@@ -212,8 +215,9 @@ export function buildDeveloperIssuePayload({
             content: createRewardCopy(),
           },
           createButtonColumns([
-            createButton("领取新手友好 issue", GOOD_FIRST_ISSUE_URL),
+            createButton("Good First Issue", GOOD_FIRST_ISSUE_URL),
             createButton("贡献者指南", CONTRIBUTOR_GUIDE_URL),
+            createButton("查看全部 Issue", ALL_ISSUES_URL),
           ]),
         ],
       },

--- a/tests/notify/developer-notify.test.ts
+++ b/tests/notify/developer-notify.test.ts
@@ -35,7 +35,7 @@ describe("developer-notify", () => {
       prUrl: "https://github.com/nexu-io/nexu/pull/10",
     });
 
-    expect(payload.card.header.title.content).toContain("新增 1 位贡献者");
+    expect(payload.card.header.title.content).toContain("又有新贡献者给 Nexu 提 PR");
     expect(payload.card.body.elements[0]).toMatchObject({
       tag: "markdown",
       content: expect.stringContaining("**Author:** alice"),
@@ -64,10 +64,10 @@ describe("developer-notify", () => {
       payload.card.body.elements[3].columns.map(
         (column) => column.elements[0].text.content,
       ),
-    ).toEqual(["贡献者指南", "立即贡献"]);
+    ).toEqual(["Good First Issue", "贡献者指南", "查看全部 Issue"]);
     expect(payload.card.body.elements[2]).toMatchObject({
       tag: "markdown",
-      content: expect.stringContaining("只需 3 步💥，1️⃣选任务 2️⃣ 认领 3️⃣ 提交"),
+      content: expect.stringContaining("只需 3 步💥：❶ 选任务 ❷ 认领 ❸ 提交 PR"),
     });
   });
 
@@ -76,7 +76,7 @@ describe("developer-notify", () => {
       issueUrl: "https://github.com/nexu-io/nexu/issues/99",
     });
 
-    expect(payload.card.header.title.content).toContain("刚新增 1 条 issue");
+    expect(payload.card.header.title.content).toContain("刚新增 1 条 issue 等你来领取");
     expect(payload.card.body.elements[1]).toMatchObject({ tag: "column_set" });
     expect(
       payload.card.body.elements[1].columns.map(
@@ -88,11 +88,11 @@ describe("developer-notify", () => {
       payload.card.body.elements[3].columns.map(
         (column) => column.elements[0].text.content,
       ),
-    ).toEqual(["领取新手友好 issue", "贡献者指南"]);
+    ).toEqual(["Good First Issue", "贡献者指南", "查看全部 Issue"]);
     expect(payload.card.body.elements[2]).toMatchObject({
       tag: "markdown",
       content: expect.stringContaining(
-        "1️⃣ 最高价值 20 美金的 nexu 使用额度积分奖励",
+        "✅ 最高 2000 积分，可兑换价值 $20 的 nexu 使用额度",
       ),
     });
   });


### PR DESCRIPTION
## Summary

Comprehensively optimized Feishu notification card copy, field labels, and button layout from a developer-facing perspective.

### Reward Section (shared by Issue + PR cards)

| Before | After |
| --- | --- |
| 1️⃣ Select task 2️⃣ Claim 3️⃣ Submit | ❶ Select task ❷ Claim ❸ Submit PR |
| 🎁 Get all these rewards 🎉 (see group announcement) | 🎁 Rewards after merge: |
| 1️⃣ $20 nexu credits reward | ✅ Up to 2,000 points, redeemable for $20 nexu credits |
| 2️⃣ GitHub README shout-out | ✅ GitHub README contributor acknowledgment |
| 3️⃣ Github community badge. | ✅ GitHub community badge |

**What improved**: Steps (❶❷❸) and rewards (✅) use distinct symbols; clarified points-to-credits conversion; fixed "Github" → "GitHub"; removed dangling "see group announcement".

### PR Notification Card

| Location | Before | After |
| --- | --- | --- |
| Title | 🎉 又新增 1 位贡献者给 Nexu 提 PR 啦～ 立即派出奖励💰！ | 🎉 又有新贡献者给 Nexu 提 PR 啦！你也来试试？ |
| Transition copy | Nexu 准备好一批对新手友好任务的 Good First Issue 👇 | Nexu 还准备了一批新手友好的 Good First Issue 等你来领 👇 提交后 24 小时内审核回复 |
| Footer buttons | 2 buttons (贡献者指南 / 立即贡献) | 3 buttons (Good First Issue / 贡献者指南 / 查看全部 Issue) |

### Issue Notification Card

| Location | Before | After |
| --- | --- | --- |
| Field labels | Mixed EN/ZH (Author / Labels / Bug description) | Consistent Chinese (提交者 / 标签 / 描述) |
| Footer buttons | 2 buttons (领取新手友好 issue / 贡献者指南) | 3 buttons (Good First Issue / 贡献者指南 / 查看全部 Issue) |

### Test Updates

Updated `tests/notify/developer-notify.test.ts` assertions to match new copy — title strings, button labels, and reward text.

## Test plan

- [ ] CI passes (lint, typecheck, test, build)
- [ ] Trigger external Issue notification → verify Chinese field labels + 3 buttons + ✅ reward symbols
- [ ] Trigger fork PR notification → verify new title + 3 buttons + transition copy

Made with [Cursor](https://cursor.com)