### PR TITLE
Add Atlas Cloud model provider

### DIFF
--- a/apps/controller/tests/model-provider-atlascloud.test.ts
+++ b/apps/controller/tests/model-provider-atlascloud.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import type { ControllerEnv } from "../src/app/env.js";
+import { compileOpenClawConfig } from "../src/lib/openclaw-config-compiler.js";
+import type { NexuConfig } from "../src/store/schemas.js";
+
+function createEnv(): ControllerEnv {
+  return {
+    nodeEnv: "test",
+    port: 3010,
+    host: "127.0.0.1",
+    webUrl: "http://localhost:5173",
+    nexuHomeDir: "/tmp/nexu-test",
+    nexuConfigPath: "/tmp/nexu-test/config.json",
+    artifactsIndexPath: "/tmp/nexu-test/artifacts/index.json",
+    compiledOpenclawSnapshotPath: "/tmp/nexu-test/compiled-openclaw.json",
+    openclawStateDir: "/tmp/openclaw",
+    openclawConfigPath: "/tmp/openclaw/openclaw.json",
+    openclawSkillsDir: "/tmp/openclaw/skills",
+    userSkillsDir: "/tmp/.agents/skills",
+    openclawWorkspaceTemplatesDir: "/tmp/openclaw/workspace-templates",
+    openclawBin: "openclaw",
+    openclawGatewayPort: 18789,
+    openclawGatewayToken: "token-123",
+    manageOpenclawProcess: false,
+    gatewayProbeEnabled: false,
+    runtimeSyncIntervalMs: 2000,
+    runtimeHealthIntervalMs: 5000,
+    defaultModelId: "atlascloud/qwen/qwen3.5-flash",
+  } as unknown as ControllerEnv;
+}
+
+function createConfig(): NexuConfig {
+  const now = new Date().toISOString();
+
+  return {
+    $schema: "https://nexu.io/config.json",
+    schemaVersion: 1,
+    app: {},
+    bots: [
+      {
+        id: "bot-1",
+        name: "Assistant",
+        slug: "assistant",
+        poolId: null,
+        status: "active",
+        modelId: "atlascloud/qwen/qwen3.5-flash",
+        systemPrompt: null,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ],
+    runtime: {
+      gateway: {
+        port: 18789,
+        bind: "loopback",
+        authMode: "token",
+      },
+      defaultModelId: "atlascloud/qwen/qwen3.5-flash",
+    },
+    models: {
+      mode: "merge",
+      providers: {
+        atlascloud: {
+          enabled: true,
+          displayName: "Atlas Cloud",
+          baseUrl: "https://api.atlascloud.ai/v1",
+          auth: "api-key",
+          api: "openai-completions",
+          apiKey: "atlas-test-key",
+          models: [],
+        },
+      },
+    },
+    providers: [],
+    integrations: [],
+    channels: [],
+    templates: {},
+    skills: {
+      version: 1,
+      defaults: {
+        enabled: true,
+        source: "inline",
+      },
+      items: {},
+    },
+    desktop: {},
+    secrets: {},
+  } as unknown as NexuConfig;
+}
+
+describe("Atlas Cloud model provider", () => {
+  it("compiles a BYOK provider with bundled OpenAI-compatible models", () => {
+    const result = compileOpenClawConfig(createConfig(), createEnv());
+
+    expect(result.agents.defaults?.model).toEqual({
+      primary: "atlascloud/qwen/qwen3.5-flash",
+    });
+    expect(result.models?.providers.atlascloud).toMatchObject({
+      baseUrl: "https://api.atlascloud.ai/v1",
+      apiKey: "atlas-test-key",
+      api: "openai-completions",
+    });
+    expect(result.models?.providers.atlascloud?.models).toEqual([
+      expect.objectContaining({
+        id: "qwen/qwen3.5-flash",
+        name: "Qwen3.5 Flash",
+      }),
+      expect.objectContaining({
+        id: "deepseek-ai/deepseek-v4-pro",
+        name: "DeepSeek V4 Pro",
+      }),
+    ]);
+  });
+});

--- a/apps/controller/tests/model-provider-registry.test.ts
+++ b/apps/controller/tests/model-provider-registry.test.ts
@@ -45,6 +45,12 @@ describe("model provider registry", () => {
       displayName: "OpenAI",
       defaultProxyUrl: "https://api.openai.com/v1",
     });
+    expect(normalizeProviderId("atlas-cloud")).toBe("atlascloud");
+    expect(getProviderAliasCandidates("atlascloud")).toContain("atlas-cloud");
+    expect(getProviderUiMetadata("atlascloud")).toMatchObject({
+      displayName: "Atlas Cloud",
+      defaultProxyUrl: "https://api.atlascloud.ai/v1",
+    });
     expect(getProviderUiMetadata("mistral")).toMatchObject({
       displayName: "Mistral AI",
       defaultProxyUrl: "https://api.mistral.ai/v1",
@@ -81,6 +87,7 @@ describe("model provider registry", () => {
       "volcengine",
       "qianfan",
       "xiaomi",
+      "atlascloud",
     ]) {
       expect(entryMap.get(providerId)?.modelsPageVisible).toBe(true);
       expect(entryMap.get(providerId)?.controllerConfigurable).toBe(true);

--- a/docs/en/guide/models.md
+++ b/docs/en/guide/models.md
@@ -40,6 +40,7 @@ After a successful connection, use the **Nexu Bot Model** dropdown at the top of
 | --- | --- | --- |
 | Anthropic | `https://api.anthropic.com` | `sk-ant-...` |
 | OpenAI | `https://api.openai.com/v1` | `sk-...` |
+| Atlas Cloud | `https://api.atlascloud.ai/v1` | `atlas-...` |
 | Google AI | `https://generativelanguage.googleapis.com/v1beta` | `AIza...` |
 | xAI | `https://api.x.ai/v1` | `xai-...` |
 | Custom | Your OpenAI-compatible endpoint | Depends on the provider |

--- a/packages/shared/src/model-providers/provider-registry.ts
+++ b/packages/shared/src/model-providers/provider-registry.ts
@@ -5,6 +5,16 @@ import type {
 } from "./provider-types.js";
 
 const bundledProviderModelsById = {
+  atlascloud: [
+    {
+      id: "qwen/qwen3.5-flash",
+      name: "Qwen3.5 Flash",
+    },
+    {
+      id: "deepseek-ai/deepseek-v4-pro",
+      name: "DeepSeek V4 Pro",
+    },
+  ],
   xiaomi: [
     {
       id: "mimo-v2-flash",
@@ -54,6 +64,24 @@ const providerRegistryEntries = [
     authModes: ["api-key"],
     apiKind: "openai-completions",
     defaultBaseUrls: ["https://api.openai.com/v1"],
+    supportsCustomBaseUrl: true,
+    supportsModelDiscovery: true,
+    supportsProxyMode: true,
+  },
+  {
+    id: "atlascloud",
+    canonicalOpenClawId: "atlascloud",
+    aliases: ["atlas-cloud"],
+    controllerConfigurable: true,
+    modelsPageVisible: true,
+    displayName: "Atlas Cloud",
+    descriptionKey: "models.provider.openaiCompatible.description",
+    apiDocsUrl: "https://docs.atlascloud.ai",
+    apiKeyPlaceholder: "atlas-...",
+    defaultProxyUrl: "https://api.atlascloud.ai/v1",
+    authModes: ["api-key"],
+    apiKind: "openai-completions",
+    defaultBaseUrls: ["https://api.atlascloud.ai/v1"],
     supportsCustomBaseUrl: true,
     supportsModelDiscovery: true,
     supportsProxyMode: true,


### PR DESCRIPTION
## Summary
- add Atlas Cloud to the shared model provider registry as an OpenAI-compatible provider
- include live-verified Atlas Cloud model entries for Qwen3.5 Flash and DeepSeek V4 Pro
- add focused provider registry tests and a docs provider table entry

## Validation
- `corepack pnpm --filter @nexu/controller exec vitest run tests/model-provider-registry.test.ts tests/model-provider-atlascloud.test.ts`
- `corepack pnpm --filter @nexu/shared typecheck`
- `corepack pnpm --filter @nexu/controller typecheck`
- `corepack pnpm exec biome check packages/shared/src/model-providers/provider-registry.ts apps/controller/tests/model-provider-registry.test.ts apps/controller/tests/model-provider-atlascloud.test.ts docs/en/guide/models.md`
- `git diff --check`
- Atlas live catalog returned the configured `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro` model IDs

Docs/README: updated the existing provider docs table only; no sponsor/logo/credits/partner promotion.