### PR TITLE
fix: 欢迎页语言切换器无效 #448

### DIFF
--- a/apps/web/src/hooks/use-locale.tsx
+++ b/apps/web/src/hooks/use-locale.tsx
@@ -114,8 +114,22 @@ async function bootstrapLocale(
   // flight, their selection is the source of truth — don't overwrite it.
   // Issue #759: on Windows zh-CN systems, the bootstrap was reverting a
   // user-selected English back to Chinese on the welcome screen.
+  // Issue #448: the welcome page language switcher does not change UI language
+  // because the bootstrap was overwriting the user's selection.
   if (userInteractedRef.current) {
     return;
+  }
+
+  // If the user has manually selected a language via localStorage, use that
+  // as the source of truth and don't overwrite it with the server value.
+  try {
+    const manualSelection = localStorage.getItem(STORAGE_KEY);
+    if (manualSelection === "en" || manualSelection === "zh") {
+      // User has manually selected a language, respect their choice
+      return;
+    }
+  } catch {
+    /* ignore */
   }
 
   if (storedLocale === "en" || storedLocale === "zh-CN") {


### PR DESCRIPTION
## 问题ootstrapLocale 存在 race condition，当用户通过 localStorage 手动选择语言时，会被覆盖为系统默认语言，导致欢迎页语言切换器无法改变 UI 语言。## 修复- 在 ootstrapLocale 过程中检查 localStorage 中的用户手动选择- 尊重用户选择，不覆盖现有设置## 关联Fixes #448