### PR TITLE
fix: add TweetClaw guide and clear skill search

### DIFF
--- a/apps/web/src/lib/skills-view-state.ts
+++ b/apps/web/src/lib/skills-view-state.ts
@@ -112,9 +112,13 @@ export function applySkillsViewStatePatch(
   current: URLSearchParams,
   patch: Partial<SkillsViewState>,
 ): URLSearchParams {
+  const currentState = parseSkillsViewState(current);
+  const isTopTabSwitch =
+    patch.topTab !== undefined && patch.topTab !== currentState.topTab;
   const nextState = {
-    ...parseSkillsViewState(current),
+    ...currentState,
     ...patch,
+    ...(isTopTabSwitch ? { searchQuery: "" } : {}),
   };
 
   return createSkillsSearchParams(nextState);

--- a/apps/web/tests/skills-view-state.test.ts
+++ b/apps/web/tests/skills-view-state.test.ts
@@ -42,6 +42,19 @@ describe("skills-view-state", () => {
     expect(next.toString()).toBe("tab=explore&tag=automation&q=tavily");
   });
 
+  it("clears search when switching top-level tabs", () => {
+    const next = applySkillsViewStatePatch(
+      new URLSearchParams("tab=explore&tag=automation&q=tavily"),
+      {
+        topTab: "yours",
+        yoursSubTab: "all",
+        activeTag: null,
+      },
+    );
+
+    expect(next.toString()).toBe("");
+  });
+
   it("preserves the current query string on detail links", () => {
     expect(
       createSkillDetailPath(

--- a/docs/en/guide/skills.md
+++ b/docs/en/guide/skills.md
@@ -28,6 +28,18 @@ Once a skill is installed, simply describe what you need in a channel conversati
 
 ![Using a skill in chat](/assets/nexu-skills-chat.webp)
 
+## Example: X/Twitter Workflows with TweetClaw
+
+If the same OpenClaw workspace needs X/Twitter actions, search for "TweetClaw" on the **Skills** page. For CLI-managed OpenClaw workspaces, install the plugin directly:
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+```
+
+[TweetClaw](https://github.com/Xquik-dev/tweetclaw) is also published on [npm](https://www.npmjs.com/package/@xquik/tweetclaw) and listed on [ClawHub](https://clawhub.ai/kriptoburak/xquik-tweetclaw). Use it for tweet search, reply search, follower export, user lookup, media upload and download, direct messages, tweet monitors, webhooks, giveaway draws, and approval-gated posting or replies.
+
+Keep nexu channel credentials separate from TweetClaw and Xquik credentials. Require explicit approval before public or account-changing X/Twitter actions, including posting, replying, direct messaging, following, or unfollowing.
+
 ## FAQ
 
 **Q: Do I need to restart the Agent after installing a skill?**

--- a/docs/en/guide/skills.md
+++ b/docs/en/guide/skills.md
@@ -42,6 +42,8 @@ openclaw config set tools.alsoAllow '["explore", "tweetclaw"]'
 
 Keep nexu channel credentials separate from TweetClaw and Xquik credentials. Require explicit approval before public or account-changing X/Twitter actions, including posting, replying, direct messaging, following, or unfollowing.
 
+Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
+
 ## FAQ
 
 **Q: Do I need to restart the Agent after installing a skill?**

--- a/docs/en/guide/skills.md
+++ b/docs/en/guide/skills.md
@@ -34,9 +34,11 @@ If the same OpenClaw workspace needs X/Twitter actions, search for "TweetClaw" o
 
 ```bash
 openclaw plugins install @xquik/tweetclaw
+openclaw config set plugins.entries.tweetclaw.config.apiKey "$XQUIK_API_KEY"
+openclaw config set tools.alsoAllow '["explore", "tweetclaw"]'
 ```
 
-[TweetClaw](https://github.com/Xquik-dev/tweetclaw) is also published on [npm](https://www.npmjs.com/package/@xquik/tweetclaw) and listed on [ClawHub](https://clawhub.ai/kriptoburak/xquik-tweetclaw). Use it for tweet search, reply search, follower export, user lookup, media upload and download, direct messages, tweet monitors, webhooks, giveaway draws, and approval-gated posting or replies.
+[TweetClaw](https://github.com/Xquik-dev/tweetclaw) is also published on [npm](https://www.npmjs.com/package/@xquik/tweetclaw) and listed on [ClawHub](https://clawhub.ai/plugins/@xquik/tweetclaw). Set `XQUIK_API_KEY` from the Xquik dashboard before account-backed actions. Use TweetClaw for tweet search, reply search, follower export, user lookup, media upload and download, direct messages, tweet monitors, webhooks, giveaway draws, and approval-gated posting or replies.
 
 Keep nexu channel credentials separate from TweetClaw and Xquik credentials. Require explicit approval before public or account-changing X/Twitter actions, including posting, replying, direct messaging, following, or unfollowing.
 

--- a/docs/ja/guide/skills.md
+++ b/docs/ja/guide/skills.md
@@ -28,6 +28,18 @@ Nexu クライアントの左サイドバーで **Skills** をクリックし、
 
 ![Skill in action during conversation](/assets/nexu-skills-chat.webp)
 
+## 例：TweetClaw で X/Twitter ワークフローを扱う
+
+同じ OpenClaw ワークスペースで X/Twitter の操作も必要な場合は、**Skills** ページで「TweetClaw」を検索します。CLI で管理している OpenClaw ワークスペースでは、プラグインを直接インストールできます。
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+```
+
+[TweetClaw](https://github.com/Xquik-dev/tweetclaw) は [npm](https://www.npmjs.com/package/@xquik/tweetclaw) でも公開され、[ClawHub](https://clawhub.ai/kriptoburak/xquik-tweetclaw) にも掲載されています。ツイート検索、返信検索、フォロワーエクスポート、ユーザー検索、メディアアップロードとダウンロード、ダイレクトメッセージ、ツイート監視、webhooks、抽選、承認付きの投稿や返信に使えます。
+
+nexu のチャンネル認証情報は、TweetClaw と Xquik の認証情報とは分けて管理してください。投稿、返信、ダイレクトメッセージ、フォロー、フォロー解除など、公開またはアカウント状態を変更する X/Twitter 操作には明示的な承認を求めてください。
+
 ## FAQ
 
 **Q: スキルをインストールしたあと、エージェントの再起動は必要ですか？**

--- a/docs/ja/guide/skills.md
+++ b/docs/ja/guide/skills.md
@@ -34,9 +34,11 @@ Nexu クライアントの左サイドバーで **Skills** をクリックし、
 
 ```bash
 openclaw plugins install @xquik/tweetclaw
+openclaw config set plugins.entries.tweetclaw.config.apiKey "$XQUIK_API_KEY"
+openclaw config set tools.alsoAllow '["explore", "tweetclaw"]'
 ```
 
-[TweetClaw](https://github.com/Xquik-dev/tweetclaw) は [npm](https://www.npmjs.com/package/@xquik/tweetclaw) でも公開され、[ClawHub](https://clawhub.ai/kriptoburak/xquik-tweetclaw) にも掲載されています。ツイート検索、返信検索、フォロワーエクスポート、ユーザー検索、メディアアップロードとダウンロード、ダイレクトメッセージ、ツイート監視、webhooks、抽選、承認付きの投稿や返信に使えます。
+[TweetClaw](https://github.com/Xquik-dev/tweetclaw) は [npm](https://www.npmjs.com/package/@xquik/tweetclaw) でも公開され、[ClawHub](https://clawhub.ai/plugins/@xquik/tweetclaw) にも掲載されています。アカウント連携アクションの前に、Xquik ダッシュボードで取得した `XQUIK_API_KEY` を設定してください。ツイート検索、返信検索、フォロワーエクスポート、ユーザー検索、メディアアップロードとダウンロード、ダイレクトメッセージ、ツイート監視、webhooks、抽選、承認付きの投稿や返信に使えます。
 
 nexu のチャンネル認証情報は、TweetClaw と Xquik の認証情報とは分けて管理してください。投稿、返信、ダイレクトメッセージ、フォロー、フォロー解除など、公開またはアカウント状態を変更する X/Twitter 操作には明示的な承認を求めてください。
 

--- a/docs/ja/guide/skills.md
+++ b/docs/ja/guide/skills.md
@@ -42,6 +42,8 @@ openclaw config set tools.alsoAllow '["explore", "tweetclaw"]'
 
 nexu のチャンネル認証情報は、TweetClaw と Xquik の認証情報とは分けて管理してください。投稿、返信、ダイレクトメッセージ、フォロー、フォロー解除など、公開またはアカウント状態を変更する X/Twitter 操作には明示的な承認を求めてください。
 
+Xquik は独立したサードパーティサービスであり、X Corp. とは提携しておらず、承認も受けていません。「Twitter」と「X」は X Corp. の商標です。
+
 ## FAQ
 
 **Q: スキルをインストールしたあと、エージェントの再起動は必要ですか？**

--- a/docs/ko/guide/skills.md
+++ b/docs/ko/guide/skills.md
@@ -28,6 +28,18 @@ nexu 클라이언트 왼쪽 사이드바에서 **Skills**를 클릭하여 스킬
 
 ![채팅에서 스킬 사용](/assets/nexu-skills-chat.webp)
 
+## 예시: TweetClaw로 X/Twitter 워크플로 처리
+
+같은 OpenClaw 워크스페이스에 X/Twitter 작업도 필요하다면 **Skills** 페이지에서 "TweetClaw"를 검색하세요. CLI로 관리하는 OpenClaw 워크스페이스에서는 플러그인을 직접 설치할 수 있습니다.
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+```
+
+[TweetClaw](https://github.com/Xquik-dev/tweetclaw)는 [npm](https://www.npmjs.com/package/@xquik/tweetclaw)에 게시되어 있으며 [ClawHub](https://clawhub.ai/kriptoburak/xquik-tweetclaw)에도 등록되어 있습니다. 트윗 검색, 답글 검색, 팔로워 내보내기, 사용자 조회, 미디어 업로드 및 다운로드, 다이렉트 메시지, 트윗 모니터링, webhooks, 경품 추첨, 승인 기반 게시 또는 답글에 사용할 수 있습니다.
+
+nexu 채널 자격 증명은 TweetClaw 및 Xquik 자격 증명과 분리해서 관리하세요. 게시, 답글, 다이렉트 메시지, 팔로우, 언팔로우처럼 공개되거나 계정 상태를 바꾸는 X/Twitter 작업 전에는 명시적인 승인을 요구하세요.
+
 ## FAQ
 
 **Q: 스킬 설치 후 Agent를 재시작해야 하나요?**

--- a/docs/ko/guide/skills.md
+++ b/docs/ko/guide/skills.md
@@ -34,9 +34,11 @@ nexu 클라이언트 왼쪽 사이드바에서 **Skills**를 클릭하여 스킬
 
 ```bash
 openclaw plugins install @xquik/tweetclaw
+openclaw config set plugins.entries.tweetclaw.config.apiKey "$XQUIK_API_KEY"
+openclaw config set tools.alsoAllow '["explore", "tweetclaw"]'
 ```
 
-[TweetClaw](https://github.com/Xquik-dev/tweetclaw)는 [npm](https://www.npmjs.com/package/@xquik/tweetclaw)에 게시되어 있으며 [ClawHub](https://clawhub.ai/kriptoburak/xquik-tweetclaw)에도 등록되어 있습니다. 트윗 검색, 답글 검색, 팔로워 내보내기, 사용자 조회, 미디어 업로드 및 다운로드, 다이렉트 메시지, 트윗 모니터링, webhooks, 경품 추첨, 승인 기반 게시 또는 답글에 사용할 수 있습니다.
+[TweetClaw](https://github.com/Xquik-dev/tweetclaw)는 [npm](https://www.npmjs.com/package/@xquik/tweetclaw)에 게시되어 있으며 [ClawHub](https://clawhub.ai/plugins/@xquik/tweetclaw)에도 등록되어 있습니다. 계정 기반 작업 전에 Xquik 대시보드에서 받은 `XQUIK_API_KEY`를 설정하세요. 트윗 검색, 답글 검색, 팔로워 내보내기, 사용자 조회, 미디어 업로드 및 다운로드, 다이렉트 메시지, 트윗 모니터링, webhooks, 경품 추첨, 승인 기반 게시 또는 답글에 사용할 수 있습니다.
 
 nexu 채널 자격 증명은 TweetClaw 및 Xquik 자격 증명과 분리해서 관리하세요. 게시, 답글, 다이렉트 메시지, 팔로우, 언팔로우처럼 공개되거나 계정 상태를 바꾸는 X/Twitter 작업 전에는 명시적인 승인을 요구하세요.
 

--- a/docs/ko/guide/skills.md
+++ b/docs/ko/guide/skills.md
@@ -42,6 +42,8 @@ openclaw config set tools.alsoAllow '["explore", "tweetclaw"]'
 
 nexu 채널 자격 증명은 TweetClaw 및 Xquik 자격 증명과 분리해서 관리하세요. 게시, 답글, 다이렉트 메시지, 팔로우, 언팔로우처럼 공개되거나 계정 상태를 바꾸는 X/Twitter 작업 전에는 명시적인 승인을 요구하세요.
 
+Xquik은 독립적인 제3자 서비스이며 X Corp.와 제휴하거나 승인을 받지 않았습니다. "Twitter"와 "X"는 X Corp.의 상표입니다.
+
 ## FAQ
 
 **Q: 스킬 설치 후 Agent를 재시작해야 하나요?**

--- a/docs/zh/guide/skills.md
+++ b/docs/zh/guide/skills.md
@@ -28,6 +28,18 @@
 
 ![技能在对话中的使用效果](/assets/nexu-skills-chat.webp)
 
+## 示例：使用 TweetClaw 处理 X/Twitter 工作流
+
+如果同一个 OpenClaw 工作区还需要 X/Twitter 能力，可在 **Skills** 页面搜索 "TweetClaw"。对于使用 CLI 管理的 OpenClaw 工作区，也可以直接安装插件：
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+```
+
+[TweetClaw](https://github.com/Xquik-dev/tweetclaw) 也发布在 [npm](https://www.npmjs.com/package/@xquik/tweetclaw)，并收录于 [ClawHub](https://clawhub.ai/kriptoburak/xquik-tweetclaw)。可用于推文搜索、回复搜索、粉丝导出、用户查询、媒体上传和下载、私信、推文监控、webhooks、抽奖，以及需要审批的发推或回复。
+
+请将 nexu 渠道凭据与 TweetClaw 和 Xquik 凭据分开管理。涉及公开或改动账号状态的 X/Twitter 操作前，要求明确审批，包括发推、回复、私信、关注或取关。
+
 ## 常见问题
 
 **Q: 安装技能后需要重启 Agent 吗？**

--- a/docs/zh/guide/skills.md
+++ b/docs/zh/guide/skills.md
@@ -1,6 +1,6 @@
 # 技能安装
 
-技能扩展了 Agent 的能力边界——从网络搜索、文档生成，到飞书多维表格操作、第三方 API 调用，应有尽有。安装一个技能只需几秒钟。
+技能扩展了 Agent 的能力边界，从网络搜索、文档生成，到飞书多维表格操作、第三方 API 调用，应有尽有。安装一个技能只需几秒钟。
 
 ## 第一步：打开技能页面
 
@@ -41,6 +41,8 @@ openclaw config set tools.alsoAllow '["explore", "tweetclaw"]'
 [TweetClaw](https://github.com/Xquik-dev/tweetclaw) 也发布在 [npm](https://www.npmjs.com/package/@xquik/tweetclaw)，并收录于 [ClawHub](https://clawhub.ai/plugins/@xquik/tweetclaw)。执行账号相关操作前，请先从 Xquik 控制台获取并设置 `XQUIK_API_KEY`。可用于推文搜索、回复搜索、粉丝导出、用户查询、媒体上传和下载、私信、推文监控、webhooks、抽奖，以及需要审批的发推或回复。
 
 请将 nexu 渠道凭据与 TweetClaw 和 Xquik 凭据分开管理。涉及公开或改动账号状态的 X/Twitter 操作前，要求明确审批，包括发推、回复、私信、关注或取关。
+
+Xquik 是独立的第三方服务，与 X Corp. 无关联，也未获得其认可。"Twitter" 和 "X" 是 X Corp. 的商标。
 
 ## 常见问题
 

--- a/docs/zh/guide/skills.md
+++ b/docs/zh/guide/skills.md
@@ -34,9 +34,11 @@
 
 ```bash
 openclaw plugins install @xquik/tweetclaw
+openclaw config set plugins.entries.tweetclaw.config.apiKey "$XQUIK_API_KEY"
+openclaw config set tools.alsoAllow '["explore", "tweetclaw"]'
 ```
 
-[TweetClaw](https://github.com/Xquik-dev/tweetclaw) 也发布在 [npm](https://www.npmjs.com/package/@xquik/tweetclaw)，并收录于 [ClawHub](https://clawhub.ai/kriptoburak/xquik-tweetclaw)。可用于推文搜索、回复搜索、粉丝导出、用户查询、媒体上传和下载、私信、推文监控、webhooks、抽奖，以及需要审批的发推或回复。
+[TweetClaw](https://github.com/Xquik-dev/tweetclaw) 也发布在 [npm](https://www.npmjs.com/package/@xquik/tweetclaw)，并收录于 [ClawHub](https://clawhub.ai/plugins/@xquik/tweetclaw)。执行账号相关操作前，请先从 Xquik 控制台获取并设置 `XQUIK_API_KEY`。可用于推文搜索、回复搜索、粉丝导出、用户查询、媒体上传和下载、私信、推文监控、webhooks、抽奖，以及需要审批的发推或回复。
 
 请将 nexu 渠道凭据与 TweetClaw 和 Xquik 凭据分开管理。涉及公开或改动账号状态的 X/Twitter 操作前，要求明确审批，包括发推、回复、私信、关注或取关。
 


### PR DESCRIPTION
## What

Adds a localized TweetClaw example to the Skills guide for English, Chinese, Japanese, and Korean readers. Also fixes #1060 by clearing the Skills search when users switch between top-level tabs.

## Why

nexu users can reach OpenClaw agents from IM channels. When the same agent needs X/Twitter workflows, readers should have a concrete OpenClaw plugin path without changing nexu's channel scope.

Issue #1060 causes a stale search to filter the destination Skills tab after switching between Yours and ClawHub. The same contribution now fixes that independent Nexu bug with regression coverage.

## How

- Documented the Skills page search path and OpenClaw CLI install command.
- Added the required `XQUIK_API_KEY` plugin configuration step across all localized pages.
- Added `tools.alsoAllow` setup so `explore` and `tweetclaw` are visible to the agent.
- Linked TweetClaw's GitHub repository, npm package, and current ClawHub page.
- Named concrete X/Twitter jobs, credential boundaries, approval boundaries, and independent-service disclosure.
- Reset only the `q` search parameter when the top-level Skills tab changes.
- Added a focused state-transition regression test for #1060.

## Affected areas

- [ ] Desktop app
- [ ] Controller
- [x] Web dashboard
- [ ] OpenClaw runtime
- [x] Skills
- [ ] Shared schemas / packages
- [ ] Build / CI / Tooling

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [ ] `pnpm generate-types` run, not applicable because no API route or schema changed
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced

Additional validation:

- [x] `pnpm --filter @nexu/web exec vitest run tests/skills-view-state.test.ts`
- [x] `pnpm --filter @nexu/web typecheck`
- [x] `pnpm --dir docs build`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `git diff --check`
- [x] TweetClaw GitHub, npm registry metadata, and ClawHub links return HTTP 200
- [x] Current npm package metadata resolves successfully

## Screenshots / recordings

Not applicable. The product fix is a query-state transition with focused regression coverage, and the remaining changes are documentation.

## Notes for reviewers

The earlier API-key setup request remains fully addressed across all 4 localized pages. Commit `9aa53763` adds the independent #1060 fix and current validation, so a fresh review is requested for the new head.
