### PR TITLE
chore(i18n): remove dead rewards.* keys from zh-CN

### DIFF
--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -286,10 +286,8 @@ const zhCN = {
   "home.noRecentActivity": "暂无最近对话",
 
   // ── Rewards ──
-  "rewards.badge": "奖励中心",
   "rewards.title": "分享 nexu，获取额外积分",
   "rewards.desc": "把 nexu 分享给你的社区，完成任务获取额外积分。",
-  "rewards.refresh": "刷新",
   "rewards.progressLabel": "已完成",
   "rewards.earnedLabel": "已获得",
   "rewards.totalCredits": "奖励额度 {{n}}",


### PR DESCRIPTION
## Summary

Removes two dead i18n keys from `apps/web/src/i18n/locales/zh-CN.ts` that have no counterparts in `en.ts` and are not referenced anywhere in source.

- `rewards.badge` → 奖励中心
- `rewards.refresh` → 刷新

After the change, `en.ts` and `zh-CN.ts` have **exactly the same set of 1052 keys**, restoring full locale parity.

## Why this is safe

Two pre-existing test assertions already guard that these raw key strings do not appear in rendered markup:

- `apps/web/tests/home.test.tsx:322-323`
- `tests/web/home.test.tsx:402-403`

```ts
expect(markup).not.toContain("rewards.badge");
expect(markup).not.toContain("rewards.refresh");
```

A repo-wide search (`rg "rewards\.(badge|refresh)"`) finds zero positive usages outside the locale file itself and those guard assertions — so removing the translations cannot surface the keys at runtime.

## Test plan

- [x] `rg "rewards\.badge|rewards\.refresh"` outside `zh-CN.ts` shows only the negative guard tests.
- [x] Locale-key diff: `en.ts` ↔ `zh-CN.ts` is now empty in both directions (1052 keys each).
- [x] `pnpm lint`
- [x] `pnpm -C apps/web typecheck`
- [x] `pnpm test` (root vitest — covers `tests/web/home.test.tsx`)
- [x] `pnpm -C apps/web test` (covers `apps/web/tests/home.test.tsx`)

## Out of scope

- A type-level parity guard (e.g. `const zhCN: typeof en`) would prevent this drift in the future; deferred to a separate PR.
- The duplicate `tests/web/home.test.tsx` vs `apps/web/tests/home.test.tsx` files contain near-identical guard assertions; consolidation is out of scope.

---

_Generated with the `auto-github-contributor` skill._
