### PR TITLE
feat(notify): display PR title in developer Feishu notification card

### DIFF
--- a/scripts/notify/developer-notify.mjs
+++ b/scripts/notify/developer-notify.mjs
@@ -136,7 +136,8 @@ function createRewardCopy() {
   ].join("\n");
 }
 
-export function buildDeveloperPrPayload({ author, labels, prUrl }) {
+export function buildDeveloperPrPayload({ title, author, labels, prUrl }) {
+  const safeTitle = sanitizeText(title || "(no title)", 120) || "(no title)";
   const safeAuthor = sanitizeText(author, 80);
   const safeLabels = sanitizeText(labels || "none", 120) || "none";
 
@@ -156,7 +157,7 @@ export function buildDeveloperPrPayload({ author, labels, prUrl }) {
         elements: [
           {
             tag: "markdown",
-            content: `**Author:** ${safeAuthor}\n**Labels:** ${safeLabels}`,
+            content: `**Title:** ${safeTitle}\n**Author:** ${safeAuthor}\n**Labels:** ${safeLabels}`,
           },
           createButtonColumns([createButton("查看贡献 PR", prUrl, "primary")]),
           {
@@ -326,6 +327,7 @@ export async function runFromEnv(env = process.env) {
 
   if (eventKind === "pr") {
     const payload = buildDeveloperPrPayload({
+      title,
       author,
       labels,
       prUrl: safeUrl,

--- a/tests/notify/developer-notify.test.ts
+++ b/tests/notify/developer-notify.test.ts
@@ -30,12 +30,17 @@ describe("developer-notify", () => {
 
   it("builds the developer PR payload with expected buttons", () => {
     const payload = buildDeveloperPrPayload({
+      title: "fix: resolve login crash",
       author: "alice",
       labels: "bug, help wanted",
       prUrl: "https://github.com/nexu-io/nexu/pull/10",
     });
 
     expect(payload.card.header.title.content).toContain("又有新贡献者给 Nexu 提 PR");
+    expect(payload.card.body.elements[0]).toMatchObject({
+      tag: "markdown",
+      content: expect.stringContaining("**Title:** fix: resolve login crash"),
+    });
     expect(payload.card.body.elements[0]).toMatchObject({
       tag: "markdown",
       content: expect.stringContaining("**Author:** alice"),


### PR DESCRIPTION
## Summary

- Add `title` field to `buildDeveloperPrPayload` so the Feishu notification card displays the PR title
- Pass `title` from `runFromEnv` to the PR payload builder (workflow already provides `TITLE` env var)
- Update test to verify title rendering in the card

## Context

The PR notification card previously only showed Author and Labels, making it hard to tell what the PR is about at a glance. Now it shows **Title**, Author, and Labels.

## Test plan

- [x] `vitest run tests/notify/developer-notify.test.ts` — all 11 tests pass
- [ ] Verify on next external fork PR that the Feishu card displays the title