### PR TITLE
feat: add MiniMax M3 provider model

### DIFF
--- a/apps/controller/src/services/model-provider-service.ts
+++ b/apps/controller/src/services/model-provider-service.ts
@@ -75,8 +75,9 @@ const MINI_MAX_PLUGIN_ID = "minimax-portal-auth";
 const MINI_MAX_OAUTH_SCOPE = "group_id profile model.completion";
 const MINI_MAX_OAUTH_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:user_code";
 const MINI_MAX_CLIENT_ID = "78257093-7e40-4613-99e0-527b14b39113";
+const MINI_MAX_TARGET_MODELS = getBundledProviderModelIds("minimax");
 const MINI_MAX_API_MODELS = [
-  "MiniMax-M2.7",
+  ...MINI_MAX_TARGET_MODELS,
   "MiniMax-M2.7-highspeed",
   "MiniMax-M2.5",
   "MiniMax-M2.5-highspeed",
@@ -85,7 +86,7 @@ const MINI_MAX_API_MODELS = [
   "MiniMax-M2",
 ];
 const MINI_MAX_OAUTH_MODELS = [
-  "MiniMax-M2.7",
+  ...MINI_MAX_TARGET_MODELS,
   "MiniMax-M2.7-highspeed",
   "MiniMax-M2.5",
   "MiniMax-M2.5-highspeed",

--- a/apps/controller/tests/model-provider-registry.test.ts
+++ b/apps/controller/tests/model-provider-registry.test.ts
@@ -50,8 +50,11 @@ describe("model provider registry", () => {
       displayName: "Mistral AI",
       defaultProxyUrl: "https://api.mistral.ai/v1",
     });
-    expect(getDefaultProviderBaseUrls("minimax")).toContain(
-      "https://api.minimaxi.com/anthropic",
+    expect(getDefaultProviderBaseUrls("minimax")).toEqual(
+      expect.arrayContaining([
+        "https://api.minimax.io/anthropic",
+        "https://api.minimaxi.com/anthropic",
+      ]),
     );
     expect(getBundledProviderModelIds("minimax").slice(0, 2)).toEqual([
       "MiniMax-M3",

--- a/apps/controller/tests/model-provider-registry.test.ts
+++ b/apps/controller/tests/model-provider-registry.test.ts
@@ -1,5 +1,6 @@
 import {
   buildCustomProviderKey,
+  getBundledProviderModelIds,
   getDefaultProviderBaseUrls,
   getProviderAliasCandidates,
   getProviderRuntimePolicy,
@@ -52,6 +53,10 @@ describe("model provider registry", () => {
     expect(getDefaultProviderBaseUrls("minimax")).toContain(
       "https://api.minimaxi.com/anthropic",
     );
+    expect(getBundledProviderModelIds("minimax").slice(0, 2)).toEqual([
+      "MiniMax-M3",
+      "MiniMax-M2.7",
+    ]);
     expect(getDefaultProviderBaseUrls("github-copilot")).toContain(
       "https://api.githubcopilot.com",
     );

--- a/docs/en/guide/models.md
+++ b/docs/en/guide/models.md
@@ -28,6 +28,34 @@ Select **Anthropic**, **OpenAI**, **Google AI**, or another provider from the li
 
 ![BYOK model configuration](/assets/nexu-models-byok.webp)
 
+### MiniMax
+
+The built-in MiniMax provider uses the Anthropic-compatible API. Choose the global or China region preset in the MiniMax settings to use the matching Anthropic-compatible base URL. To use the OpenAI-compatible API instead, add a **Custom OpenAI-compatible** provider and enter the matching OpenAI-compatible base URL.
+
+| Region | Anthropic-compatible base URL | OpenAI-compatible base URL |
+| --- | --- | --- |
+| Global | `https://api.minimax.io/anthropic` | `https://api.minimax.io/v1` |
+| China | `https://api.minimaxi.com/anthropic` | `https://api.minimaxi.com/v1` |
+
+Keep the Anthropic-compatible base URL ending in `/anthropic`. Nexu passes this base URL directly to the runtime, which appends `/v1/messages`.
+
+MiniMax model discovery includes `MiniMax-M3` and `MiniMax-M2.7`. The provider reports the following model metadata; input availability in Nexu depends on the selected product surface.
+
+| Model | Context window | Input modalities | Thinking modes |
+| --- | ---: | --- | --- |
+| `MiniMax-M3` | 1,000,000 tokens | Text, image, video | Adaptive, disabled |
+| `MiniMax-M2.7` | 204,800 tokens | Text | Always on |
+
+MiniMax BYOK prices are in USD per one million tokens:
+
+| Model and service tier | Input token range | Input | Output | Cache read | Cache write |
+| --- | --- | ---: | ---: | ---: | ---: |
+| `MiniMax-M3`, standard | Up to 512,000 | $0.30 | $1.20 | $0.06 | N/A |
+| `MiniMax-M3`, standard | Above 512,000 | $0.60 | $2.40 | $0.12 | N/A |
+| `MiniMax-M3`, priority | Up to 512,000 | $0.45 | $1.80 | $0.09 | N/A |
+| `MiniMax-M3`, priority | Above 512,000 | $0.90 | $3.60 | $0.18 | N/A |
+| `MiniMax-M2.7` | All requests | $0.30 | $1.20 | $0.06 | $0.375 |
+
 ## Step 3: Select the Active Model
 
 After a successful connection, use the **Nexu Bot Model** dropdown at the top of the Settings page to choose the model your Agent should use.

--- a/docs/en/guide/models.md
+++ b/docs/en/guide/models.md
@@ -48,13 +48,10 @@ MiniMax model discovery includes `MiniMax-M3` and `MiniMax-M2.7`. The provider r
 
 MiniMax BYOK prices are in USD per one million tokens:
 
-| Model and service tier | Input token range | Input | Output | Cache read | Cache write |
-| --- | --- | ---: | ---: | ---: | ---: |
-| `MiniMax-M3`, standard | Up to 512,000 | $0.30 | $1.20 | $0.06 | N/A |
-| `MiniMax-M3`, standard | Above 512,000 | $0.60 | $2.40 | $0.12 | N/A |
-| `MiniMax-M3`, priority | Up to 512,000 | $0.45 | $1.80 | $0.09 | N/A |
-| `MiniMax-M3`, priority | Above 512,000 | $0.90 | $3.60 | $0.18 | N/A |
-| `MiniMax-M2.7` | All requests | $0.30 | $1.20 | $0.06 | $0.375 |
+| Model | Input | Output | Cache read | Cache write |
+| --- | ---: | ---: | ---: | ---: |
+| `MiniMax-M3` | $0.60 | $2.40 | $0.12 | N/A |
+| `MiniMax-M2.7` | $0.30 | $1.20 | $0.06 | $0.375 |
 
 ## Step 3: Select the Active Model
 

--- a/packages/shared/src/model-providers/provider-registry.ts
+++ b/packages/shared/src/model-providers/provider-registry.ts
@@ -5,6 +5,16 @@ import type {
 } from "./provider-types.js";
 
 const bundledProviderModelsById = {
+  minimax: [
+    {
+      id: "MiniMax-M3",
+      name: "MiniMax-M3",
+    },
+    {
+      id: "MiniMax-M2.7",
+      name: "MiniMax-M2.7",
+    },
+  ],
   xiaomi: [
     {
       id: "mimo-v2-flash",

--- a/tests/desktop/model-provider-service.test.ts
+++ b/tests/desktop/model-provider-service.test.ts
@@ -190,9 +190,14 @@ describe("ModelProviderService", () => {
     };
 
     const status = await service.getMiniMaxOauthStatus();
+    const provider = await store.getProvider("minimax");
 
     expect(status.connected).toBe(true);
     expect(status.inProgress).toBe(false);
+    expect(provider?.models.slice(0, 2)).toEqual([
+      "MiniMax-M3",
+      "MiniMax-M2.7",
+    ]);
   });
 
   it("normalizes minimax poll interval without over-scaling millisecond values", async () => {


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry.

## What

- Register MiniMax-M3 ahead of MiniMax-M2.7 in the bundled provider model inventory.
- Include the target models in MiniMax API-key and OAuth model discovery without removing existing models.
- Document both regional OpenAI-compatible and Anthropic-compatible bases, model metadata, and pricing.

## Why

MiniMax-M3 was missing from the existing provider registry and discovery paths.

## How

- Use the shared bundled model inventory as the target model source for controller discovery.
- Keep the existing Anthropic-compatible runtime configuration and document the existing custom OpenAI-compatible path.
- Add focused registry and OAuth refresh regression assertions.

## Affected areas

- [ ] Desktop app (Electron shell)
- [x] Controller (backend / API)
- [ ] Web dashboard (React UI)
- [ ] OpenClaw runtime
- [ ] Skills
- [x] Shared schemas / packages
- [ ] Build / CI / Tooling

## Checklist

- [x] `pnpm exec biome check apps/controller/src/services/model-provider-service.ts apps/controller/tests/model-provider-registry.test.ts packages/shared/src/model-providers/provider-registry.ts tests/desktop/model-provider-service.test.ts`
- [x] `pnpm --filter @nexu/shared typecheck`
- [x] `pnpm --filter @nexu/controller typecheck`
- [x] `pnpm exec vitest run tests/desktop/model-provider-service.test.ts`
- [x] `pnpm --dir apps/controller exec vitest run tests/model-provider-registry.test.ts`
- [x] No credentials or tokens in code or logs
- [x] No `any` types introduced

## Notes for reviewers

The built-in MiniMax provider remains Anthropic-compatible. The documented custom provider path covers OpenAI-compatible endpoints for both regions.